### PR TITLE
refactor: clap -> pico-args

### DIFF
--- a/.lane/log.jsonl
+++ b/.lane/log.jsonl
@@ -25,3 +25,4 @@
 {"anchor":"fn write_state_file","at":"2026-08-22T18:23:07Z","branch":"state-out-of-git","id":"01M0GFVWN31756XJ6E56B8N99V","kind":"evict","path":"crates/lane/src/store.rs","reason":"anchor missing"}
 {"anchor":"fn create","at":"2026-08-22T20:52:05Z","body_hash":"97bc6a740125f84b","branch":"state-out-of-git","id":"01M0EXNVCK4JP9328P47M4W2C1","kind":"holds","norm":"1","path":"crates/lane/src/worktree.rs","raw_hash":"7d27fd0bd69499c0","sig":"2a21aaf08379e25a"}
 {"anchor":"@file","at":"2026-08-22T20:52:05Z","body_hash":"c48edff8d22ea483","branch":"state-out-of-git","id":"01M0ESRPDGANMXC60YCD3VYVS5","kind":"holds","norm":"1","path":"test_lane.sh","raw_hash":"61108909a406b19a","sig":"e3b0c44298fc1c14"}
+{"at":"2026-08-24T01:30:33Z","branch":"argv-manual","kind":"landing","lane":"01M0RP74Q1CSNQ7SBJNKTQQR59"}

--- a/.lane/memory/crates/lane/Cargo.toml/01M0RP813WRK018HGY8ATHW0XT-pico-args-ships-eq-separator.md
+++ b/.lane/memory/crates/lane/Cargo.toml/01M0RP813WRK018HGY8ATHW0XT-pico-args-ships-eq-separator.md
@@ -1,0 +1,9 @@
+---
+id: 01M0RP813WRK018HGY8ATHW0XT
+anchor: pico-args
+created: 2026-08-24T01:30:25Z
+branch: argv-manual
+norm: '1'
+---
+
+pico-args ships eq-separator and short-space-opt off by default, so an unfeatured dependency turns --base=main into "the '--base' option doesn't have an associated value"; both are named in the manifest on purpose

--- a/.lane/memory/crates/lane/src/args.rs/01M0RP813X90RVC2J9FEMBECX0-pico-args-has-no-handling-of.md
+++ b/.lane/memory/crates/lane/src/args.rs/01M0RP813X90RVC2J9FEMBECX0-pico-args-has-no-handling-of.md
@@ -1,0 +1,13 @@
+---
+id: 01M0RP813X90RVC2J9FEMBECX0
+anchor: fn terminated
+created: 2026-08-24T01:30:25Z
+branch: argv-manual
+norm: '1'
+sig: 7b60764a4d3b6ee8
+body_hash: 9c08eb1b1627f4b2
+raw_hash: 15891290909f68f7
+lines: 174-183
+---
+
+pico-args has no -- handling of its own, so the split must happen before Arguments::from_vec sees the words; otherwise a flag written after -- is still read as one

--- a/.lane/memory/crates/lane/src/help.rs/01M0RP8141K78K4HX605TH4W8E-the-parse-errors-quote-this.md
+++ b/.lane/memory/crates/lane/src/help.rs/01M0RP8141K78K4HX605TH4W8E-the-parse-errors-quote-this.md
@@ -1,0 +1,13 @@
+---
+id: 01M0RP8141K78K4HX605TH4W8E
+anchor: fn usage
+created: 2026-08-24T01:30:25Z
+branch: argv-manual
+norm: '1'
+sig: b118a8f064d37898
+body_hash: 5813c3a56ee99991
+raw_hash: 4259161586c45c1f
+lines: 55-74
+---
+
+the parse errors quote this line rather than writing their own, which is what keeps an error and the screen it points at from disagreeing

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,56 +12,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "anstream"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
-dependencies = [
- "anstyle",
- "anstyle-parse",
- "anstyle-query",
- "anstyle-wincon",
- "colorchoice",
- "is_terminal_polyfill",
- "utf8parse",
-]
-
-[[package]]
-name = "anstyle"
-version = "1.0.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
-
-[[package]]
-name = "anstyle-parse"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
-dependencies = [
- "utf8parse",
-]
-
-[[package]]
-name = "anstyle-query"
-version = "1.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
-dependencies = [
- "windows-sys",
-]
-
-[[package]]
-name = "anstyle-wincon"
-version = "3.0.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
-dependencies = [
- "anstyle",
- "once_cell_polyfill",
- "windows-sys",
-]
-
-[[package]]
 name = "anyhow"
 version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -120,52 +70,6 @@ dependencies = [
  "cpufeatures",
  "rand_core",
 ]
-
-[[package]]
-name = "clap"
-version = "4.6.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "473c7e07f409a8d772161724aa8db6a765a2532a70f9667eeb7b49d3d02fbdca"
-dependencies = [
- "clap_builder",
- "clap_derive",
-]
-
-[[package]]
-name = "clap_builder"
-version = "4.6.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b48fea5a88e9ae728a2dcbedbfc0e730f7d60da42e1cb049a83c9fb8b789889"
-dependencies = [
- "anstream",
- "anstyle",
- "clap_lex",
- "strsim",
-]
-
-[[package]]
-name = "clap_derive"
-version = "4.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d012d2b9d65aca7f18f4d9878a045bc17899bba951561ba5ec3c2ba1eed9a061"
-dependencies = [
- "heck",
- "proc-macro2",
- "quote",
- "syn 3.0.3",
-]
-
-[[package]]
-name = "clap_lex"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
-
-[[package]]
-name = "colorchoice"
-version = "1.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "const-oid"
@@ -304,12 +208,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
-name = "heck"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
-
-[[package]]
 name = "hybrid-array"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -327,12 +225,6 @@ dependencies = [
  "equivalent",
  "hashbrown",
 ]
-
-[[package]]
-name = "is_terminal_polyfill"
-version = "1.70.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
 name = "itoa"
@@ -409,9 +301,9 @@ name = "lane"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "clap",
  "jiff",
  "libc",
+ "pico-args",
  "rustix",
  "serde",
  "serde_json",
@@ -471,10 +363,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
-name = "once_cell_polyfill"
-version = "1.70.2"
+name = "pico-args"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+checksum = "5be167a7af36ee22fe3115051bc51f6e6c7054c9348e28deb4f49bd6f705a315"
 
 [[package]]
 name = "pin-project-lite"
@@ -686,12 +578,6 @@ name = "streaming-iterator"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b2231b7c3057d5e4ad0156fb3dc807d900806020c5ffa3ee6ff2c8c76fb8520"
-
-[[package]]
-name = "strsim"
-version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "syn"
@@ -915,12 +801,6 @@ name = "unsafe-libyaml"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
-
-[[package]]
-name = "utf8parse"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "walkdir"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ unimplemented = "warn"
 
 [profile.release]
 opt-level = 3
-lto = "thin"
+lto = "fat"
 codegen-units = 1
 strip = true
+panic = "abort"

--- a/crates/lane/Cargo.toml
+++ b/crates/lane/Cargo.toml
@@ -31,8 +31,10 @@ path = "src/main.rs"
 
 [dependencies]
 anyhow = "1.0.104"
-clap = { version = "4.6.6", features = ["derive"] }
 jiff = "0.2.35"
+# Both separators are off by default; clap accepted `--base=main` and `-psrc/x.rs`,
+# and a reader who types either should not be told the flag has no value.
+pico-args = { version = "0.5.0", features = ["eq-separator", "short-space-opt"] }
 serde = { version = "1.0.229", features = ["derive"] }
 serde_json = "1.0.151"
 serde_yaml_ng = "0.10.0"

--- a/crates/lane/src/args.rs
+++ b/crates/lane/src/args.rs
@@ -1,0 +1,514 @@
+//! Argument parsing. A leading word selects the command; everything after it is
+//! read by `pico-args` and what it could not place is checked here.
+//!
+//! [`parse`] is pure and takes the argument list explicitly, so a test drives it
+//! without a process. `-h`/`--help` anywhere in a command's arguments wins over
+//! the rest of them, and a bare `lane` prints the root screen. Words after `--`
+//! are positional whatever they look like, which is what lets a note's text
+//! start with a dash.
+
+use crate::help::Help;
+use anyhow::Result;
+use std::ffi::OsString;
+
+pub const VERSION: &str = env!("CARGO_PKG_VERSION");
+
+const MAX_NOTES: usize = 5;
+const MAX_CHARS: usize = 1200;
+
+/// Every command that appears in help, for the typo suggestion.
+const COMMANDS: &[&str] = &[
+    "init",
+    "new",
+    "ls",
+    "path",
+    "note",
+    "install",
+    "uninstall",
+    "why",
+    "holds",
+    "check",
+    "audit",
+    "done",
+    "sweep",
+    "rm",
+    "shellenv",
+];
+
+/// How much memory one `(path, anchor)` may keep. Shared by `audit` and `done`,
+/// which is why it is a type rather than two pairs of fields.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Budget {
+    pub max_notes: usize,
+    pub max_chars: usize,
+}
+
+impl Default for Budget {
+    fn default() -> Self {
+        Self {
+            max_notes: MAX_NOTES,
+            max_chars: MAX_CHARS,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Installable {
+    Hooks,
+    Skill,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct NewArgs {
+    pub name: String,
+    pub base: Option<String>,
+    pub dirty: bool,
+    pub cd: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct NoteArgs {
+    pub text: String,
+    pub path: String,
+    pub anchor: String,
+    pub supersedes: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct WhyArgs {
+    pub path: Option<String>,
+    pub anchor: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AuditArgs {
+    pub base: String,
+    pub budget: Budget,
+    pub json: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DoneArgs {
+    pub trunk: Option<String>,
+    pub keep: bool,
+    pub cd: bool,
+    pub squash: bool,
+    pub no_merge: bool,
+    pub budget: Budget,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RmArgs {
+    pub name: String,
+    pub force: bool,
+}
+
+/// What the argument list asked for. `Help` and `Version` are answers in their
+/// own right rather than a flag on a command, because neither reaches the store.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Parsed {
+    Init,
+    New(NewArgs),
+    Ls,
+    Path { name: String },
+    Note(NoteArgs),
+    Install(Installable),
+    Uninstall(Installable),
+    Capture { rev: String },
+    Why(WhyArgs),
+    Holds { id: String },
+    Check { json: bool },
+    Audit(AuditArgs),
+    Done(DoneArgs),
+    Sweep { dry_run: bool },
+    Rm(RmArgs),
+    Shellenv,
+    Help(Help),
+    Version,
+}
+
+/// Parse the arguments after the program name.
+///
+/// # Example
+/// ```
+/// use lane::args::{Installable, Parsed, parse};
+/// let parsed = parse(vec!["install".into(), "skill".into()]).unwrap();
+/// assert_eq!(parsed, Parsed::Install(Installable::Skill));
+/// ```
+pub fn parse(raw: Vec<OsString>) -> Result<Parsed> {
+    let head = raw.first().and_then(|a| a.to_str()).map(str::to_owned);
+    match head.as_deref() {
+        Some("init") => bare(rest(raw), Help::Init, Parsed::Init),
+        Some("new") => parse_new(rest(raw)),
+        Some("ls") => bare(rest(raw), Help::Ls, Parsed::Ls),
+        Some("path") => parse_one(rest(raw), Help::Path, "<NAME>", |name| Parsed::Path {
+            name,
+        }),
+        Some("note") => parse_note(rest(raw)),
+        Some("install") => parse_installable(rest(raw), Help::Install, Parsed::Install),
+        Some("uninstall") => parse_installable(rest(raw), Help::Uninstall, Parsed::Uninstall),
+        Some("capture") => parse_capture(rest(raw)),
+        Some("why") => parse_why(rest(raw)),
+        Some("holds") => parse_one(rest(raw), Help::Holds, "<ID>", |id| Parsed::Holds { id }),
+        Some("check") => parse_check(rest(raw)),
+        Some("audit") => parse_audit(rest(raw)),
+        Some("done") => parse_done(rest(raw)),
+        Some("sweep") => parse_sweep(rest(raw)),
+        Some("rm") => parse_rm(rest(raw)),
+        Some("shellenv") => bare(rest(raw), Help::Shellenv, Parsed::Shellenv),
+        Some("-h" | "--help") => Ok(Parsed::Help(Help::Root)),
+        Some("-V" | "--version") => Ok(Parsed::Version),
+        None => Ok(Parsed::Help(Help::Root)),
+        Some(other) if other.starts_with('-') => Err(unexpected(other, Help::Root)),
+        Some(other) => Err(unrecognized(other)),
+    }
+}
+
+/// Drop the leading command word.
+fn rest(raw: Vec<OsString>) -> Vec<OsString> {
+    raw.into_iter().skip(1).collect()
+}
+
+/// Split at a bare `--`. Nothing after it is read as a flag, by pico-args or by
+/// the leftover check below.
+fn terminated(raw: Vec<OsString>) -> (Vec<OsString>, Vec<OsString>) {
+    match raw.iter().position(|a| a.as_os_str() == "--") {
+        Some(at) => {
+            let mut flags = raw;
+            let tail = flags.split_off(at);
+            (flags, tail.into_iter().skip(1).collect())
+        }
+        None => (raw, Vec::new()),
+    }
+}
+
+/// What pico-args could not place, refusing anything that still looks like a
+/// flag. Words held back by `--` join the positionals without that check.
+fn positionals(
+    pargs: pico_args::Arguments,
+    after: Vec<OsString>,
+    help: Help,
+) -> Result<Vec<String>> {
+    let mut out = Vec::new();
+    for arg in pargs.finish() {
+        let text = arg.to_string_lossy().into_owned();
+        if text.starts_with('-') {
+            return Err(unexpected(&text, help));
+        }
+        out.push(text);
+    }
+    out.extend(after.into_iter().map(|a| a.to_string_lossy().into_owned()));
+    Ok(out)
+}
+
+fn one(got: Vec<String>, name: &str, help: Help) -> Result<String> {
+    let mut got = got.into_iter();
+    let Some(first) = got.next() else {
+        return Err(missing(&[name], help));
+    };
+    match got.next() {
+        Some(extra) => Err(unexpected(&extra, help)),
+        None => Ok(first),
+    }
+}
+
+fn at_most_one(got: Vec<String>, help: Help) -> Result<Option<String>> {
+    let mut got = got.into_iter();
+    let first = got.next();
+    match got.next() {
+        Some(extra) => Err(unexpected(&extra, help)),
+        None => Ok(first),
+    }
+}
+
+fn none(got: Vec<String>, help: Help) -> Result<()> {
+    match got.into_iter().next() {
+        Some(extra) => Err(unexpected(&extra, help)),
+        None => Ok(()),
+    }
+}
+
+/// A command with no arguments of its own.
+fn bare(raw: Vec<OsString>, help: Help, parsed: Parsed) -> Result<Parsed> {
+    let (flags, after) = terminated(raw);
+    let mut pargs = pico_args::Arguments::from_vec(flags);
+    if pargs.contains(["-h", "--help"]) {
+        return Ok(Parsed::Help(help));
+    }
+    none(positionals(pargs, after, help)?, help)?;
+    Ok(parsed)
+}
+
+/// A command whose whole surface is one required word.
+fn parse_one(
+    raw: Vec<OsString>,
+    help: Help,
+    name: &str,
+    build: fn(String) -> Parsed,
+) -> Result<Parsed> {
+    let (flags, after) = terminated(raw);
+    let mut pargs = pico_args::Arguments::from_vec(flags);
+    if pargs.contains(["-h", "--help"]) {
+        return Ok(Parsed::Help(help));
+    }
+    Ok(build(one(positionals(pargs, after, help)?, name, help)?))
+}
+
+fn parse_new(raw: Vec<OsString>) -> Result<Parsed> {
+    let (flags, after) = terminated(raw);
+    let mut pargs = pico_args::Arguments::from_vec(flags);
+    if pargs.contains(["-h", "--help"]) {
+        return Ok(Parsed::Help(Help::New));
+    }
+    let base = pargs.opt_value_from_str("--base")?;
+    let dirty = pargs.contains("--dirty");
+    let cd = pargs.contains("--cd");
+    let name = one(positionals(pargs, after, Help::New)?, "<NAME>", Help::New)?;
+    Ok(Parsed::New(NewArgs {
+        name,
+        base,
+        dirty,
+        cd,
+    }))
+}
+
+fn parse_note(raw: Vec<OsString>) -> Result<Parsed> {
+    let (flags, after) = terminated(raw);
+    let mut pargs = pico_args::Arguments::from_vec(flags);
+    if pargs.contains(["-h", "--help"]) {
+        return Ok(Parsed::Help(Help::Note));
+    }
+    let path: Option<String> = pargs.opt_value_from_str(["-p", "--path"])?;
+    let anchor: Option<String> = pargs.opt_value_from_str(["-a", "--anchor"])?;
+    let supersedes = pargs.opt_value_from_str("--supersedes")?;
+    let text = at_most_one(positionals(pargs, after, Help::Note)?, Help::Note)?;
+
+    // Both are required, and a reader who forgot both should be told so once.
+    match (text, path) {
+        (Some(text), Some(path)) => Ok(Parsed::Note(NoteArgs {
+            text,
+            path,
+            anchor: anchor.unwrap_or_else(|| "@file".to_string()),
+            supersedes,
+        })),
+        (text, path) => {
+            let mut absent = Vec::new();
+            if path.is_none() {
+                absent.push("--path <PATH>");
+            }
+            if text.is_none() {
+                absent.push("<TEXT>");
+            }
+            Err(missing(&absent, Help::Note))
+        }
+    }
+}
+
+fn parse_installable(
+    raw: Vec<OsString>,
+    help: Help,
+    build: fn(Installable) -> Parsed,
+) -> Result<Parsed> {
+    let (flags, after) = terminated(raw);
+    let mut pargs = pico_args::Arguments::from_vec(flags);
+    if pargs.contains(["-h", "--help"]) {
+        return Ok(Parsed::Help(help));
+    }
+    let what = one(positionals(pargs, after, help)?, "<hooks|skill>", help)?;
+    match what.as_str() {
+        "hooks" => Ok(build(Installable::Hooks)),
+        "skill" => Ok(build(Installable::Skill)),
+        other => Err(anyhow::anyhow!(
+            "unrecognized integration '{other}'{}\n\n\
+             Usage: {}\n\nFor more information, try '{} --help'.",
+            help.tip(),
+            help.usage(),
+            help.invocation()
+        )),
+    }
+}
+
+/// The commit-message hook's own entry point. Hidden: it is called by a hook,
+/// never typed, so it has no help screen to point a reader at.
+fn parse_capture(raw: Vec<OsString>) -> Result<Parsed> {
+    let (flags, after) = terminated(raw);
+    let pargs = pico_args::Arguments::from_vec(flags);
+    let rev = one(positionals(pargs, after, Help::Root)?, "<REV>", Help::Root)?;
+    Ok(Parsed::Capture { rev })
+}
+
+fn parse_why(raw: Vec<OsString>) -> Result<Parsed> {
+    let (flags, after) = terminated(raw);
+    let mut pargs = pico_args::Arguments::from_vec(flags);
+    if pargs.contains(["-h", "--help"]) {
+        return Ok(Parsed::Help(Help::Why));
+    }
+    let anchor = pargs.opt_value_from_str(["-a", "--anchor"])?;
+    let path = at_most_one(positionals(pargs, after, Help::Why)?, Help::Why)?;
+    Ok(Parsed::Why(WhyArgs { path, anchor }))
+}
+
+fn parse_check(raw: Vec<OsString>) -> Result<Parsed> {
+    let (flags, after) = terminated(raw);
+    let mut pargs = pico_args::Arguments::from_vec(flags);
+    if pargs.contains(["-h", "--help"]) {
+        return Ok(Parsed::Help(Help::Check));
+    }
+    let json = pargs.contains("--json");
+    none(positionals(pargs, after, Help::Check)?, Help::Check)?;
+    Ok(Parsed::Check { json })
+}
+
+fn parse_audit(raw: Vec<OsString>) -> Result<Parsed> {
+    let (flags, after) = terminated(raw);
+    let mut pargs = pico_args::Arguments::from_vec(flags);
+    if pargs.contains(["-h", "--help"]) {
+        return Ok(Parsed::Help(Help::Audit));
+    }
+    let base: Option<String> = pargs.opt_value_from_str("--base")?;
+    let budget = budget(&mut pargs)?;
+    let json = pargs.contains("--json");
+    none(positionals(pargs, after, Help::Audit)?, Help::Audit)?;
+    Ok(Parsed::Audit(AuditArgs {
+        base: base.unwrap_or_default(),
+        budget,
+        json,
+    }))
+}
+
+fn parse_done(raw: Vec<OsString>) -> Result<Parsed> {
+    let (flags, after) = terminated(raw);
+    let mut pargs = pico_args::Arguments::from_vec(flags);
+    if pargs.contains(["-h", "--help"]) {
+        return Ok(Parsed::Help(Help::Done));
+    }
+    let trunk = pargs.opt_value_from_str("--trunk")?;
+    let keep = pargs.contains("--keep");
+    let cd = pargs.contains("--cd");
+    let squash = pargs.contains("--squash");
+    let no_merge = pargs.contains("--no-merge");
+    let budget = budget(&mut pargs)?;
+    none(positionals(pargs, after, Help::Done)?, Help::Done)?;
+    // `--squash` writes the merge commit `--no-merge` exists to leave to the pull
+    // request, so asking for both asks for opposite things.
+    if squash && no_merge {
+        return Err(conflict("--squash", "--no-merge", Help::Done));
+    }
+    Ok(Parsed::Done(DoneArgs {
+        trunk,
+        keep,
+        cd,
+        squash,
+        no_merge,
+        budget,
+    }))
+}
+
+fn parse_sweep(raw: Vec<OsString>) -> Result<Parsed> {
+    let (flags, after) = terminated(raw);
+    let mut pargs = pico_args::Arguments::from_vec(flags);
+    if pargs.contains(["-h", "--help"]) {
+        return Ok(Parsed::Help(Help::Sweep));
+    }
+    let dry_run = pargs.contains("--dry-run");
+    none(positionals(pargs, after, Help::Sweep)?, Help::Sweep)?;
+    Ok(Parsed::Sweep { dry_run })
+}
+
+fn parse_rm(raw: Vec<OsString>) -> Result<Parsed> {
+    let (flags, after) = terminated(raw);
+    let mut pargs = pico_args::Arguments::from_vec(flags);
+    if pargs.contains(["-h", "--help"]) {
+        return Ok(Parsed::Help(Help::Rm));
+    }
+    let force = pargs.contains("--force");
+    let name = one(positionals(pargs, after, Help::Rm)?, "<NAME>", Help::Rm)?;
+    Ok(Parsed::Rm(RmArgs { name, force }))
+}
+
+/// The budget flags `audit` and `done` share.
+fn budget(pargs: &mut pico_args::Arguments) -> Result<Budget> {
+    let default = Budget::default();
+    Ok(Budget {
+        max_notes: pargs
+            .opt_value_from_str("--max-notes")?
+            .unwrap_or(default.max_notes),
+        max_chars: pargs
+            .opt_value_from_str("--max-chars")?
+            .unwrap_or(default.max_chars),
+    })
+}
+
+fn unexpected(token: &str, help: Help) -> anyhow::Error {
+    // A word that only looks like a flag — a note's text, a branch named `-x` —
+    // has somewhere to go, and the reader is told where rather than left to guess.
+    let tip = match token.starts_with('-') {
+        true => format!("\n\n  tip: to pass '{token}' as a value, use '-- {token}'"),
+        false => String::new(),
+    };
+    anyhow::anyhow!(
+        "unexpected argument '{token}' found{tip}\n\nUsage: {}\n\nFor more information, try '{} --help'.",
+        help.usage(),
+        help.invocation()
+    )
+}
+
+fn conflict(one: &str, other: &str, help: Help) -> anyhow::Error {
+    anyhow::anyhow!(
+        "the argument '{one}' cannot be used with '{other}'\n\nUsage: {}\n\nFor more information, try '{} --help'.",
+        help.usage(),
+        help.invocation()
+    )
+}
+
+fn missing(absent: &[&str], help: Help) -> anyhow::Error {
+    let list = absent
+        .iter()
+        .map(|name| format!("  {name}"))
+        .collect::<Vec<_>>()
+        .join("\n");
+    anyhow::anyhow!(
+        "the following required arguments were not provided:\n{list}{}\n\nUsage: {}\n\nFor more information, try '{} --help'.",
+        help.tip(),
+        help.usage(),
+        help.invocation()
+    )
+}
+
+fn unrecognized(typed: &str) -> anyhow::Error {
+    let tip = match nearest(typed) {
+        Some(name) => format!("\n\n  tip: a similar subcommand exists: '{name}'"),
+        None => String::new(),
+    };
+    anyhow::anyhow!(
+        "unrecognized subcommand '{typed}'{tip}\n\nUsage: {}\n\nFor more information, try '{} --help'.",
+        Help::Root.usage(),
+        Help::Root.invocation()
+    )
+}
+
+/// The closest command name, when one is close enough to be worth offering.
+/// Two edits is the bound: past that the guess is noise rather than a typo.
+fn nearest(typed: &str) -> Option<&'static str> {
+    COMMANDS
+        .iter()
+        .map(|name| (distance(typed, name), *name))
+        .filter(|(d, _)| *d <= 2)
+        .min_by_key(|(d, _)| *d)
+        .map(|(_, name)| name)
+}
+
+fn distance(a: &str, b: &str) -> usize {
+    let b: Vec<char> = b.chars().collect();
+    let mut prev: Vec<usize> = (0..=b.len()).collect();
+    let mut cur = vec![0; b.len() + 1];
+    for (i, ac) in a.chars().enumerate() {
+        cur[0] = i + 1;
+        for (j, bc) in b.iter().enumerate() {
+            let cost = usize::from(ac != *bc);
+            cur[j + 1] = (prev[j] + cost).min(prev[j + 1] + 1).min(cur[j] + 1);
+        }
+        std::mem::swap(&mut prev, &mut cur);
+    }
+    prev[b.len()]
+}

--- a/crates/lane/src/cli.rs
+++ b/crates/lane/src/cli.rs
@@ -1,5 +1,6 @@
 //! Command surface. Every command returns an exit code; failures bubble as errors.
 
+use crate::args::{self, Budget, Installable, Parsed};
 use crate::audit;
 use crate::capture;
 use crate::git::{self, git, try_git};
@@ -8,140 +9,11 @@ use crate::syntax::{Resolution, Source};
 use crate::util::now_iso;
 use crate::worktree as wt;
 use anyhow::{Result, bail};
-use clap::{Args, Parser, Subcommand};
 use rustix::fs::{FlockOperation, flock};
 use std::fs::{File, OpenOptions};
 use std::io::{IsTerminal, Write};
 use std::ops::Range;
 use std::path::{Path, PathBuf};
-
-const MAX_NOTES: usize = 5;
-const MAX_CHARS: usize = 1200;
-
-#[derive(Parser, Debug)]
-#[command(
-    name = "lane",
-    version,
-    about = "copy-on-write worktrees with memory that survives them"
-)]
-pub struct Cli {
-    #[command(subcommand)]
-    command: Command,
-}
-
-#[derive(Args, Debug, Clone)]
-struct BudgetArgs {
-    #[arg(long, default_value_t = MAX_NOTES)]
-    max_notes: usize,
-    #[arg(long, default_value_t = MAX_CHARS)]
-    max_chars: usize,
-}
-
-#[derive(Subcommand, Debug)]
-enum Command {
-    /// scaffold memory + merge rules, probe reflink
-    Init,
-    /// create a CoW lane
-    New {
-        name: String,
-        #[arg(long)]
-        base: Option<String>,
-        /// carry uncommitted work into the lane
-        #[arg(long)]
-        dirty: bool,
-        /// print path last, for shell fn
-        #[arg(long)]
-        cd: bool,
-    },
-    /// list lanes
-    Ls,
-    /// print a lane's path
-    Path { name: String },
-    /// record a finding
-    Note {
-        text: String,
-        #[arg(short, long)]
-        path: String,
-        #[arg(short, long, default_value = "@file")]
-        anchor: String,
-        #[arg(long)]
-        supersedes: Option<String>,
-    },
-    /// install lane's agent integrations
-    Install {
-        #[command(subcommand)]
-        what: Installable,
-    },
-    /// remove lane's agent integrations
-    Uninstall {
-        #[command(subcommand)]
-        what: Installable,
-    },
-    #[command(hide = true)]
-    Capture { rev: String },
-    /// show context for a path
-    Why {
-        path: Option<String>,
-        #[arg(short, long)]
-        anchor: Option<String>,
-    },
-    /// re-vouch for a drifted note
-    Holds { id: String },
-    /// staleness report
-    Check {
-        #[arg(long)]
-        json: bool,
-    },
-    /// promote, re-anchor, rank, evict
-    Audit {
-        #[arg(long, default_value = "")]
-        base: String,
-        #[command(flatten)]
-        budget: BudgetArgs,
-        #[arg(long)]
-        json: bool,
-    },
-    /// rebase, audit, fast-forward, remove
-    Done {
-        #[arg(long)]
-        trunk: Option<String>,
-        #[arg(long)]
-        keep: bool,
-        #[arg(long)]
-        cd: bool,
-        /// squash lane commits into one landing commit
-        #[arg(long, conflicts_with = "no_merge")]
-        squash: bool,
-        /// stop after the memory commit, for a pull request to carry
-        #[arg(long)]
-        no_merge: bool,
-        #[command(flatten)]
-        budget: BudgetArgs,
-    },
-    /// remove lanes whose branch has landed in trunk
-    Sweep {
-        /// list what would go, remove nothing
-        #[arg(long)]
-        dry_run: bool,
-    },
-    /// discard a lane without landing it
-    Rm {
-        name: String,
-        /// discard commits trunk does not have
-        #[arg(long)]
-        force: bool,
-    },
-    /// print shell integration
-    Shellenv,
-}
-
-#[derive(Subcommand, Debug)]
-enum Installable {
-    /// commit-message capture hooks
-    Hooks,
-    /// the lane skill, teaching an agent the daily loop
-    Skill,
-}
 
 /// Takes the stream it will be written to; under --cd that is stderr, not stdout.
 fn bold(text: &str, tty: bool) -> String {
@@ -153,49 +25,62 @@ fn bold(text: &str, tty: bool) -> String {
 }
 
 pub fn run() -> Result<i32> {
-    match Cli::parse().command {
-        Command::Init => init(),
-        Command::New {
-            name,
-            base,
-            dirty,
-            cd,
-        } => new(&name, base.as_deref(), dirty, cd),
-        Command::Ls => ls(),
-        Command::Path { name } => path(&name),
-        Command::Note {
-            text,
-            path,
-            anchor,
-            supersedes,
-        } => note(&text, &path, &anchor, supersedes.as_deref()),
-        Command::Install { what } => match what {
+    // A usage error is the reader's, not the program's: it exits 2, the way a
+    // command line has always distinguished "you typed it wrong" from "it failed".
+    let parsed = match args::parse(std::env::args_os().skip(1).collect()) {
+        Ok(parsed) => parsed,
+        Err(err) => {
+            eprintln!("error: {err:#}");
+            return Ok(2);
+        }
+    };
+
+    match parsed {
+        Parsed::Help(topic) => {
+            println!("{}", topic.text());
+            Ok(0)
+        }
+        Parsed::Version => {
+            println!("lane {}", args::VERSION);
+            Ok(0)
+        }
+        Parsed::Init => init(),
+        Parsed::New(args) => new(&args.name, args.base.as_deref(), args.dirty, args.cd),
+        Parsed::Ls => ls(),
+        Parsed::Path { name } => path(&name),
+        Parsed::Note(args) => note(
+            &args.text,
+            &args.path,
+            &args.anchor,
+            args.supersedes.as_deref(),
+        ),
+        Parsed::Install(what) => match what {
             Installable::Hooks => hooks_install(),
             Installable::Skill => skill_install(),
         },
-        Command::Uninstall { what } => match what {
+        Parsed::Uninstall(what) => match what {
             Installable::Hooks => hooks_uninstall(),
             Installable::Skill => skill_uninstall(),
         },
-        Command::Capture { rev } => {
+        Parsed::Capture { rev } => {
             capture::capture(&rev);
             Ok(0)
         }
-        Command::Why { path, anchor } => why(path.as_deref(), anchor.as_deref()),
-        Command::Holds { id } => holds(&id),
-        Command::Check { json } => check(json),
-        Command::Audit { base, budget, json } => audit_cmd(&base, &budget, json),
-        Command::Done {
-            trunk,
-            keep,
-            cd,
-            squash,
-            no_merge,
-            budget,
-        } => done(trunk.as_deref(), keep, cd, squash, no_merge, &budget),
-        Command::Sweep { dry_run } => sweep(dry_run),
-        Command::Rm { name, force } => rm(&name, force),
-        Command::Shellenv => shellenv(),
+        Parsed::Why(args) => why(args.path.as_deref(), args.anchor.as_deref()),
+        Parsed::Holds { id } => holds(&id),
+        Parsed::Check { json } => check(json),
+        Parsed::Audit(args) => audit_cmd(&args.base, &args.budget, args.json),
+        Parsed::Done(args) => done(
+            args.trunk.as_deref(),
+            args.keep,
+            args.cd,
+            args.squash,
+            args.no_merge,
+            &args.budget,
+        ),
+        Parsed::Sweep { dry_run } => sweep(dry_run),
+        Parsed::Rm(args) => rm(&args.name, args.force),
+        Parsed::Shellenv => shellenv(),
     }
 }
 
@@ -935,7 +820,7 @@ fn mark(tier: &str) -> &'static str {
     }
 }
 
-fn options(base: &str, budget: &BudgetArgs) -> audit::Options {
+fn options(base: &str, budget: &Budget) -> audit::Options {
     audit::Options {
         base: base.to_string(),
         max_notes: budget.max_notes,
@@ -943,7 +828,7 @@ fn options(base: &str, budget: &BudgetArgs) -> audit::Options {
     }
 }
 
-fn audit_cmd(base: &str, budget: &BudgetArgs, json: bool) -> Result<i32> {
+fn audit_cmd(base: &str, budget: &Budget, json: bool) -> Result<i32> {
     let root = git::repo_root()?;
     let _lock = if root == wt::main_root()? {
         Some(LandingLock::acquire(&wt::trunk_name(&root))?)
@@ -981,7 +866,7 @@ fn done(
     cd: bool,
     squash: bool,
     no_merge: bool,
-    budget: &BudgetArgs,
+    budget: &Budget,
 ) -> Result<i32> {
     let lane_path = git::repo_root()?;
     let root = wt::main_root()?;
@@ -1135,29 +1020,6 @@ mod tests {
 
         flock(&first, FlockOperation::NonBlockingLockExclusive).unwrap();
         assert!(flock(&second, FlockOperation::NonBlockingLockExclusive).is_err());
-    }
-
-    #[test]
-    fn install_and_uninstall_take_hooks_or_skill() {
-        let cli = Cli::try_parse_from(["lane", "install", "skill"]).unwrap();
-        assert!(matches!(
-            cli.command,
-            Command::Install {
-                what: Installable::Skill
-            }
-        ));
-        let cli = Cli::try_parse_from(["lane", "uninstall", "hooks"]).unwrap();
-        assert!(matches!(
-            cli.command,
-            Command::Uninstall {
-                what: Installable::Hooks
-            }
-        ));
-    }
-
-    #[test]
-    fn the_old_hooks_install_spelling_no_longer_parses() {
-        assert!(Cli::try_parse_from(["lane", "hooks", "install"]).is_err());
     }
 
     #[test]

--- a/crates/lane/src/help.rs
+++ b/crates/lane/src/help.rs
@@ -183,7 +183,8 @@ const NEW: &str = "
 
 const LS: &str = "
   Description
-    List every lane in this repository with the branch it carries.
+    List every lane in this repository: its name, the branch it carries,
+    whether its worktree is clean, and how many notes it has yet to land.
 
   Usage
     $ lane ls

--- a/crates/lane/src/help.rs
+++ b/crates/lane/src/help.rs
@@ -1,0 +1,386 @@
+//! The help screens, and the usage lines the parse errors quote.
+//!
+//! Every screen is a static string rather than something rendered from the
+//! parser's tables: nothing here can drift at run time, and the wording is
+//! written for a reader instead of derived from field names. [`Help::usage`] is
+//! the same line the screen opens with, so an error and the screen it points at
+//! cannot disagree.
+
+/// Which screen to print. Reached from a `-h`/`--help` anywhere in a command's
+/// arguments, and from a bare `lane`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Help {
+    Root,
+    Init,
+    New,
+    Ls,
+    Path,
+    Note,
+    Install,
+    Uninstall,
+    Why,
+    Holds,
+    Check,
+    Audit,
+    Done,
+    Sweep,
+    Rm,
+    Shellenv,
+}
+
+impl Help {
+    /// The whole screen, as printed to stdout.
+    pub fn text(self) -> &'static str {
+        match self {
+            Help::Root => ROOT,
+            Help::Init => INIT,
+            Help::New => NEW,
+            Help::Ls => LS,
+            Help::Path => PATH,
+            Help::Note => NOTE,
+            Help::Install => INSTALL,
+            Help::Uninstall => UNINSTALL,
+            Help::Why => WHY,
+            Help::Holds => HOLDS,
+            Help::Check => CHECK,
+            Help::Audit => AUDIT,
+            Help::Done => DONE,
+            Help::Sweep => SWEEP,
+            Help::Rm => RM,
+            Help::Shellenv => SHELLENV,
+        }
+    }
+
+    /// The one-line grammar, quoted by a parse error.
+    pub fn usage(self) -> &'static str {
+        match self {
+            Help::Root => "lane <COMMAND>",
+            Help::Init => "lane init",
+            Help::New => "lane new [OPTIONS] <NAME>",
+            Help::Ls => "lane ls",
+            Help::Path => "lane path <NAME>",
+            Help::Note => "lane note [OPTIONS] --path <PATH> <TEXT>",
+            Help::Install => "lane install <hooks|skill>",
+            Help::Uninstall => "lane uninstall <hooks|skill>",
+            Help::Why => "lane why [OPTIONS] [PATH]",
+            Help::Holds => "lane holds <ID>",
+            Help::Check => "lane check [--json]",
+            Help::Audit => "lane audit [OPTIONS]",
+            Help::Done => "lane done [OPTIONS]",
+            Help::Sweep => "lane sweep [--dry-run]",
+            Help::Rm => "lane rm [--force] <NAME>",
+            Help::Shellenv => "lane shellenv",
+        }
+    }
+
+    /// A line saying what a command's choices mean, where the names do not say
+    /// it themselves. Shown under any error about them, so the reader who typed
+    /// the wrong one and the reader who typed neither are told the same thing.
+    pub fn tip(self) -> &'static str {
+        match self {
+            Help::Install | Help::Uninstall => {
+                "\n\n  tip: `hooks` captures Why: trailers, `skill` teaches an agent the loop"
+            }
+            _ => "",
+        }
+    }
+
+    /// What to tell the reader to run for more, without the flag.
+    pub fn invocation(self) -> &'static str {
+        match self {
+            Help::Root => "lane",
+            Help::Init => "lane init",
+            Help::New => "lane new",
+            Help::Ls => "lane ls",
+            Help::Path => "lane path",
+            Help::Note => "lane note",
+            Help::Install => "lane install",
+            Help::Uninstall => "lane uninstall",
+            Help::Why => "lane why",
+            Help::Holds => "lane holds",
+            Help::Check => "lane check",
+            Help::Audit => "lane audit",
+            Help::Done => "lane done",
+            Help::Sweep => "lane sweep",
+            Help::Rm => "lane rm",
+            Help::Shellenv => "lane shellenv",
+        }
+    }
+}
+
+// Each screen opens with a blank line and indents two spaces; `run` prints them
+// with `println!`, which supplies the matching trailing one, so a screen is
+// padded top and bottom.
+
+const ROOT: &str = "
+  copy-on-write worktrees with memory that survives them
+
+  Usage
+    $ lane <command> [options]
+
+  Commands
+    init         Scaffold memory + merge rules, probe reflink
+    new          Create a CoW lane
+    ls           List lanes
+    path         Print a lane's path
+    note         Record a finding
+    install      Install lane's agent integrations
+    uninstall    Remove lane's agent integrations
+    why          Show context for a path
+    holds        Re-vouch for a drifted note
+    check        Staleness report
+    audit        Promote, re-anchor, rank, evict
+    done         Rebase, audit, fast-forward, remove
+    sweep        Remove lanes whose branch has landed
+    rm           Discard a lane without landing it
+    shellenv     Print shell integration
+
+  Options
+    -h, --help       Display this message
+    -V, --version    Display current version
+
+  Examples
+    $ lane new fix-login
+    $ lane note -p src/auth.rs -a 'fn verify' 'tokens rotate on refresh'
+    $ lane why src/auth.rs
+    $ lane done
+";
+
+const INIT: &str = "
+  Description
+    Scaffold .lane/, register the union merge rule for the append-only record,
+    write the AGENTS.md protocol, and report whether this filesystem can
+    reflink. Safe to re-run: an edited protocol is refused, not overwritten.
+
+  Usage
+    $ lane init
+
+  Options
+    -h, --help    Display this message
+";
+
+const NEW: &str = "
+  Description
+    Create a lane: a worktree under .lane/trees/ and the branch it is on.
+    Everything git ignores is cloned by reference rather than copied, so a
+    build cache or node_modules costs no disk. Where the filesystem cannot
+    reflink, a plain worktree is left instead and the reason is printed.
+
+  Usage
+    $ lane new <name> [options]
+
+  Options
+    --base <rev>    Branch from <rev> instead of the trunk
+    --dirty         Carry uncommitted work into the lane
+    --cd            Print the path last, for the shell function
+    -h, --help      Display this message
+
+  Examples
+    $ lane new fix-login
+    $ lane new spike --dirty
+    $ lane new hotfix --base v1.2.0
+";
+
+const LS: &str = "
+  Description
+    List every lane in this repository with the branch it carries.
+
+  Usage
+    $ lane ls
+
+  Options
+    -h, --help    Display this message
+";
+
+const PATH: &str = "
+  Description
+    Print one lane's worktree path. The shell function built by `lane shellenv`
+    calls this to implement `lane cd`.
+
+  Usage
+    $ lane path <name>
+
+  Options
+    -h, --help    Display this message
+";
+
+const NOTE: &str = "
+  Description
+    Record one finding about one anchor. The note is written once and never
+    rewritten, so two lanes can hold notes about the same anchor and a merge
+    has nothing to resolve. An anchor is `fn verify`, `#script`, `## Heading`,
+    or `@file` for the whole file.
+
+  Usage
+    $ lane note -p <path> [options] <text>
+
+  Options
+    -p, --path <path>      The file the finding is about (required)
+    -a, --anchor <anchor>  The symbol within it (default: @file)
+        --supersedes <id>  Retire this note, which the new one replaces
+    -h, --help             Display this message
+
+  Examples
+    $ lane note -p src/auth.rs -a 'fn verify' 'tokens rotate on refresh'
+    $ lane note -p README.md -a '## Install' 'the tarball is flat, not nested'
+    $ lane note -p src/auth.rs -a 'fn verify' --supersedes 01M0G2 'and only once'
+";
+
+const INSTALL: &str = "
+  Description
+    Install one of lane's agent integrations. `hooks` adds the commit-message
+    capture hooks that turn a `Why:` trailer into a pending note. `skill`
+    writes the lane skill, which teaches an agent the daily loop.
+
+  Usage
+    $ lane install <hooks|skill>
+
+  Options
+    -h, --help    Display this message
+
+  Examples
+    $ lane install hooks
+    $ lane install skill
+";
+
+const UNINSTALL: &str = "
+  Description
+    Remove one of lane's agent integrations. Only lane's own delimited block is
+    spliced out, so anything else in the file survives.
+
+  Usage
+    $ lane uninstall <hooks|skill>
+
+  Options
+    -h, --help    Display this message
+";
+
+const WHY: &str = "
+  Description
+    Print what earlier lanes learned about a path: every note held for it, with
+    the anchor it is about and the id you need to re-vouch for it. With no
+    path, report the whole store.
+
+  Usage
+    $ lane why [path] [options]
+
+  Options
+    -a, --anchor <anchor>  Only notes held for this anchor
+    -h, --help             Display this message
+
+  Examples
+    $ lane why src/auth.rs
+    $ lane why src/auth.rs -a 'fn verify'
+";
+
+const HOLDS: &str = "
+  Description
+    Re-vouch for a note that drifted: the span it describes changed, and you
+    have read it and say it is still true. Any unambiguous prefix of the id
+    works. The alternatives are `lane note --supersedes <id>` when the sentence
+    must change, and deleting the note file when the constraint is gone.
+
+  Usage
+    $ lane holds <id>
+
+  Options
+    -h, --help    Display this message
+";
+
+const CHECK: &str = "
+  Description
+    List every note that is not fresh, each with the id you need next. A note
+    stays listed until you hold it, supersede it, or delete it.
+
+  Usage
+    $ lane check [options]
+
+  Options
+    --json        Emit a JSON report, with each note's body and current span
+    -h, --help    Display this message
+";
+
+const AUDIT: &str = "
+  Description
+    Resolve pending notes against the working tree, follow renames, re-anchor
+    what moved, rank each (path, anchor) against its budget, and evict the
+    remainder to the attic with a reason. `lane done` runs this for you; run it
+    by hand to see what a landing would do.
+
+  Usage
+    $ lane audit [options]
+
+  Options
+    --base <rev>        Rank notes for paths this lane touched since <rev>
+    --max-notes <n>     Notes kept per anchor (default: 5)
+    --max-chars <n>     Characters kept per anchor (default: 1200)
+    --json              Emit a JSON report
+    -h, --help          Display this message
+";
+
+const DONE: &str = "
+  Description
+    Land a lane: rebase onto the trunk, audit memory against the post-rebase
+    tree, commit the memory it changed, fast-forward the trunk, and remove the
+    worktree. A lock held for the whole landing makes it exclusive, so two
+    lanes landing at once serialize rather than race.
+
+  Usage
+    $ lane done [options]
+
+  Options
+    --trunk <branch>    Land onto <branch> instead of the detected trunk
+    --no-merge          Stop at the commit, for a pull request to carry
+    --squash            Squash the lane's commits into one landing commit
+    --keep              Leave the worktree in place after landing
+    --cd                Print the path last, for the shell function
+    --max-notes <n>     Notes kept per anchor (default: 5)
+    --max-chars <n>     Characters kept per anchor (default: 1200)
+    -h, --help          Display this message
+
+  Examples
+    $ lane done
+    $ lane done --squash
+    $ lane done --no-merge     # then: git push -u origin <branch>
+";
+
+const SWEEP: &str = "
+  Description
+    Remove every lane whose branch has landed in trunk. A lane prepared with
+    `lane done --no-merge` sits here until its pull request merges; this is
+    what collects it. Work committed after the merge is never discarded.
+
+  Usage
+    $ lane sweep [options]
+
+  Options
+    --dry-run     List what would go, remove nothing
+    -h, --help    Display this message
+";
+
+const RM: &str = "
+  Description
+    Discard a lane without landing it. Its per-branch state and record go with
+    it. A lane holding commits the trunk does not have is refused unless
+    --force says to throw them away.
+
+  Usage
+    $ lane rm <name> [options]
+
+  Options
+    --force       Discard commits the trunk does not have
+    -h, --help    Display this message
+";
+
+const SHELLENV: &str = "
+  Description
+    Print the shell function that makes `lane new` and `lane done` leave you in
+    the right directory, and adds `lane cd <name>`. Add it to .zshrc or
+    .bashrc once per machine.
+
+  Usage
+    $ eval \"$(lane shellenv)\"
+
+  Options
+    -h, --help    Display this message
+";

--- a/crates/lane/src/help.rs
+++ b/crates/lane/src/help.rs
@@ -113,8 +113,6 @@ impl Help {
 // padded top and bottom.
 
 const ROOT: &str = "
-  copy-on-write worktrees with memory that survives them
-
   Usage
     $ lane <command> [options]
 
@@ -148,9 +146,8 @@ const ROOT: &str = "
 
 const INIT: &str = "
   Description
-    Scaffold .lane/, register the union merge rule for the append-only record,
-    write the AGENTS.md protocol, and report whether this filesystem can
-    reflink. Safe to re-run: an edited protocol is refused, not overwritten.
+    Scaffold .lane/, the merge rule, and the AGENTS.md protocol, and report
+    whether this filesystem can reflink. Safe to re-run.
 
   Usage
     $ lane init
@@ -161,10 +158,8 @@ const INIT: &str = "
 
 const NEW: &str = "
   Description
-    Create a lane: a worktree under .lane/trees/ and the branch it is on.
-    Everything git ignores is cloned by reference rather than copied, so a
-    build cache or node_modules costs no disk. Where the filesystem cannot
-    reflink, a plain worktree is left instead and the reason is printed.
+    Create a worktree under .lane/trees/ and the branch it is on. Everything
+    git ignores is cloned by reference, so a build cache costs no disk.
 
   Usage
     $ lane new <name> [options]
@@ -183,8 +178,8 @@ const NEW: &str = "
 
 const LS: &str = "
   Description
-    List every lane in this repository: its name, the branch it carries,
-    whether its worktree is clean, and how many notes it has yet to land.
+    Every lane's name, the branch it carries, whether it is clean, and how
+    many notes it has yet to land.
 
   Usage
     $ lane ls
@@ -195,8 +190,7 @@ const LS: &str = "
 
 const PATH: &str = "
   Description
-    Print one lane's worktree path. The shell function built by `lane shellenv`
-    calls this to implement `lane cd`.
+    Print one lane's worktree path.
 
   Usage
     $ lane path <name>
@@ -207,10 +201,8 @@ const PATH: &str = "
 
 const NOTE: &str = "
   Description
-    Record one finding about one anchor. The note is written once and never
-    rewritten, so two lanes can hold notes about the same anchor and a merge
-    has nothing to resolve. An anchor is `fn verify`, `#script`, `## Heading`,
-    or `@file` for the whole file.
+    Record one finding about one anchor. An anchor is `fn verify`, `#script`,
+    `## Heading`, or `@file` for the whole file.
 
   Usage
     $ lane note -p <path> [options] <text>
@@ -229,9 +221,8 @@ const NOTE: &str = "
 
 const INSTALL: &str = "
   Description
-    Install one of lane's agent integrations. `hooks` adds the commit-message
-    capture hooks that turn a `Why:` trailer into a pending note. `skill`
-    writes the lane skill, which teaches an agent the daily loop.
+    Install an agent integration. `hooks` captures a commit's `Why:` trailer
+    as a pending note; `skill` teaches an agent the daily loop.
 
   Usage
     $ lane install <hooks|skill>
@@ -246,8 +237,8 @@ const INSTALL: &str = "
 
 const UNINSTALL: &str = "
   Description
-    Remove one of lane's agent integrations. Only lane's own delimited block is
-    spliced out, so anything else in the file survives.
+    Remove an agent integration. Only lane's own delimited block is spliced
+    out, so the rest of the file survives.
 
   Usage
     $ lane uninstall <hooks|skill>
@@ -258,9 +249,8 @@ const UNINSTALL: &str = "
 
 const WHY: &str = "
   Description
-    Print what earlier lanes learned about a path: every note held for it, with
-    the anchor it is about and the id you need to re-vouch for it. With no
-    path, report the whole store.
+    Print what earlier lanes learned about a path, each note with the id you
+    need to re-vouch for it. With no path, report the whole store.
 
   Usage
     $ lane why [path] [options]
@@ -276,10 +266,8 @@ const WHY: &str = "
 
 const HOLDS: &str = "
   Description
-    Re-vouch for a note that drifted: the span it describes changed, and you
-    have read it and say it is still true. Any unambiguous prefix of the id
-    works. The alternatives are `lane note --supersedes <id>` when the sentence
-    must change, and deleting the note file when the constraint is gone.
+    Re-vouch for a drifted note: its span changed and you say it is still
+    true. Any unambiguous prefix of the id works.
 
   Usage
     $ lane holds <id>
@@ -290,8 +278,7 @@ const HOLDS: &str = "
 
 const CHECK: &str = "
   Description
-    List every note that is not fresh, each with the id you need next. A note
-    stays listed until you hold it, supersede it, or delete it.
+    Every note that is not fresh, each with the id you need next.
 
   Usage
     $ lane check [options]
@@ -303,10 +290,8 @@ const CHECK: &str = "
 
 const AUDIT: &str = "
   Description
-    Resolve pending notes against the working tree, follow renames, re-anchor
-    what moved, rank each (path, anchor) against its budget, and evict the
-    remainder to the attic with a reason. `lane done` runs this for you; run it
-    by hand to see what a landing would do.
+    Resolve pending notes against the working tree, re-anchor what moved, and
+    evict past the budget to the attic. `lane done` runs this for you.
 
   Usage
     $ lane audit [options]
@@ -321,10 +306,8 @@ const AUDIT: &str = "
 
 const DONE: &str = "
   Description
-    Land a lane: rebase onto the trunk, audit memory against the post-rebase
-    tree, commit the memory it changed, fast-forward the trunk, and remove the
-    worktree. A lock held for the whole landing makes it exclusive, so two
-    lanes landing at once serialize rather than race.
+    Land a lane: rebase onto the trunk, audit memory, fast-forward, and remove
+    the worktree. Landings are locked, so two at once serialize.
 
   Usage
     $ lane done [options]
@@ -361,9 +344,8 @@ const SWEEP: &str = "
 
 const RM: &str = "
   Description
-    Discard a lane without landing it. Its per-branch state and record go with
-    it. A lane holding commits the trunk does not have is refused unless
-    --force says to throw them away.
+    Discard a lane without landing it, with its per-branch state and record.
+    Commits the trunk does not have are refused unless --force.
 
   Usage
     $ lane rm <name> [options]
@@ -375,9 +357,8 @@ const RM: &str = "
 
 const SHELLENV: &str = "
   Description
-    Print the shell function that makes `lane new` and `lane done` leave you in
-    the right directory, and adds `lane cd <name>`. Add it to .zshrc or
-    .bashrc once per machine.
+    Print the shell function that leaves you in the right directory after
+    `lane new` and `lane done`, and adds `lane cd <name>`.
 
   Usage
     $ eval \"$(lane shellenv)\"

--- a/crates/lane/src/lib.rs
+++ b/crates/lane/src/lib.rs
@@ -1,8 +1,10 @@
+pub mod args;
 pub mod audit;
 pub mod capture;
 pub mod cli;
 pub mod cow;
 pub mod git;
+pub mod help;
 pub mod note;
 pub mod store;
 pub mod syntax;

--- a/crates/lane/tests/args.rs
+++ b/crates/lane/tests/args.rs
@@ -1,0 +1,511 @@
+//! The argument parser, driven the way a shell drives it: a list of words in,
+//! one `Parsed` out, and no process in between.
+//!
+//! These live outside `args.rs` because they are longer than the parser they
+//! cover, and only reach its public surface anyway.
+
+use anyhow::Result;
+use lane::args::*;
+use lane::help::Help;
+use std::ffi::OsString;
+
+/// The parser is the whole surface now, so the tests drive it the way a
+/// shell does: a list of words, with no process in between.
+fn parse_words(words: &[&str]) -> Result<Parsed> {
+    parse(words.iter().map(OsString::from).collect())
+}
+
+fn ok(words: &[&str]) -> Parsed {
+    parse_words(words).expect("parses")
+}
+
+fn err(words: &[&str]) -> String {
+    format!("{:#}", parse_words(words).expect_err("refuses"))
+}
+
+#[test]
+fn bare_lane_and_the_help_flags_reach_the_root_screen() {
+    assert_eq!(ok(&[]), Parsed::Help(Help::Root));
+    assert_eq!(ok(&["-h"]), Parsed::Help(Help::Root));
+    assert_eq!(ok(&["--help"]), Parsed::Help(Help::Root));
+}
+
+#[test]
+fn version_has_clap_s_spelling() {
+    assert_eq!(ok(&["-V"]), Parsed::Version);
+    assert_eq!(ok(&["--version"]), Parsed::Version);
+}
+
+#[test]
+fn every_command_answers_its_own_help_flag() {
+    for (word, screen) in [
+        ("init", Help::Init),
+        ("new", Help::New),
+        ("ls", Help::Ls),
+        ("path", Help::Path),
+        ("note", Help::Note),
+        ("install", Help::Install),
+        ("uninstall", Help::Uninstall),
+        ("why", Help::Why),
+        ("holds", Help::Holds),
+        ("check", Help::Check),
+        ("audit", Help::Audit),
+        ("done", Help::Done),
+        ("sweep", Help::Sweep),
+        ("rm", Help::Rm),
+        ("shellenv", Help::Shellenv),
+    ] {
+        assert_eq!(ok(&[word, "--help"]), Parsed::Help(screen), "{word} --help");
+        assert_eq!(ok(&[word, "-h"]), Parsed::Help(screen), "{word} -h");
+    }
+}
+
+#[test]
+fn help_wins_over_the_arguments_beside_it() {
+    assert_eq!(ok(&["new", "some-lane", "-h"]), Parsed::Help(Help::New));
+    assert_eq!(ok(&["rm", "--force", "-h"]), Parsed::Help(Help::Rm));
+}
+
+#[test]
+fn commands_without_arguments_take_none() {
+    assert_eq!(ok(&["init"]), Parsed::Init);
+    assert_eq!(ok(&["ls"]), Parsed::Ls);
+    assert_eq!(ok(&["shellenv"]), Parsed::Shellenv);
+    assert!(err(&["ls", "extra"]).contains("unexpected argument 'extra' found"));
+}
+
+#[test]
+fn new_reads_its_flags_before_or_after_the_name() {
+    let expected = Parsed::New(NewArgs {
+        name: "fix-login".into(),
+        base: Some("main".into()),
+        dirty: true,
+        cd: true,
+    });
+    assert_eq!(
+        ok(&["new", "fix-login", "--base", "main", "--dirty", "--cd"]),
+        expected
+    );
+    assert_eq!(
+        ok(&["new", "--cd", "--base", "main", "--dirty", "fix-login"]),
+        expected
+    );
+}
+
+#[test]
+fn new_defaults_the_flags_it_was_not_given() {
+    assert_eq!(
+        ok(&["new", "spike"]),
+        Parsed::New(NewArgs {
+            name: "spike".into(),
+            base: None,
+            dirty: false,
+            cd: false,
+        })
+    );
+}
+
+#[test]
+fn the_shell_function_s_own_invocation_still_parses() {
+    // `lane shellenv` writes `command lane new --cd "$@"`, so the flag
+    // arrives before the name and must not swallow it.
+    assert_eq!(
+        ok(&["new", "--cd", "fix-login"]),
+        Parsed::New(NewArgs {
+            name: "fix-login".into(),
+            base: None,
+            dirty: false,
+            cd: true,
+        })
+    );
+    assert_eq!(
+        ok(&["done", "--cd"]),
+        Parsed::Done(DoneArgs {
+            trunk: None,
+            keep: false,
+            cd: true,
+            squash: false,
+            no_merge: false,
+            budget: Budget::default(),
+        })
+    );
+}
+
+#[test]
+fn a_missing_name_names_itself() {
+    let message = err(&["new"]);
+    assert!(message.contains("the following required arguments were not provided"));
+    assert!(message.contains("<NAME>"));
+    assert!(message.contains("Usage: lane new [OPTIONS] <NAME>"));
+    assert!(message.contains("try 'lane new --help'"));
+}
+
+/// Just the names a "required arguments were not provided" error lists.
+/// The usage line below it repeats them, so the whole message cannot say
+/// which ones were actually absent.
+fn absent(words: &[&str]) -> Vec<String> {
+    let message = err(words);
+    let (_, listed) = message
+        .split_once("the following required arguments were not provided:\n")
+        .unwrap_or_else(|| panic!("not a required-argument error:\n{message}"));
+    listed
+        .lines()
+        .take_while(|line| !line.is_empty())
+        .map(|line| line.trim().to_string())
+        .collect()
+}
+
+#[test]
+fn note_requires_both_its_text_and_its_path() {
+    assert_eq!(absent(&["note"]), ["--path <PATH>", "<TEXT>"]);
+    assert_eq!(absent(&["note", "a finding"]), ["--path <PATH>"]);
+    assert_eq!(absent(&["note", "-p", "src/auth.rs"]), ["<TEXT>"]);
+}
+
+#[test]
+fn note_defaults_the_anchor_to_the_whole_file() {
+    assert_eq!(
+        ok(&["note", "-p", "src/auth.rs", "a finding"]),
+        Parsed::Note(NoteArgs {
+            text: "a finding".into(),
+            path: "src/auth.rs".into(),
+            anchor: "@file".into(),
+            supersedes: None,
+        })
+    );
+}
+
+#[test]
+fn note_takes_the_long_and_short_spellings_alike() {
+    let expected = Parsed::Note(NoteArgs {
+        text: "a finding".into(),
+        path: "src/auth.rs".into(),
+        anchor: "fn verify".into(),
+        supersedes: Some("01M0G2".into()),
+    });
+    assert_eq!(
+        ok(&[
+            "note",
+            "-p",
+            "src/auth.rs",
+            "-a",
+            "fn verify",
+            "--supersedes",
+            "01M0G2",
+            "a finding",
+        ]),
+        expected
+    );
+    assert_eq!(
+        ok(&[
+            "note",
+            "--path",
+            "src/auth.rs",
+            "--anchor",
+            "fn verify",
+            "--supersedes",
+            "01M0G2",
+            "a finding",
+        ]),
+        expected
+    );
+}
+
+#[test]
+fn joined_values_parse_the_way_clap_read_them() {
+    assert_eq!(
+        ok(&["note", "--path=src/auth.rs", "--anchor=fn verify", "text"]),
+        Parsed::Note(NoteArgs {
+            text: "text".into(),
+            path: "src/auth.rs".into(),
+            anchor: "fn verify".into(),
+            supersedes: None,
+        })
+    );
+    assert_eq!(
+        ok(&["note", "-psrc/auth.rs", "text"]),
+        Parsed::Note(NoteArgs {
+            text: "text".into(),
+            path: "src/auth.rs".into(),
+            anchor: "@file".into(),
+            supersedes: None,
+        })
+    );
+    let Parsed::Audit(audit) = ok(&["audit", "--base=HEAD~3", "--max-notes=3"]) else {
+        panic!("expected audit");
+    };
+    assert_eq!(audit.base, "HEAD~3");
+    assert_eq!(audit.budget.max_notes, 3);
+}
+
+#[test]
+fn a_double_dash_lets_a_finding_start_with_one() {
+    assert_eq!(
+        ok(&[
+            "note",
+            "-p",
+            "README.md",
+            "--",
+            "--dirty is not the default"
+        ]),
+        Parsed::Note(NoteArgs {
+            text: "--dirty is not the default".into(),
+            path: "README.md".into(),
+            anchor: "@file".into(),
+            supersedes: None,
+        })
+    );
+}
+
+#[test]
+fn install_and_uninstall_take_hooks_or_skill() {
+    assert_eq!(
+        ok(&["install", "skill"]),
+        Parsed::Install(Installable::Skill)
+    );
+    assert_eq!(
+        ok(&["install", "hooks"]),
+        Parsed::Install(Installable::Hooks)
+    );
+    assert_eq!(
+        ok(&["uninstall", "hooks"]),
+        Parsed::Uninstall(Installable::Hooks)
+    );
+    assert_eq!(
+        ok(&["uninstall", "skill"]),
+        Parsed::Uninstall(Installable::Skill)
+    );
+}
+
+#[test]
+fn both_ways_of_getting_an_integration_wrong_say_what_they_mean() {
+    // Named once on `Help`, so the reader who typed neither and the reader
+    // who typed the wrong one cannot be told different things.
+    let tip = Help::Install.tip().trim();
+    assert!(err(&["install"]).contains(tip));
+    assert!(err(&["install", "hook"]).contains(tip));
+    assert!(err(&["uninstall", "hook"]).contains(Help::Uninstall.tip().trim()));
+    // The tip sits under the list it explains, not after the closing line.
+    let message = err(&["install"]);
+    assert!(
+        message.find(tip) < message.find("For more information"),
+        "{message}"
+    );
+    assert!(Help::New.tip().is_empty());
+}
+
+#[test]
+fn a_word_that_only_looks_like_a_flag_is_told_where_to_go() {
+    let message = err(&["new", "spike", "--bogus"]);
+    assert!(
+        message.contains("tip: to pass '--bogus' as a value, use '-- --bogus'"),
+        "{message}"
+    );
+    // A plain word is not a flag, so it gets no advice about `--`.
+    assert!(!err(&["ls", "extra"]).contains("tip:"));
+}
+
+#[test]
+fn an_integration_lane_does_not_ship_is_named_back() {
+    let message = err(&["install", "hook"]);
+    assert!(
+        message.contains("unrecognized integration 'hook'"),
+        "{message}"
+    );
+    assert!(
+        message.contains("Usage: lane install <hooks|skill>"),
+        "{message}"
+    );
+    assert!(err(&["install"]).contains("<hooks|skill>"));
+}
+
+#[test]
+fn the_old_hooks_install_spelling_no_longer_parses() {
+    assert!(parse_words(&["hooks", "install"]).is_err());
+}
+
+#[test]
+fn why_takes_an_optional_path_and_anchor() {
+    assert_eq!(
+        ok(&["why"]),
+        Parsed::Why(WhyArgs {
+            path: None,
+            anchor: None
+        })
+    );
+    assert_eq!(
+        ok(&["why", "src/auth.rs", "-a", "fn verify"]),
+        Parsed::Why(WhyArgs {
+            path: Some("src/auth.rs".into()),
+            anchor: Some("fn verify".into()),
+        })
+    );
+    assert!(err(&["why", "one", "two"]).contains("unexpected argument 'two' found"));
+}
+
+#[test]
+fn the_budget_flags_default_and_override_together() {
+    let Parsed::Audit(audit) = ok(&["audit"]) else {
+        panic!("expected audit");
+    };
+    assert_eq!(audit.budget, Budget::default());
+    assert_eq!(audit.budget.max_notes, 5);
+    assert_eq!(audit.budget.max_chars, 1200);
+    assert_eq!(audit.base, "");
+    assert!(!audit.json);
+
+    let Parsed::Done(done) = ok(&["done", "--max-chars", "80"]) else {
+        panic!("expected done");
+    };
+    assert_eq!(done.budget.max_notes, 5);
+    assert_eq!(done.budget.max_chars, 80);
+}
+
+#[test]
+fn done_and_rm_read_the_rest_of_their_flags() {
+    assert_eq!(
+        ok(&["done", "--trunk", "release", "--keep", "--squash"]),
+        Parsed::Done(DoneArgs {
+            trunk: Some("release".into()),
+            keep: true,
+            cd: false,
+            squash: true,
+            no_merge: false,
+            budget: Budget::default(),
+        })
+    );
+    assert_eq!(
+        ok(&["rm", "spike", "--force"]),
+        Parsed::Rm(RmArgs {
+            name: "spike".into(),
+            force: true,
+        })
+    );
+    assert_eq!(ok(&["check", "--json"]), Parsed::Check { json: true });
+    assert_eq!(
+        ok(&["holds", "01M0G2"]),
+        Parsed::Holds {
+            id: "01M0G2".into()
+        }
+    );
+    assert_eq!(
+        ok(&["path", "spike"]),
+        Parsed::Path {
+            name: "spike".into()
+        }
+    );
+}
+
+#[test]
+fn capture_stays_hidden_but_still_reads_its_revision() {
+    assert_eq!(
+        ok(&["capture", "HEAD"]),
+        Parsed::Capture { rev: "HEAD".into() }
+    );
+    assert!(!Help::Root.text().contains("capture"));
+}
+
+#[test]
+fn a_flag_no_command_owns_is_refused() {
+    assert!(err(&["new", "spike", "--bogus"]).contains("unexpected argument '--bogus' found"));
+    assert!(err(&["--bogus"]).contains("unexpected argument '--bogus' found"));
+    assert!(err(&["check", "--jsonn"]).contains("unexpected argument '--jsonn' found"));
+}
+
+#[test]
+fn a_number_that_is_not_one_says_so() {
+    let message = err(&["audit", "--max-notes", "many"]);
+    assert!(message.contains("failed to parse 'many'"), "{message}");
+}
+
+#[test]
+fn an_unknown_command_offers_the_one_that_was_meant() {
+    let message = err(&["nope"]);
+    assert!(
+        message.contains("unrecognized subcommand 'nope'"),
+        "{message}"
+    );
+    assert!(
+        message.contains("tip: a similar subcommand exists: 'note'"),
+        "{message}"
+    );
+    assert!(err(&["nwe"]).contains("'new'"));
+    // Nothing within two edits: a guess would be noise, so none is offered.
+    assert!(!err(&["frobnicate"]).contains("tip:"));
+}
+
+#[test]
+fn every_command_the_root_screen_lists_parses() {
+    // Read out of the screen rather than out of a second list: a command added
+    // to one and not the other is exactly what this is here to catch.
+    let listed: Vec<&str> = Help::Root
+        .text()
+        .split("  Commands\n")
+        .nth(1)
+        .expect("the root screen lists commands")
+        .lines()
+        .take_while(|line| !line.trim().is_empty())
+        .filter_map(|line| line.split_whitespace().next())
+        .collect();
+    assert_eq!(listed.len(), 15, "{listed:?}");
+    for name in listed {
+        assert!(matches!(ok(&[name, "--help"]), Parsed::Help(_)), "{name}");
+    }
+}
+
+#[test]
+fn every_screen_quotes_a_usage_line_it_agrees_with() {
+    for screen in [
+        Help::Root,
+        Help::Init,
+        Help::New,
+        Help::Ls,
+        Help::Path,
+        Help::Note,
+        Help::Install,
+        Help::Uninstall,
+        Help::Why,
+        Help::Holds,
+        Help::Check,
+        Help::Audit,
+        Help::Done,
+        Help::Sweep,
+        Help::Rm,
+        Help::Shellenv,
+    ] {
+        let text = screen.text();
+        assert!(text.starts_with('\n'), "{screen:?} opens with a blank line");
+        assert!(text.contains("  Usage\n"), "{screen:?} has a usage section");
+        assert!(text.contains("-h, --help"), "{screen:?} documents --help");
+        assert!(
+            screen.usage().starts_with(screen.invocation()),
+            "{screen:?} usage and invocation disagree"
+        );
+    }
+}
+
+#[test]
+fn done_prepares_for_a_pull_request_or_lands_it_but_not_both() {
+    let Parsed::Done(done) = ok(&["done", "--no-merge"]) else {
+        panic!("expected done");
+    };
+    assert!(done.no_merge);
+    assert!(!done.squash);
+
+    // `--squash` writes the merge commit `--no-merge` leaves to the pull request.
+    let message = err(&["done", "--squash", "--no-merge"]);
+    assert!(
+        message.contains("the argument '--squash' cannot be used with '--no-merge'"),
+        "{message}"
+    );
+    assert!(message.contains("try 'lane done --help'"), "{message}");
+}
+
+#[test]
+fn sweep_takes_only_its_dry_run() {
+    assert_eq!(ok(&["sweep"]), Parsed::Sweep { dry_run: false });
+    assert_eq!(ok(&["sweep", "--dry-run"]), Parsed::Sweep { dry_run: true });
+    assert_eq!(ok(&["sweep", "--help"]), Parsed::Help(Help::Sweep));
+    assert!(err(&["sweep", "extra"]).contains("unexpected argument 'extra' found"));
+    assert!(err(&["sweep", "--dry"]).contains("unexpected argument '--dry' found"));
+}


### PR DESCRIPTION
Replaces clap 4.6.6 with a hand-written surface over [pico-args](https://github.com/RazrFalcon/pico-args) 0.5.0, following the structure used in the starship toolkit. One of two alternatives; the other is #3. Rebased onto #5 and prepared with `lane done --no-merge`.

## Structure

- **`crates/lane/src/args.rs`** — `pub fn parse(raw: Vec<OsString>) -> Result<Parsed>`, pure and taking the words explicitly, with a `parse_<cmd>` per command over `pico_args::Arguments::from_vec`. `contains(["-h","--help"])` first, `opt_value_from_str` for values, `finish()` last with a strict bail on anything left over.
- **`crates/lane/src/help.rs`** — the `Help` enum and one `const` screen per command.
- **`crates/lane/tests/args.rs`** — 30 parser tests. They started inline but pushed `args.rs` past the 800-line limit, so they moved out.

`cli.rs` loses 233 lines: the derive block is gone and `run()` matches on `Parsed`.

## Deviations from the reference, each deliberate

- **Exit 2 for usage errors.** The toolkit maps any `Err` to `ExitCode::FAILURE`. lane's clap build exited 2, and `lane done` already uses 2 for "not inside a lane", so `run()` catches the parse error itself and returns 2.
- **`--` is handled before pico-args sees the words.** pico-args has no terminator support, so a flag written after `--` is still read as one. `lane note -p README.md -- "--dirty is not the default"` works.
- **`eq-separator` and `short-space-opt` are enabled.** Both ship off. Without them `lane audit --base=HEAD~3` fails with "the '--base' option doesn't have an associated value" — a silent regression from clap. `combined-flags` stayed off; lane has no boolean short flags.
- **`--squash` / `--no-merge` is checked by hand.** clap's `conflicts_with` has no equivalent here, so `parse_done` compares the two and raises clap's exact message.

## Build profile

`perf(build): fat lto+abort` moves `[profile.release]` from `lto = "thin"` to `"fat"` and adds `panic = "abort"`. That is worth more than the parser swap and costs nothing:

| profile | clap | usage (#3) | **pico-args** |
|---|---:|---:|---:|
| thin, O3 (what `main` ships) | 14,614,864 B | 14,733,728 B | 14,295,152 B |
| fat, O3 | 14,451,184 B | 14,550,736 B | 14,136,688 B |
| **fat + abort, O3** | 14,153,360 B | 14,302,480 B | **13,921,472 B** |
| fat + abort, Os | 13,625,088 B | 13,691,600 B | 13,442,672 B |
| fat + abort, Oz | 13,283,008 B | 13,316,736 B | 13,149,568 B |

Fat LTO is worth ~160 KB; `panic = "abort"` is worth roughly twice that, as the unwinding tables are the larger single item. Nothing in the tree calls `catch_unwind` and there are no `should_panic` tests, so aborting only changes the exit code on a bug. Holding the parser constant and moving only the profile, two builds of the clap binary measure 85.0 ms ± 7.8 and 87.1 ms ± 6.3 on `lane check` (400 runs, user CPU 59.6 vs 59.3 ms). The gap is inside σ, so this shows no measurable regression rather than a speedup.

**`opt-level` was left at 3 on purpose.** `"s"` takes another 528 KB but costs ~7% user CPU on `lane check` (59.8 → 64.1 ms, floor 74.5 → 79.0 ms); `"z"` takes 870 KB for +35% wall and +53% CPU. The tree-sitter grammars are both most of the binary and the hot path in `syntax.rs`, so size and speed trade against each other directly here. That is also why `-Oz` compresses the parser-choice gap — usage-vs-clap narrows from +118,864 B to +33,728 B once grammar code dominates.

The profile change is orthogonal to the #3-vs-#4 decision and applies to whichever lands. It may be cleaner as its own commit on `main`, with both PRs rebased onto it.

## What it costs and buys

Against `main`'s current profile, stripped:

| | clap | pico-args | |
|---|---:|---:|---|
| stripped binary | 14,614,864 B | 13,921,472 B | **−693,392 B (−4.75%)** |
| of which the parser swap | | | −319,712 B |
| of which the build profile | | | −373,680 B |
| third-party crates | 13 | 1 | −12 |
| `lane check`, 400 runs | 84.7 ms (59.0 ms CPU) | 87.2 ms (59.4 ms CPU) | within noise |
| `--version`, 3000 runs | 4.8 ms | 4.7 ms | within noise |

13 crates leave the graph — `clap`, `clap_builder`, `clap_derive`, `clap_lex`, `anstream`, `anstyle`, `anstyle-parse`, `anstyle-query`, `colorchoice`, `heck`, `is_terminal_polyfill`, `strsim`, `utf8parse` — and `pico-args` arrives alone.

Every flag has a description now. Under clap, `--base`, `--path`, `--supersedes`, `--json`, `--trunk`, `--keep`, `--cd`, `--dry-run`, `--max-notes` and `--max-chars` printed with nothing beside them — nobody writes a doc comment for `#[arg(long)] json: bool`. Hand-writing the screens forced all of them to get a line.

The cost is that the surface is now code to maintain: the `--` terminator, a 12-line Levenshtein for the typo suggestion, the required-argument message, and 16 help screens that can drift from the parser. A test reads the command list out of the root screen and parses each name, so a command added to one and not the other fails. `Help::usage()` is quoted by the errors rather than restated, so an error and its screen cannot disagree.

**It caught me once already.** I wrote the `ls` description from the command name rather than from `fn ls` and got it wrong (fixed in the second commit). Derived help cannot describe a flag that does not exist; hand-written help can describe a command it has not read. That is the standing risk, and #5's `sweep` and `--no-merge` were the first test of it — both had to be added to the parser, the screens, the suggestion list and the tests by hand, where the derive would have taken one attribute each.

## Test plan

- [x] `cargo test` — 114 pass (71 lib, 30 parser, 10 clone-layer, 2 tour, 1 doc)
- [x] `./test_lane.sh` — 150 pass
- [x] `cargo clippy --all-targets -- -D warnings` and `cargo fmt --check` — clean
- [x] Error wording and exit codes match clap, including the "similar subcommand exists" tip, the `-- <value>` tip, and `--squash` with `--no-merge`
- [x] `sweep` and `done --no-merge` parse, and their screens agree with the root list
- [x] Full suite re-run under `panic = "abort"` — no test depends on unwinding
- [ ] Read the 16 help screens for anything else stated from the command name rather than the source
- [ ] Decide between this and #3
- [ ] Decide whether the profile change should land on `main` separately
- [ ] Decide whether `opt-level = "s"` is worth 528 KB for ~7% CPU

Two intentional improvements over clap: `lane install` with no argument errors instead of printing help, and both the missing and the misspelled case carry one line saying what `hooks` and `skill` actually do.

