### PR TITLE
ci: prune stale caches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,3 +43,23 @@ jobs:
 
       # Builds the binary itself and drives real git repos in a tmpdir.
       - run: ./test_lane.sh
+
+  # Every main push whose manifests move writes a new entry and leaves the old one behind
+  # until GitHub's own eviction. Keep the newest entry per restore key, drop the rest.
+  prune:
+    needs: gates
+    if: github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+    steps:
+      - env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh cache list --repo "$GITHUB_REPOSITORY" --limit 100 --json id,key,createdAt \
+            | jq -r 'group_by(.key | sub("-[^-]+$"; ""))
+                     | map(sort_by(.createdAt) | reverse | .[1:])
+                     | flatten | .[].id' \
+            | while read -r id; do
+                gh cache delete --repo "$GITHUB_REPOSITORY" "$id"
+              done

--- a/.lane/log.jsonl
+++ b/.lane/log.jsonl
@@ -26,3 +26,4 @@
 {"anchor":"fn create","at":"2026-08-22T20:52:05Z","body_hash":"97bc6a740125f84b","branch":"state-out-of-git","id":"01M0EXNVCK4JP9328P47M4W2C1","kind":"holds","norm":"1","path":"crates/lane/src/worktree.rs","raw_hash":"7d27fd0bd69499c0","sig":"2a21aaf08379e25a"}
 {"anchor":"@file","at":"2026-08-22T20:52:05Z","body_hash":"c48edff8d22ea483","branch":"state-out-of-git","id":"01M0ESRPDGANMXC60YCD3VYVS5","kind":"holds","norm":"1","path":"test_lane.sh","raw_hash":"61108909a406b19a","sig":"e3b0c44298fc1c14"}
 {"at":"2026-08-24T01:30:33Z","branch":"argv-manual","kind":"landing","lane":"01M0RP74Q1CSNQ7SBJNKTQQR59"}
+{"anchor":"@file","at":"2026-08-24T18:41:36Z","body_hash":"87beb9cf647e7c1b","branch":"ci-cache-prune","id":"01M0ESRPDGANMXC60YCD3VYVS5","kind":"holds","norm":"1","path":"test_lane.sh","raw_hash":"a9e6a05f50ff68bb","sig":"e3b0c44298fc1c14"}

--- a/.lane/log.jsonl
+++ b/.lane/log.jsonl
@@ -27,3 +27,4 @@
 {"anchor":"@file","at":"2026-08-22T20:52:05Z","body_hash":"c48edff8d22ea483","branch":"state-out-of-git","id":"01M0ESRPDGANMXC60YCD3VYVS5","kind":"holds","norm":"1","path":"test_lane.sh","raw_hash":"61108909a406b19a","sig":"e3b0c44298fc1c14"}
 {"at":"2026-08-24T01:30:33Z","branch":"argv-manual","kind":"landing","lane":"01M0RP74Q1CSNQ7SBJNKTQQR59"}
 {"anchor":"@file","at":"2026-08-24T18:41:36Z","body_hash":"87beb9cf647e7c1b","branch":"ci-cache-prune","id":"01M0ESRPDGANMXC60YCD3VYVS5","kind":"holds","norm":"1","path":"test_lane.sh","raw_hash":"a9e6a05f50ff68bb","sig":"e3b0c44298fc1c14"}
+{"at":"2026-08-24T18:48:15Z","branch":"ci-cache-prune","kind":"landing","lane":"01M0THKV4P8ABWJ2N1V8XJJ307"}

--- a/.lane/memory/.github/workflows/ci.yml/01M0THM3E8J7FS0WE1PEAA168Y-a-cache-key-is-never-overwri.md
+++ b/.lane/memory/.github/workflows/ci.yml/01M0THM3E8J7FS0WE1PEAA168Y-a-cache-key-is-never-overwri.md
@@ -1,0 +1,13 @@
+---
+id: 01M0THM3E8J7FS0WE1PEAA168Y
+anchor: '@file'
+created: 2026-08-24T18:48:09Z
+branch: ci-cache-prune
+norm: '1'
+sig: eb0ffc2134160f8f
+body_hash: e82819e4d3a6ec21
+raw_hash: a539e516f73f6132
+lines: 1-65
+---
+
+a cache key is never overwritten, so a main run must delete the entries it supersedes or they sit until GitHub's own eviction


### PR DESCRIPTION
A cache key is never overwritten. `save-if` already keeps branches from saving, but every
main push that moved the manifests wrote a new entry and left the old one behind until
GitHub's own 7-day / 10 GB eviction. The repo had reached 12 entries, 1.81 GB.

Adds a `prune` job that runs on main after `gates`. It groups caches by restore key — the
key minus its trailing lockfile hash — and deletes all but the newest in each group.
Steady state is one entry per matrix OS.

The existing backlog is already cleared: 12 entries / 1.81 GB -> 2 entries / 284 MiB.

Verified by extracting the `run` block from the parsed workflow and executing it under
`bash -e` against a `gh` shim; it selected exactly the 10 stale ids and no others.