### PR TITLE
refactor: clap -> usage

### DIFF
--- a/.lane/log.jsonl
+++ b/.lane/log.jsonl
@@ -25,3 +25,4 @@
 {"anchor":"fn write_state_file","at":"2026-08-22T18:23:07Z","branch":"state-out-of-git","id":"01M0GFVWN31756XJ6E56B8N99V","kind":"evict","path":"crates/lane/src/store.rs","reason":"anchor missing"}
 {"anchor":"fn create","at":"2026-08-22T20:52:05Z","body_hash":"97bc6a740125f84b","branch":"state-out-of-git","id":"01M0EXNVCK4JP9328P47M4W2C1","kind":"holds","norm":"1","path":"crates/lane/src/worktree.rs","raw_hash":"7d27fd0bd69499c0","sig":"2a21aaf08379e25a"}
 {"anchor":"@file","at":"2026-08-22T20:52:05Z","body_hash":"c48edff8d22ea483","branch":"state-out-of-git","id":"01M0ESRPDGANMXC60YCD3VYVS5","kind":"holds","norm":"1","path":"test_lane.sh","raw_hash":"61108909a406b19a","sig":"e3b0c44298fc1c14"}
+{"at":"2026-08-24T01:30:32Z","branch":"usage-migration","kind":"landing","lane":"01M0RP72P6CSKWM9DM64CP3X8B"}

--- a/.lane/memory/crates/lane/Cargo.toml/01M0RP804X44PK5X9XYSWWGAET-measured-against-clap-4-6-6.md
+++ b/.lane/memory/crates/lane/Cargo.toml/01M0RP804X44PK5X9XYSWWGAET-measured-against-clap-4-6-6.md
@@ -1,0 +1,9 @@
+---
+id: 01M0RP804X44PK5X9XYSWWGAET
+anchor: usage
+created: 2026-08-24T01:30:16Z
+branch: usage-migration
+norm: '1'
+---
+
+measured against clap 4.6.6 at lane's scale: the stripped binary grew 70 KB (+0.48%) and wall time did not move; usage's published win is at mise scale, so the reason to stay is the smaller graph and the portable spec, not size or speed

--- a/.lane/memory/crates/lane/src/cli.rs/01M0RP804XQ1AXBN00DZEX4CK0-usage-sorts-subcommands-alph.md
+++ b/.lane/memory/crates/lane/src/cli.rs/01M0RP804XQ1AXBN00DZEX4CK0-usage-sorts-subcommands-alph.md
@@ -1,0 +1,13 @@
+---
+id: 01M0RP804XQ1AXBN00DZEX4CK0
+anchor: enum Command
+created: 2026-08-24T01:30:16Z
+branch: usage-migration
+norm: '1'
+sig: f23b4e0bbef9e6e7
+body_hash: 418a75b9dfb72592
+raw_hash: 4fa75f4da53832c2
+lines: 38-148
+---
+
+usage sorts subcommands alphabetically where clap kept declaration order, so every variant carries display_order to hold the workflow order the README documents

--- a/.lane/memory/crates/lane/src/cli.rs/01M0RP8055DHXBS165696WAHB3-usage-treats-an-unknown-flag.md
+++ b/.lane/memory/crates/lane/src/cli.rs/01M0RP8055DHXBS165696WAHB3-usage-treats-an-unknown-flag.md
@@ -1,0 +1,13 @@
+---
+id: 01M0RP8055DHXBS165696WAHB3
+anchor: struct Cli
+created: 2026-08-24T01:30:16Z
+branch: usage-migration
+norm: '1'
+sig: 6b6db5d128fddaa6
+body_hash: ea773d26a9c4aad7
+raw_hash: a00b0f26f8b230e9
+lines: 24-27
+---
+
+usage treats an unknown flag as a value by default; unknown_flags = "error" on the root restores clap's rejection and reaches every subcommand

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,56 +12,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "anstream"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
-dependencies = [
- "anstyle",
- "anstyle-parse",
- "anstyle-query",
- "anstyle-wincon",
- "colorchoice",
- "is_terminal_polyfill",
- "utf8parse",
-]
-
-[[package]]
-name = "anstyle"
-version = "1.0.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
-
-[[package]]
-name = "anstyle-parse"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
-dependencies = [
- "utf8parse",
-]
-
-[[package]]
-name = "anstyle-query"
-version = "1.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
-dependencies = [
- "windows-sys",
-]
-
-[[package]]
-name = "anstyle-wincon"
-version = "3.0.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
-dependencies = [
- "anstyle",
- "once_cell_polyfill",
- "windows-sys",
-]
-
-[[package]]
 name = "anyhow"
 version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -120,52 +70,6 @@ dependencies = [
  "cpufeatures",
  "rand_core",
 ]
-
-[[package]]
-name = "clap"
-version = "4.6.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "473c7e07f409a8d772161724aa8db6a765a2532a70f9667eeb7b49d3d02fbdca"
-dependencies = [
- "clap_builder",
- "clap_derive",
-]
-
-[[package]]
-name = "clap_builder"
-version = "4.6.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b48fea5a88e9ae728a2dcbedbfc0e730f7d60da42e1cb049a83c9fb8b789889"
-dependencies = [
- "anstream",
- "anstyle",
- "clap_lex",
- "strsim",
-]
-
-[[package]]
-name = "clap_derive"
-version = "4.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d012d2b9d65aca7f18f4d9878a045bc17899bba951561ba5ec3c2ba1eed9a061"
-dependencies = [
- "heck",
- "proc-macro2",
- "quote",
- "syn 3.0.3",
-]
-
-[[package]]
-name = "clap_lex"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
-
-[[package]]
-name = "colorchoice"
-version = "1.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "const-oid"
@@ -304,12 +208,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
-name = "heck"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
-
-[[package]]
 name = "hybrid-array"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -327,12 +225,6 @@ dependencies = [
  "equivalent",
  "hashbrown",
 ]
-
-[[package]]
-name = "is_terminal_polyfill"
-version = "1.70.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
 name = "itoa"
@@ -409,7 +301,6 @@ name = "lane"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "clap",
  "jiff",
  "libc",
  "rustix",
@@ -433,6 +324,7 @@ dependencies = [
  "tree-sitter-rust",
  "tree-sitter-typescript",
  "ulid",
+ "usage-rs",
  "walkdir",
 ]
 
@@ -469,12 +361,6 @@ name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
-
-[[package]]
-name = "once_cell_polyfill"
-version = "1.70.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "pin-project-lite"
@@ -686,12 +572,6 @@ name = "streaming-iterator"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b2231b7c3057d5e4ad0156fb3dc807d900806020c5ffa3ee6ff2c8c76fb8520"
-
-[[package]]
-name = "strsim"
-version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "syn"
@@ -917,10 +797,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
-name = "utf8parse"
-version = "0.2.2"
+name = "usage-argv"
+version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+checksum = "162179f728d278bd58665be652eee85d2ae555bf28128476d009e75e264f49d3"
+
+[[package]]
+name = "usage-derive"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "419bca1663d0d5c5fc5ed50b2150240f849310da92af5030daad6007959fa302"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
+]
+
+[[package]]
+name = "usage-rs"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f6fbc51c1c0ecb24dc799c6002c20b39736d0ddf47fa1167a21014485eb40a5"
+dependencies = [
+ "usage-argv",
+ "usage-derive",
+]
 
 [[package]]
 name = "walkdir"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -798,15 +798,15 @@ checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
 name = "usage-argv"
-version = "6.0.0"
+version = "6.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "162179f728d278bd58665be652eee85d2ae555bf28128476d009e75e264f49d3"
+checksum = "ecb8bc2270df585912b1c3eca56c1319c441b6c4e4f977a107e93e709d5e7650"
 
 [[package]]
 name = "usage-derive"
-version = "6.0.0"
+version = "6.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "419bca1663d0d5c5fc5ed50b2150240f849310da92af5030daad6007959fa302"
+checksum = "11ba84e10f41a34ec00b52e8a4f1c875b2811a0a4c65b0d352ab180138d6e491"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -815,9 +815,9 @@ dependencies = [
 
 [[package]]
 name = "usage-rs"
-version = "6.0.0"
+version = "6.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f6fbc51c1c0ecb24dc799c6002c20b39736d0ddf47fa1167a21014485eb40a5"
+checksum = "da081ad5fff1d9a3e5d8ef4e2cb90a212fe23387682c99302f6562cb641b896f"
 dependencies = [
  "usage-argv",
  "usage-derive",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ resolver = "3"
 [workspace.package]
 version = "0.1.0"
 edition = "2024"
-rust-version = "1.85"
+rust-version = "1.91"
 license = "MIT"
 repository = "https://github.com/lukeed/lane"
 

--- a/crates/lane/Cargo.toml
+++ b/crates/lane/Cargo.toml
@@ -31,7 +31,6 @@ path = "src/main.rs"
 
 [dependencies]
 anyhow = "1.0.104"
-clap = { version = "4.6.6", features = ["derive"] }
 jiff = "0.2.35"
 serde = { version = "1.0.229", features = ["derive"] }
 serde_json = "1.0.151"
@@ -54,6 +53,7 @@ tree-sitter-python = "0.25.0"
 tree-sitter-rust = "0.24.2"
 tree-sitter-typescript = "0.23.2"
 ulid = "3.0.0"
+usage = { package = "usage-rs", version = "6.0.0" }
 walkdir = "2.5.0"
 
 [lints]

--- a/crates/lane/Cargo.toml
+++ b/crates/lane/Cargo.toml
@@ -53,7 +53,7 @@ tree-sitter-python = "0.25.0"
 tree-sitter-rust = "0.24.2"
 tree-sitter-typescript = "0.23.2"
 ulid = "3.0.0"
-usage = { package = "usage-rs", version = "6.0.0" }
+usage = { package = "usage-rs", version = "6.3.0" }
 walkdir = "2.5.0"
 
 [lints]

--- a/crates/lane/src/cli.rs
+++ b/crates/lane/src/cli.rs
@@ -599,10 +599,10 @@ fn skill_uninstall() -> Result<i32> {
     std::fs::remove_file(&path)?;
     println!("removed {}", path.display());
     // Only the lane/ dir we just emptied; never .agents/ or .agents/skills/, which may hold others.
-    if let Some(dir) = path.parent() {
-        if std::fs::read_dir(dir)?.next().is_none() {
-            std::fs::remove_dir(dir)?;
-        }
+    if let Some(dir) = path.parent()
+        && std::fs::read_dir(dir)?.next().is_none()
+    {
+        std::fs::remove_dir(dir)?;
     }
     Ok(0)
 }

--- a/crates/lane/src/cli.rs
+++ b/crates/lane/src/cli.rs
@@ -119,7 +119,7 @@ enum Command {
         #[usage(long)]
         cd: bool,
         /// squash lane commits into one landing commit
-        #[usage(long, conflicts_with = "no_merge")]
+        #[usage(long, conflicts = "no_merge")]
         squash: bool,
         /// stop after the memory commit, for a pull request to carry
         #[usage(long)]

--- a/crates/lane/src/cli.rs
+++ b/crates/lane/src/cli.rs
@@ -8,134 +8,146 @@ use crate::syntax::{Resolution, Source};
 use crate::util::now_iso;
 use crate::worktree as wt;
 use anyhow::{Result, bail};
-use clap::{Args, Parser, Subcommand};
 use rustix::fs::{FlockOperation, flock};
 use std::fs::{File, OpenOptions};
 use std::io::{IsTerminal, Write};
 use std::ops::Range;
 use std::path::{Path, PathBuf};
 
-const MAX_NOTES: usize = 5;
-const MAX_CHARS: usize = 1200;
-
-#[derive(Parser, Debug)]
-#[command(
-    name = "lane",
+#[derive(usage::Cli, Debug)]
+#[usage(
+    bin = "lane",
     version,
-    about = "copy-on-write worktrees with memory that survives them"
+    about = "copy-on-write worktrees with memory that survives them",
+    unknown_flags = "error"
 )]
 pub struct Cli {
-    #[command(subcommand)]
+    #[usage(subcommand)]
     command: Command,
 }
 
-#[derive(Args, Debug, Clone)]
+#[derive(usage::Args, Debug, Clone)]
 struct BudgetArgs {
-    #[arg(long, default_value_t = MAX_NOTES)]
+    #[usage(long, default = "5")]
     max_notes: usize,
-    #[arg(long, default_value_t = MAX_CHARS)]
+    #[usage(long, default = "1200")]
     max_chars: usize,
 }
 
-#[derive(Subcommand, Debug)]
+#[derive(usage::Subcommands, Debug)]
 enum Command {
     /// scaffold memory + merge rules, probe reflink
+    #[usage(display_order = 1)]
     Init,
     /// create a CoW lane
+    #[usage(display_order = 2)]
     New {
         name: String,
-        #[arg(long)]
+        #[usage(long)]
         base: Option<String>,
         /// carry uncommitted work into the lane
-        #[arg(long)]
+        #[usage(long)]
         dirty: bool,
         /// print path last, for shell fn
-        #[arg(long)]
+        #[usage(long)]
         cd: bool,
     },
     /// list lanes
+    #[usage(display_order = 3)]
     Ls,
     /// print a lane's path
+    #[usage(display_order = 4)]
     Path { name: String },
     /// record a finding
+    #[usage(display_order = 5)]
     Note {
         text: String,
-        #[arg(short, long)]
+        #[usage(short, long)]
         path: String,
-        #[arg(short, long, default_value = "@file")]
+        #[usage(short, long, default = "@file")]
         anchor: String,
-        #[arg(long)]
+        #[usage(long)]
         supersedes: Option<String>,
     },
     /// install lane's agent integrations
+    #[usage(display_order = 6)]
     Install {
-        #[command(subcommand)]
+        #[usage(subcommand)]
         what: Installable,
     },
     /// remove lane's agent integrations
+    #[usage(display_order = 7)]
     Uninstall {
-        #[command(subcommand)]
+        #[usage(subcommand)]
         what: Installable,
     },
-    #[command(hide = true)]
+    #[usage(hide)]
     Capture { rev: String },
     /// show context for a path
+    #[usage(display_order = 8)]
     Why {
         path: Option<String>,
-        #[arg(short, long)]
+        #[usage(short, long)]
         anchor: Option<String>,
     },
     /// re-vouch for a drifted note
+    #[usage(display_order = 9)]
     Holds { id: String },
     /// staleness report
+    #[usage(display_order = 10)]
     Check {
-        #[arg(long)]
+        #[usage(long)]
         json: bool,
     },
     /// promote, re-anchor, rank, evict
+    #[usage(display_order = 11)]
     Audit {
-        #[arg(long, default_value = "")]
+        #[usage(long, default = "")]
         base: String,
-        #[command(flatten)]
+        #[usage(flatten)]
         budget: BudgetArgs,
-        #[arg(long)]
+        #[usage(long)]
         json: bool,
     },
     /// rebase, audit, fast-forward, remove
+    #[usage(display_order = 12)]
     Done {
-        #[arg(long)]
+        #[usage(long)]
         trunk: Option<String>,
-        #[arg(long)]
+        #[usage(long)]
         keep: bool,
-        #[arg(long)]
+        #[usage(long)]
         cd: bool,
         /// squash lane commits into one landing commit
-        #[arg(long, conflicts_with = "no_merge")]
+        #[usage(long, conflicts_with = "no_merge")]
         squash: bool,
         /// stop after the memory commit, for a pull request to carry
-        #[arg(long)]
+        #[usage(long)]
         no_merge: bool,
-        #[command(flatten)]
+        #[usage(flatten)]
         budget: BudgetArgs,
     },
     /// remove lanes whose branch has landed in trunk
+    #[usage(display_order = 13)]
     Sweep {
         /// list what would go, remove nothing
-        #[arg(long)]
+        #[usage(long)]
         dry_run: bool,
     },
     /// discard a lane without landing it
+    #[usage(display_order = 14)]
     Rm {
         name: String,
         /// discard commits trunk does not have
-        #[arg(long)]
+        #[usage(long)]
         force: bool,
     },
     /// print shell integration
+    #[usage(display_order = 15)]
     Shellenv,
 }
 
-#[derive(Subcommand, Debug)]
+#[derive(usage::Subcommands, Debug)]
 enum Installable {
     /// commit-message capture hooks
     Hooks,
@@ -1120,6 +1132,7 @@ fn shellenv() -> Result<i32> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::ffi::OsStr;
 
     #[test]
     fn flock_excludes_a_second_open_file_description() {
@@ -1139,14 +1152,14 @@ mod tests {
 
     #[test]
     fn install_and_uninstall_take_hooks_or_skill() {
-        let cli = Cli::try_parse_from(["lane", "install", "skill"]).unwrap();
+        let cli = Cli::try_parse_from(&["lane", "install", "skill"].map(OsStr::new)).unwrap();
         assert!(matches!(
             cli.command,
             Command::Install {
                 what: Installable::Skill
             }
         ));
-        let cli = Cli::try_parse_from(["lane", "uninstall", "hooks"]).unwrap();
+        let cli = Cli::try_parse_from(&["lane", "uninstall", "hooks"].map(OsStr::new)).unwrap();
         assert!(matches!(
             cli.command,
             Command::Uninstall {
@@ -1157,7 +1170,7 @@ mod tests {
 
     #[test]
     fn the_old_hooks_install_spelling_no_longer_parses() {
-        assert!(Cli::try_parse_from(["lane", "hooks", "install"]).is_err());
+        assert!(Cli::try_parse_from(&["lane", "hooks", "install"].map(OsStr::new)).is_err());
     }
 
     #[test]


### PR DESCRIPTION
Replaces clap 4.6.6 with [usage-rs](https://github.com/jdx/usage) 6.3.0. One of two alternatives; the other is #4. Rebased onto #5 and prepared with `lane done --no-merge`.

The whole change is the derive block in `crates/lane/src/cli.rs`. The implementation below it is untouched, and `main.rs` never changed — `Cli::parse()` is a drop-in.

## Mapping

| clap | usage |
|---|---|
| `#[derive(Parser)]` | `#[derive(usage::Cli)]` |
| `#[derive(Args)]` / `#[derive(Subcommand)]` | `#[derive(usage::Args)]` / `#[derive(usage::Subcommands)]` |
| `#[command(...)]` / `#[arg(...)]` | `#[usage(...)]` |
| `name = "lane"` | `bin = "lane"` |
| `hide = true` | `hide` |
| `default_value` | `default` |
| `conflicts_with` | `conflicts` |

Three things had to be declared rather than inherited:

- **`unknown_flags = "error"`** — usage treats an unknown flag as a *value* by default, which suits a wrapper CLI and not this one. Declared once on the root; it reaches every subcommand.
- **`display_order` on all 15 variants** — usage sorts subcommands alphabetically where clap kept declaration order. Without it `lane --help` opens with `audit, check, done…` instead of the workflow order the README documents. This is the one piece of added ceremony: inserting a command means renumbering, as `sweep` just did.
- **`MAX_NOTES` / `MAX_CHARS` deleted** — usage wants a string literal beside `default_value_t` so the default reaches the portable spec. Keeping both would be two sources of truth.

Three test call sites needed `.map(OsStr::new)`; `try_parse_from` takes `&[&OsStr]`, not `IntoIterator`.

## Moving to 6.3.0

The branch was opened against 6.0.0. Two things came with the bump to the released line:

- 6.1.0 removed the clap compatibility spellings, so `conflicts_with` became `conflicts`. It is a compile error, not a silent change.
- usage-rs declares `rust-version = "1.91"`, so the workspace MSRV moved 1.85 → 1.91. That bump is what makes clippy read a nested `if` in `skill_uninstall` as a let-chain, which is why an unrelated-looking lint fix rides along. The lint is latent on `main` and only fires at 1.91.

## What it costs

Measured against this branch's base, release profile, stripped. All three usage crates pinned per row — `cargo update -p usage-rs` alone leaves `usage-argv` floating and the numbers come out wrong:

| build | stripped binary | vs clap |
|---|---:|---:|
| clap 4.6.6 | 14,614,864 B | — |
| usage 6.0.0 | 14,684,480 B | +69,616 B |
| usage 6.1.0 | 14,684,496 B | +69,632 B |
| usage 6.1.1 | 14,668,032 B | +53,168 B |
| usage 6.2.0 | 14,717,088 B | +102,224 B |
| **usage 6.3.0** | **14,733,728 B** | **+118,864 B (+0.81%)** |
| usage 6.3.0, `spec` + `help` only | 14,700,432 B | +85,568 B |

6.1.1's out-of-lined error construction won back ~16 KB, then 6.2.0's help redesign cost ~49 KB and 6.3.0's default colors another ~17 KB. Dropping `diagnostics` returns 33,296 B but loses the did-you-mean tips that currently match clap's word for word.

Wall time is unchanged: `--version` over 3000 runs sits at 3.1 ms min / 2.0 ms user+sys for clap against 3.2 ms / 2.2 ms for usage, with σ larger than the gap. Neither parser is visible next to process startup for a 14.6 MB binary.

usage's published win (1.3 MB vs clap's 3.1 MB) is at mise scale — 211 commands, 722 flags — where clap spends real time building and validating the tree before reading a word. lane has 16 commands, so there is no tree-building cost to eliminate, and the static tables plus help renderer cost more than they save. **The +0.48% in the original version of this description flattered the result**; lane's 14.6 MB is mostly tree-sitter grammars, so the absolute delta is the honest number, and it grew.

## What it buys

13 crates leave the graph and 3 arrive:

- out: `clap`, `clap_builder`, `clap_derive`, `clap_lex`, `anstream`, `anstyle`, `anstyle-parse`, `anstyle-query`, `colorchoice`, `heck`, `is_terminal_polyfill`, `strsim`, `utf8parse`
- in: `usage-rs`, `usage-argv`, `usage-derive`

And `lane __usage_spec__` emits the whole command surface as KDL, which `usage g markdown` and `usage g manpage` consume — that could replace the hand-kept commands data behind the site's `/commands` page.

## Test plan

- [x] `cargo test` — 85 pass
- [x] `./test_lane.sh` — 150 pass
- [x] `cargo clippy --all-targets -- -D warnings` and `cargo fmt --check` — clean
- [x] Error text and exit codes match clap, including `--squash` / `--no-merge` (same message, exit 2), unknown flags, and the hidden `capture`
- [x] `sweep` lands in workflow position, not alphabetically
- [x] `lane __usage_spec__` still emits KDL on 6.3.0
- [ ] Decide between this and #4
- [ ] Decide whether to trade `diagnostics` for 33 KB

## Cosmetic diffs

Two carried over from the original: usage heads the section `Flags:` instead of `Options:`, and prints `lane 0.1.0` above the about line.

Two are new in 6.2.0+ and are a regression:

- Defaults always render on their own line. `lane audit --help` now reads `--max-notes <MAX_NOTES>` then `(default: 5)` on the next line, where clap kept `[default: 5]` inline. It is width-independent, and adding a doc comment does not fold it back — the continuation line stays either way. No documented knob short of a custom `help_template`.
- `--base <BASE>` on `audit` prints `(default: )`, rendering the empty `default = ""` literally. clap hid it.
