### PR TITLE
perf: stop paying for git startup

### DIFF
--- a/.lane/log.jsonl
+++ b/.lane/log.jsonl
@@ -28,3 +28,4 @@
 {"at":"2026-08-24T01:30:33Z","branch":"argv-manual","kind":"landing","lane":"01M0RP74Q1CSNQ7SBJNKTQQR59"}
 {"anchor":"@file","at":"2026-08-24T18:41:36Z","body_hash":"87beb9cf647e7c1b","branch":"ci-cache-prune","id":"01M0ESRPDGANMXC60YCD3VYVS5","kind":"holds","norm":"1","path":"test_lane.sh","raw_hash":"a9e6a05f50ff68bb","sig":"e3b0c44298fc1c14"}
 {"at":"2026-08-24T18:48:15Z","branch":"ci-cache-prune","kind":"landing","lane":"01M0THKV4P8ABWJ2N1V8XJJ307"}
+{"at":"2026-08-24T19:42:10Z","branch":"perf-audit","kind":"landing","lane":"01M0TGVNCZR5V7TEH34CYQ5AC7"}

--- a/.lane/log.jsonl
+++ b/.lane/log.jsonl
@@ -29,3 +29,6 @@
 {"anchor":"@file","at":"2026-08-24T18:41:36Z","body_hash":"87beb9cf647e7c1b","branch":"ci-cache-prune","id":"01M0ESRPDGANMXC60YCD3VYVS5","kind":"holds","norm":"1","path":"test_lane.sh","raw_hash":"a9e6a05f50ff68bb","sig":"e3b0c44298fc1c14"}
 {"at":"2026-08-24T18:48:15Z","branch":"ci-cache-prune","kind":"landing","lane":"01M0THKV4P8ABWJ2N1V8XJJ307"}
 {"at":"2026-08-24T19:42:10Z","branch":"perf-audit","kind":"landing","lane":"01M0TGVNCZR5V7TEH34CYQ5AC7"}
+{"anchor":"fn acquire","at":"2026-08-24T19:42:51Z","body_hash":"bac6a3e1e712e18d","branch":"perf-audit","id":"01M0G14CMHEQQ05FRZT0PZA5EG","kind":"holds","norm":"1","path":"crates/lane/src/cli.rs","raw_hash":"e484b52dcbe99ef9","sig":"0bff83f9aaa042a1"}
+{"anchor":"fn create","at":"2026-08-24T19:42:51Z","body_hash":"bfc1cf40b1329b34","branch":"perf-audit","id":"01M0EXNVCK4JP9328P47M4W2C1","kind":"holds","norm":"1","path":"crates/lane/src/worktree.rs","raw_hash":"00e7afe49321a755","sig":"2a21aaf08379e25a"}
+{"anchor":"@file","at":"2026-08-24T19:42:51Z","body_hash":"87beb9cf647e7c1b","branch":"perf-audit","id":"01M0ESRPDGANMXC60YCD3VYVS5","kind":"holds","norm":"1","path":"test_lane.sh","raw_hash":"a9e6a05f50ff68bb","sig":"e3b0c44298fc1c14"}

--- a/.lane/memory/crates/lane/src/cli.rs/01M0TMPTS17M4SC4911BATBKA3-per-lane-status-probes-may-f.md
+++ b/.lane/memory/crates/lane/src/cli.rs/01M0TMPTS17M4SC4911BATBKA3-per-lane-status-probes-may-f.md
@@ -1,0 +1,13 @@
+---
+id: 01M0TMPTS17M4SC4911BATBKA3
+anchor: fn ls
+created: 2026-08-24T19:21:38Z
+branch: perf-audit
+norm: '1'
+sig: 5a116c9621df3b1f
+body_hash: 27b7fc3a8d91e4e0
+raw_hash: 4b7cd8eb7d9310a4
+lines: 533-572
+---
+
+Per-lane status probes may finish out of order, but each result must remain paired with the list_lanes order for stable output.

--- a/.lane/memory/crates/lane/src/git.rs/01M0TMPTQRCWTQSYSN39AMB9RG-git-dir-stays-per-worktree-b.md
+++ b/.lane/memory/crates/lane/src/git.rs/01M0TMPTQRCWTQSYSN39AMB9RG-git-dir-stays-per-worktree-b.md
@@ -1,0 +1,13 @@
+---
+id: 01M0TMPTQRCWTQSYSN39AMB9RG
+anchor: fn layout
+created: 2026-08-24T18:50:48Z
+branch: perf-audit
+norm: '1'
+sig: 8d764c9bac251436
+body_hash: 3626ff17a60c7fc3
+raw_hash: d21fcf6e0849e1ca
+lines: 56-62
+---
+
+git_dir stays per-worktree because lane identities and pending queues must not leak from a primary worktree into a linked lane

--- a/.lane/memory/crates/lane/src/git.rs/01M0TMPTRNJVJYQ52G0CF8ZV5J-on-macos-usr-bin-git-costs-2.md
+++ b/.lane/memory/crates/lane/src/git.rs/01M0TMPTRNJVJYQ52G0CF8ZV5J-on-macos-usr-bin-git-costs-2.md
@@ -1,0 +1,13 @@
+---
+id: 01M0TMPTRNJVJYQ52G0CF8ZV5J
+anchor: fn layout
+created: 2026-08-24T19:14:32Z
+branch: perf-audit
+norm: '1'
+sig: 8d764c9bac251436
+body_hash: 3626ff17a60c7fc3
+raw_hash: d21fcf6e0849e1ca
+lines: 56-62
+---
+
+on macOS /usr/bin/git costs ~20 ms to reach main() — `git --version` with no repo measures 20.4 ms — so a spawn is worth ~20 ms whatever it does, and spawn COUNT is the number that moves wall time here, not what each command asks for. that is why layout reads .git, the gitdir: pointer and commondir directly instead of asking rev-parse

--- a/.lane/memory/crates/lane/src/git.rs/01M0TMPTRQ3T4E9ZAVYT7G7E6Y-git-dir-is-per-worktree-and.md
+++ b/.lane/memory/crates/lane/src/git.rs/01M0TMPTRQ3T4E9ZAVYT7G7E6Y-git-dir-is-per-worktree-and.md
@@ -1,0 +1,13 @@
+---
+id: 01M0TMPTRQ3T4E9ZAVYT7G7E6Y
+anchor: struct RepoLayout
+created: 2026-08-24T19:14:32Z
+branch: perf-audit
+norm: '1'
+sig: 096b5de33f51b8a7
+body_hash: 4f4e2f70126b3686
+raw_hash: 1a8efaf217f3750a
+lines: 48-53
+---
+
+git_dir is per-worktree and common_dir is shared, and the two must not be swapped: lane/id and lane/pending.jsonl are deliberately per-worktree, which is what stops a lane inheriting the queue its parent has not promoted. info/exclude and hooks are NOT safe to compute this way — info/ is on git's shared list and hooks obeys core.hooksPath — so both still shell out

--- a/.lane/memory/crates/lane/src/syntax.rs/01M0TMPTR29GTK9N5MA1Z0PHKD-line-starts-must-preserve-st.md
+++ b/.lane/memory/crates/lane/src/syntax.rs/01M0TMPTR29GTK9N5MA1Z0PHKD-line-starts-must-preserve-st.md
@@ -1,0 +1,13 @@
+---
+id: 01M0TMPTR29GTK9N5MA1Z0PHKD
+anchor: struct Source
+created: 2026-08-24T19:09:49Z
+branch: perf-audit
+norm: '1'
+sig: 7877fe79130c24bf
+body_hash: ea97b192f427557c
+raw_hash: 046908bc9d1ec197
+lines: 225-231
+---
+
+line_starts must preserve str::lines() line count while byte_range keeps split_inclusive newline bytes exactly, because fingerprints hash the resulting span text

--- a/.lane/memory/crates/lane/src/syntax.rs/01M0TMPTRSMCPHAKVYK4FMJJ3K-span-text-feeds-the-note-fin.md
+++ b/.lane/memory/crates/lane/src/syntax.rs/01M0TMPTRSMCPHAKVYK4FMJJ3K-span-text-feeds-the-note-fin.md
@@ -1,0 +1,13 @@
+---
+id: 01M0TMPTRSMCPHAKVYK4FMJJ3K
+anchor: fn byte_range
+created: 2026-08-24T19:14:32Z
+branch: perf-audit
+norm: '1'
+sig: 651739647cf1a22b
+body_hash: 465d8737e0d68b54
+raw_hash: 2fdd1141ea465d06
+lines: 272-290
+---
+
+span_text feeds the note fingerprints, so a one-byte shift here silently marks every note in every repo as drifted. the line index was proved against the old scan over CRLF, multi-byte UTF-8 and inverted spans rather than against fresh expectations, because a test written next to the change encodes the change's own blind spot

--- a/.lane/memory/scripts/bench.sh/01M0TMPTRYPFSM840B8F3VVSX1-the-fixture-is-generated-rat.md
+++ b/.lane/memory/scripts/bench.sh/01M0TMPTRYPFSM840B8F3VVSX1-the-fixture-is-generated-rat.md
@@ -1,0 +1,13 @@
+---
+id: 01M0TMPTRYPFSM840B8F3VVSX1
+anchor: '@file'
+created: 2026-08-24T19:14:40Z
+branch: perf-audit
+norm: '1'
+sig: e3b0c44298fc1c14
+body_hash: f618acf54c6f0860
+raw_hash: 990fc9f07f020906
+lines: 1-286
+---
+
+the fixture is generated rather than pointed at this repo on purpose: note count and file sizes drift with every commit, so timing the live repo makes a baseline meaningless a week later. notes are weighted onto one file because that is the shape that exposes work repeated per note over a single parsed tree

--- a/crates/lane/src/cli.rs
+++ b/crates/lane/src/cli.rs
@@ -90,13 +90,8 @@ struct LandingLock {
 
 impl LandingLock {
     fn acquire(trunk: &str) -> Result<Self> {
-        let common = git(
-            &["rev-parse", "--path-format=absolute", "--git-common-dir"],
-            None,
-        )?;
-        let path = PathBuf::from(common)
-            .join("lane")
-            .join(format!("{trunk}.lock"));
+        let common = git::layout(&std::env::current_dir()?)?.common_dir;
+        let path = common.join("lane").join(format!("{trunk}.lock"));
         if let Some(parent) = path.parent() {
             std::fs::create_dir_all(parent)?;
         }
@@ -545,17 +540,23 @@ fn ls() -> Result<i32> {
     // A week can pass between preparing a lane and its pull request merging, so `ls` has
     // to say the lane is collectable without being asked.
     let landed = landed_lanes(&root);
-    for lane in lanes {
+    let dirty: Vec<bool> = std::thread::scope(|scope| {
+        let workers: Vec<_> = lanes
+            .iter()
+            .map(|lane| scope.spawn(|| wt::is_dirty(&lane.path)))
+            .collect();
+        workers
+            .into_iter()
+            .map(|handle| handle.join().expect("status worker panicked"))
+            .collect()
+    });
+    for (lane, dirty) in lanes.into_iter().zip(dirty) {
         let name = lane
             .path
             .file_name()
             .map(|n| n.to_string_lossy().to_string())
             .unwrap_or_default();
-        let dirty = if wt::is_dirty(&lane.path) {
-            "dirty"
-        } else {
-            "clean"
-        };
+        let dirty = if dirty { "dirty" } else { "clean" };
         let state = if landed.contains(&store::lane_id(&lane.path)) {
             "landed"
         } else {

--- a/crates/lane/src/git.rs
+++ b/crates/lane/src/git.rs
@@ -1,7 +1,7 @@
 //! git via subprocess: rebase and worktree stay git's job, so we never reimplement them.
 
-use anyhow::{Result, bail};
-use std::path::Path;
+use anyhow::{Context, Result, bail};
+use std::path::{Path, PathBuf};
 use std::process::Command;
 
 fn spawn(args: &[&str], cwd: Option<&Path>) -> Result<std::process::Output> {
@@ -39,8 +39,92 @@ pub fn git_ok(args: &[&str], cwd: Option<&Path>) -> bool {
     matches!(spawn(args, cwd), Ok(out) if out.status.success())
 }
 
-pub fn repo_root() -> Result<std::path::PathBuf> {
-    Ok(git(&["rev-parse", "--show-toplevel"], None)?.into())
+/// Filesystem layout for the worktree containing a directory.
+///
+/// `git_dir` is per-worktree; `common_dir` is shared by every linked worktree.
+/// Keep those separate: lane's pending queue and identity intentionally live in
+/// the former, while the primary worktree is the parent of the latter.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RepoLayout {
+    pub git_dir: PathBuf,
+    pub common_dir: PathBuf,
+    pub repo_root: PathBuf,
+    pub main_root: PathBuf,
+}
+
+/// Discover a repository layout without spawning git.
+pub fn layout(start: &Path) -> Result<RepoLayout> {
+    resolve_layout(
+        start,
+        std::env::var_os("GIT_DIR").map(PathBuf::from),
+        std::env::var_os("GIT_COMMON_DIR").map(PathBuf::from),
+    )
+}
+
+fn resolve_layout(
+    start: &Path,
+    git_dir_override: Option<PathBuf>,
+    common_dir_override: Option<PathBuf>,
+) -> Result<RepoLayout> {
+    let start = std::fs::canonicalize(start)
+        .with_context(|| format!("{} is not a git repository", start.display()))?;
+    let repo_root = find_repo_root(&start)?;
+    let discovered_git_dir = git_dir_at(&repo_root)?;
+    let git_dir = canonical_path(git_dir_override.unwrap_or(discovered_git_dir), &repo_root)?;
+
+    let common_dir = match common_dir_override {
+        Some(path) => canonical_path(path, &repo_root)?,
+        None => match std::fs::read_to_string(git_dir.join("commondir")) {
+            Ok(path) => canonical_path(PathBuf::from(path.trim()), &git_dir)?,
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => git_dir.clone(),
+            Err(error) => return Err(error).context("read git commondir"),
+        },
+    };
+    let main_root = common_dir
+        .parent()
+        .context("git common directory has no parent")?
+        .to_path_buf();
+
+    Ok(RepoLayout {
+        git_dir,
+        common_dir,
+        repo_root,
+        main_root,
+    })
+}
+
+fn find_repo_root(start: &Path) -> Result<PathBuf> {
+    for dir in start.ancestors() {
+        if dir.join(".git").exists() {
+            return Ok(dir.to_path_buf());
+        }
+    }
+    bail!("{} is not a git repository", start.display())
+}
+
+fn git_dir_at(repo_root: &Path) -> Result<PathBuf> {
+    let dot_git = repo_root.join(".git");
+    if dot_git.is_dir() {
+        return Ok(dot_git);
+    }
+    let contents = std::fs::read_to_string(&dot_git).context("read .git file")?;
+    let Some(path) = contents.trim().strip_prefix("gitdir:") else {
+        bail!("{} has an invalid .git file", repo_root.display());
+    };
+    Ok(PathBuf::from(path.trim()))
+}
+
+fn canonical_path(path: PathBuf, base: &Path) -> Result<PathBuf> {
+    let path = if path.is_absolute() {
+        path
+    } else {
+        base.join(path)
+    };
+    std::fs::canonicalize(&path).with_context(|| format!("canonicalize {}", path.display()))
+}
+
+pub fn repo_root() -> Result<PathBuf> {
+    Ok(layout(&std::env::current_dir()?)?.repo_root)
 }
 
 pub fn current_branch() -> String {
@@ -107,4 +191,119 @@ pub fn renames(base: &str) -> Vec<(String, String)> {
         pairs.reverse();
     }
     pairs
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    fn primary() -> (TempDir, PathBuf) {
+        let temp = TempDir::new().unwrap();
+        let root = temp.path().join("repo");
+        std::fs::create_dir_all(root.join(".git")).unwrap();
+        (temp, root)
+    }
+
+    fn linked_worktree(root: &Path) -> PathBuf {
+        let lane = root.join(".lane/trees/alpha");
+        let git_dir = root.join(".git/worktrees/alpha");
+        std::fs::create_dir_all(&lane).unwrap();
+        std::fs::create_dir_all(&git_dir).unwrap();
+        std::fs::write(lane.join(".git"), "gitdir: ../../../.git/worktrees/alpha\n").unwrap();
+        std::fs::write(git_dir.join("commondir"), "../..\n").unwrap();
+        lane
+    }
+
+    #[test]
+    fn discovers_primary_root_from_a_subdirectory() {
+        let (_temp, root) = primary();
+        let nested = root.join("src/nested");
+        std::fs::create_dir_all(&nested).unwrap();
+
+        let layout = resolve_layout(&nested, None, None).unwrap();
+        let git_dir = std::fs::canonicalize(root.join(".git")).unwrap();
+        let root = std::fs::canonicalize(root).unwrap();
+        assert_eq!(layout.git_dir, git_dir);
+        assert_eq!(layout.common_dir, layout.git_dir);
+        assert_eq!(layout.repo_root, root);
+        assert_eq!(layout.main_root, layout.repo_root);
+    }
+
+    #[test]
+    fn linked_worktree_uses_per_worktree_git_dir_and_primary_main_root() {
+        let (_temp, root) = primary();
+        let lane = linked_worktree(&root);
+
+        let layout = resolve_layout(&lane.join("src"), None, None).unwrap_err();
+        assert!(layout.to_string().contains("not a git repository"));
+        std::fs::create_dir(lane.join("src")).unwrap();
+        let layout = resolve_layout(&lane.join("src"), None, None).unwrap();
+
+        assert_eq!(
+            layout.git_dir,
+            std::fs::canonicalize(root.join(".git/worktrees/alpha")).unwrap()
+        );
+        assert_eq!(
+            layout.common_dir,
+            std::fs::canonicalize(root.join(".git")).unwrap()
+        );
+        assert_eq!(layout.repo_root, std::fs::canonicalize(&lane).unwrap());
+        // A lane's own root and the primary root must never be conflated.
+        assert_ne!(layout.repo_root, layout.main_root);
+        assert_eq!(layout.main_root, std::fs::canonicalize(root).unwrap());
+    }
+
+    #[test]
+    fn absolute_gitdir_and_environment_overrides_win() {
+        let (_temp, root) = primary();
+        let lane = root.join("lane");
+        let alternate_git = root.join("alternate/git");
+        let alternate_common = root.join("alternate/common");
+        std::fs::create_dir_all(&lane).unwrap();
+        std::fs::create_dir_all(&alternate_git).unwrap();
+        std::fs::create_dir_all(&alternate_common).unwrap();
+        std::fs::write(
+            lane.join(".git"),
+            format!("gitdir: {}\n", alternate_git.display()),
+        )
+        .unwrap();
+
+        let layout = resolve_layout(
+            &lane,
+            Some(alternate_git.clone()),
+            Some(alternate_common.clone()),
+        )
+        .unwrap();
+        assert_eq!(
+            layout.git_dir,
+            std::fs::canonicalize(alternate_git).unwrap()
+        );
+        assert_eq!(
+            layout.common_dir,
+            std::fs::canonicalize(&alternate_common).unwrap()
+        );
+        assert_eq!(
+            layout.main_root,
+            std::fs::canonicalize(alternate_common.parent().unwrap()).unwrap()
+        );
+    }
+
+    #[test]
+    fn rejects_non_repositories() {
+        let temp = TempDir::new().unwrap();
+        let error = resolve_layout(temp.path(), None, None).unwrap_err();
+        assert!(error.to_string().contains("not a git repository"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn canonicalizes_symlinked_starting_paths() {
+        let (temp, root) = primary();
+        let link = temp.path().join("linked-repo");
+        std::os::unix::fs::symlink(&root, &link).unwrap();
+
+        let layout = resolve_layout(&link, None, None).unwrap();
+        assert_eq!(layout.repo_root, std::fs::canonicalize(root).unwrap());
+    }
 }

--- a/crates/lane/src/store.rs
+++ b/crates/lane/src/store.rs
@@ -27,15 +27,9 @@ pub const EVICT: &str = "evict";
 /// Per-worktree: git resolves an uncommon path inside .git/worktrees/<name> for a lane,
 /// so a lane cannot inherit the queue its parent has not promoted yet.
 pub fn pending_path(worktree: &Path) -> PathBuf {
-    let resolved = git::try_git(
-        &["rev-parse", "--path-format=absolute", "--git-path", PENDING],
-        Some(worktree),
-    );
-    if resolved.is_empty() {
-        worktree.join(".git").join(PENDING)
-    } else {
-        PathBuf::from(resolved)
-    }
+    git::layout(worktree)
+        .map(|layout| layout.git_dir.join(PENDING))
+        .unwrap_or_else(|_| worktree.join(".git").join(PENDING))
 }
 
 /// A lane's own identity, stamped at creation and never committed.
@@ -44,28 +38,20 @@ pub fn pending_path(worktree: &Path) -> PathBuf {
 /// names are reused — `fix` twice in a week is normal — so the name alone would make a
 /// fresh lane look like the landed one it was named after.
 pub fn lane_id(worktree: &Path) -> String {
-    let path = git::try_git(
-        &["rev-parse", "--path-format=absolute", "--git-path", LANE_ID],
-        Some(worktree),
-    );
-    if path.is_empty() {
+    let Ok(layout) = git::layout(worktree) else {
         return String::new();
-    }
-    std::fs::read_to_string(path)
+    };
+    std::fs::read_to_string(layout.git_dir.join(LANE_ID))
         .unwrap_or_default()
         .trim()
         .into()
 }
 
 pub fn stamp_lane_id(worktree: &Path) -> Result<()> {
-    let path = git::try_git(
-        &["rev-parse", "--path-format=absolute", "--git-path", LANE_ID],
-        Some(worktree),
-    );
-    if path.is_empty() {
+    let Ok(layout) = git::layout(worktree) else {
         return Ok(());
-    }
-    let path = PathBuf::from(path);
+    };
+    let path = layout.git_dir.join(LANE_ID);
     if let Some(parent) = path.parent() {
         std::fs::create_dir_all(parent)?;
     }

--- a/crates/lane/src/syntax.rs
+++ b/crates/lane/src/syntax.rs
@@ -24,9 +24,11 @@ pub enum Resolution {
 struct Grammar {
     language: fn() -> Language,
     decls: &'static str,
+    query: &'static OnceLock<Option<Query>>,
 }
 
-const RUST: Grammar = Grammar {
+static RUST_QUERY: OnceLock<Option<Query>> = OnceLock::new();
+static RUST: Grammar = Grammar {
     language: || tree_sitter_rust::LANGUAGE.into(),
     decls: r#"
         (function_item name: (identifier) @name) @decl
@@ -40,9 +42,11 @@ const RUST: Grammar = Grammar {
         (macro_definition name: (identifier) @name) @decl
         (impl_item type: (type_identifier) @name) @decl
     "#,
+    query: &RUST_QUERY,
 };
 
-const GO: Grammar = Grammar {
+static GO_QUERY: OnceLock<Option<Query>> = OnceLock::new();
+static GO: Grammar = Grammar {
     language: || tree_sitter_go::LANGUAGE.into(),
     decls: r#"
         (function_declaration name: (identifier) @name) @decl
@@ -51,14 +55,17 @@ const GO: Grammar = Grammar {
         (const_declaration (const_spec name: (identifier) @name)) @decl
         (var_declaration (var_spec name: (identifier) @name)) @decl
     "#,
+    query: &GO_QUERY,
 };
 
-const PYTHON: Grammar = Grammar {
+static PYTHON_QUERY: OnceLock<Option<Query>> = OnceLock::new();
+static PYTHON: Grammar = Grammar {
     language: || tree_sitter_python::LANGUAGE.into(),
     decls: r#"
         (function_definition name: (identifier) @name) @decl
         (class_definition name: (identifier) @name) @decl
     "#,
+    query: &PYTHON_QUERY,
 };
 
 /// Shared by javascript, typescript and tsx; the TS-only forms are appended below.
@@ -92,7 +99,8 @@ const C_DECLS: &str = r#"
     (type_definition declarator: (type_identifier) @name) @decl
 "#;
 
-const JAVA: Grammar = Grammar {
+static JAVA_QUERY: OnceLock<Option<Query>> = OnceLock::new();
+static JAVA: Grammar = Grammar {
     language: || tree_sitter_java::LANGUAGE.into(),
     decls: r#"
         (method_declaration name: (identifier) @name) @decl
@@ -102,60 +110,89 @@ const JAVA: Grammar = Grammar {
         (enum_declaration name: (identifier) @name) @decl
         (record_declaration name: (identifier) @name) @decl
     "#,
+    query: &JAVA_QUERY,
 };
 
-const BASH: Grammar = Grammar {
+static BASH_QUERY: OnceLock<Option<Query>> = OnceLock::new();
+static BASH: Grammar = Grammar {
     language: || tree_sitter_bash::LANGUAGE.into(),
     decls: r#"(function_definition name: (word) @name) @decl"#,
+    query: &BASH_QUERY,
 };
 
 /// css/html/markdown carry no name anchors; they are here for block, heading and comment work.
-const CSS: Grammar = Grammar {
+static CSS_QUERY: OnceLock<Option<Query>> = OnceLock::new();
+static CSS: Grammar = Grammar {
     language: || tree_sitter_css::LANGUAGE.into(),
     decls: "",
+    query: &CSS_QUERY,
 };
 
-const HTML: Grammar = Grammar {
+static HTML_QUERY: OnceLock<Option<Query>> = OnceLock::new();
+static HTML: Grammar = Grammar {
     language: || tree_sitter_html::LANGUAGE.into(),
     decls: "",
+    query: &HTML_QUERY,
 };
 
-const MARKDOWN: Grammar = Grammar {
+static MARKDOWN_QUERY: OnceLock<Option<Query>> = OnceLock::new();
+static MARKDOWN: Grammar = Grammar {
     language: || tree_sitter_md::LANGUAGE.into(),
     decls: "",
+    query: &MARKDOWN_QUERY,
 };
 
-fn grammar_for(ext: &str) -> Option<Grammar> {
+static JS_QUERY: OnceLock<Option<Query>> = OnceLock::new();
+static JS: Grammar = Grammar {
+    language: || tree_sitter_javascript::LANGUAGE.into(),
+    decls: JS_DECLS,
+    query: &JS_QUERY,
+};
+
+static TYPESCRIPT_QUERY: OnceLock<Option<Query>> = OnceLock::new();
+static TYPESCRIPT: Grammar = Grammar {
+    language: || tree_sitter_typescript::LANGUAGE_TYPESCRIPT.into(),
+    decls: TS_DECLS,
+    query: &TYPESCRIPT_QUERY,
+};
+
+static TSX_QUERY: OnceLock<Option<Query>> = OnceLock::new();
+static TSX: Grammar = Grammar {
+    language: || tree_sitter_typescript::LANGUAGE_TSX.into(),
+    decls: TS_DECLS,
+    query: &TSX_QUERY,
+};
+
+static C_QUERY: OnceLock<Option<Query>> = OnceLock::new();
+static C: Grammar = Grammar {
+    language: || tree_sitter_c::LANGUAGE.into(),
+    decls: C_DECLS,
+    query: &C_QUERY,
+};
+
+static CPP_QUERY: OnceLock<Option<Query>> = OnceLock::new();
+static CPP: Grammar = Grammar {
+    language: || tree_sitter_cpp::LANGUAGE.into(),
+    decls: C_DECLS,
+    query: &CPP_QUERY,
+};
+
+fn grammar_for(ext: &str) -> Option<&'static Grammar> {
     Some(match ext {
-        "rs" => RUST,
-        "go" => GO,
-        "py" | "pyi" => PYTHON,
-        "js" | "mjs" | "cjs" | "jsx" => Grammar {
-            language: || tree_sitter_javascript::LANGUAGE.into(),
-            decls: JS_DECLS,
-        },
-        "ts" | "mts" | "cts" => Grammar {
-            language: || tree_sitter_typescript::LANGUAGE_TYPESCRIPT.into(),
-            decls: TS_DECLS,
-        },
-        "tsx" => Grammar {
-            language: || tree_sitter_typescript::LANGUAGE_TSX.into(),
-            decls: TS_DECLS,
-        },
-        "c" | "h" => Grammar {
-            language: || tree_sitter_c::LANGUAGE.into(),
-            decls: C_DECLS,
-        },
-        "cc" | "cpp" | "cxx" | "hpp" | "hh" | "hxx" => Grammar {
-            language: || tree_sitter_cpp::LANGUAGE.into(),
-            decls: C_DECLS,
-        },
-        "java" => JAVA,
-        "sh" | "bash" | "zsh" => BASH,
-        "css" => CSS,
+        "rs" => &RUST,
+        "go" => &GO,
+        "py" | "pyi" => &PYTHON,
+        "js" | "mjs" | "cjs" | "jsx" => &JS,
+        "ts" | "mts" | "cts" => &TYPESCRIPT,
+        "tsx" => &TSX,
+        "c" | "h" => &C,
+        "cc" | "cpp" | "cxx" | "hpp" | "hh" | "hxx" => &CPP,
+        "java" => &JAVA,
+        "sh" | "bash" | "zsh" => &BASH,
+        "css" => &CSS,
         // An SFC is three languages in one; html locates the blocks, the anchor picks the rest.
-        "html" | "htm" | "svelte" | "vue" => HTML,
-        "md" | "markdown" => MARKDOWN,
+        "html" | "htm" | "svelte" | "vue" => &HTML,
+        "md" | "markdown" => &MARKDOWN,
         _ => return None,
     })
 }
@@ -170,13 +207,27 @@ fn parse_with(text: &str, language: &Language) -> Option<Tree> {
     parser.parse(text, None)
 }
 
+/// Byte offsets for the starts of the lines that `str::lines()` reports.
+fn line_starts(text: &str) -> Vec<usize> {
+    if text.is_empty() {
+        return Vec::new();
+    }
+    let mut starts = vec![0];
+    for (offset, byte) in text.bytes().enumerate() {
+        if byte == b'\n' && offset + 1 < text.len() {
+            starts.push(offset + 1);
+        }
+    }
+    starts
+}
+
 /// One parsed file, reused across every note anchored to it.
 pub struct Source {
     text: String,
+    line_starts: Vec<usize>,
     ext: String,
-    grammar: Option<Grammar>,
+    grammar: Option<&'static Grammar>,
     tree: Option<Tree>,
-    query: OnceLock<Option<Query>>,
 }
 
 impl Source {
@@ -191,33 +242,50 @@ impl Source {
             .and_then(|g| parse_with(text, &(g.language)()));
         Source {
             text: text.to_string(),
+            line_starts: line_starts(text),
             ext,
             grammar,
             tree,
-            query: OnceLock::new(),
         }
     }
 
     fn line_count(&self) -> usize {
-        self.text.lines().count()
+        self.line_starts.len()
+    }
+
+    /// A line with the same terminator handling as `str::lines()`.
+    fn line_at(&self, row: usize) -> Option<&str> {
+        let start = *self.line_starts.get(row)?;
+        let end = self
+            .line_starts
+            .get(row + 1)
+            .copied()
+            .unwrap_or(self.text.len());
+        let line = &self.text[start..end];
+        if let Some(line) = line.strip_suffix('\n') {
+            return Some(line.strip_suffix('\r').unwrap_or(line));
+        }
+        Some(line)
     }
 
     /// Byte range covering a 1-indexed inclusive line span.
     fn byte_range(&self, span: Span) -> Range<usize> {
-        let mut start = self.text.len();
-        let mut end = self.text.len();
-        let mut offset = 0usize;
-        for (i, line) in self.text.split_inclusive('\n').enumerate() {
-            let no = i + 1;
-            if no == span.start {
-                start = offset;
-            }
-            offset += line.len();
-            if no == span.end {
-                end = offset;
-                break;
-            }
-        }
+        let start = span
+            .start
+            .checked_sub(1)
+            .and_then(|line| self.line_starts.get(line))
+            .copied()
+            .unwrap_or(self.text.len());
+        let end = span
+            .end
+            .checked_sub(1)
+            .and_then(|line| {
+                self.line_starts
+                    .get(line + 1)
+                    .copied()
+                    .or_else(|| self.line_starts.get(line).map(|_| self.text.len()))
+            })
+            .unwrap_or(self.text.len());
         start.min(end)..end
     }
 
@@ -313,7 +381,7 @@ impl Source {
     /// `fn verify` or a bare `verify`: the earliest declaration of that name in the file.
     fn resolve_decl(&self, anchor: &str) -> Option<Span> {
         let tree = self.tree.as_ref()?;
-        let query = self.decl_query().as_ref()?;
+        let query = self.decl_query()?;
         let parts: Vec<&str> = anchor.split_whitespace().collect();
         let name = *parts.last()?;
         let keyword = if parts.len() > 1 {
@@ -344,7 +412,7 @@ impl Source {
             // must find a line that really says `fn`, whichever pattern matched it.
             if let Some(kw) = keyword {
                 let row = decl.node.start_position().row;
-                let line = self.text.lines().nth(row).unwrap_or_default();
+                let line = self.line_at(row).unwrap_or_default();
                 if !has_word(line, kw) {
                     continue;
                 }
@@ -357,14 +425,17 @@ impl Source {
         best.map(|(_, span)| span)
     }
 
-    fn decl_query(&self) -> &Option<Query> {
-        self.query.get_or_init(|| {
-            let g = self.grammar.as_ref()?;
-            if g.decls.trim().is_empty() {
-                return None;
-            }
-            Query::new(&(g.language)(), g.decls).ok()
-        })
+    fn decl_query(&self) -> Option<&Query> {
+        let grammar = self.grammar?;
+        grammar
+            .query
+            .get_or_init(|| {
+                if grammar.decls.trim().is_empty() {
+                    return None;
+                }
+                Query::new(&(grammar.language)(), grammar.decls).ok()
+            })
+            .as_ref()
     }
 
     /// Which grammar owns the comments inside this span.
@@ -691,5 +762,103 @@ pub fn refresh(token: &str) -> String {
             src.resolve_detail("fn verfy"),
             Resolution::NotFound
         ));
+    }
+
+    fn legacy_span_text(text: &str, span: Span) -> String {
+        let mut start = text.len();
+        let mut end = text.len();
+        let mut offset = 0usize;
+        for (i, line) in text.split_inclusive('\n').enumerate() {
+            let no = i + 1;
+            if no == span.start {
+                start = offset;
+            }
+            offset += line.len();
+            if no == span.end {
+                end = offset;
+                break;
+            }
+        }
+        text[start.min(end)..end].to_string()
+    }
+
+    #[test]
+    fn line_index_matches_str_lines_for_edge_cases() {
+        for (text, count) in [
+            ("", 0),
+            ("one", 1),
+            ("one\n", 1),
+            ("one\r\n", 1),
+            ("a\r\nb\r\n", 2),
+            ("a\n\nb\n", 3),
+            ("é 🙂\n中", 2),
+        ] {
+            let src = Source::new(text, "a.rs");
+            assert_eq!(src.line_count(), count, "{text:?}");
+            assert_eq!(src.line_count(), text.lines().count(), "{text:?}");
+            for (row, line) in text.lines().enumerate() {
+                assert_eq!(src.line_at(row), Some(line), "{text:?}, row {row}");
+            }
+        }
+    }
+
+    #[test]
+    fn indexed_byte_ranges_preserve_legacy_span_text_exactly() {
+        let text = "é 🙂\r\n\r\n中\n";
+        let src = Source::new(text, "a.rs");
+        for span in [
+            Span { start: 1, end: 1 },
+            Span { start: 2, end: 99 },
+            Span { start: 99, end: 99 },
+            Span { start: 3, end: 1 },
+            Span { start: 1, end: 99 },
+            Span { start: 0, end: 1 },
+        ] {
+            assert_eq!(
+                src.span_text(span),
+                legacy_span_text(text, span),
+                "{span:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn declaration_queries_are_shared_per_grammar() {
+        let rust_a = Source::new("fn shared() {}\n", "a.rs");
+        let rust_b = Source::new("fn shared() {}\n", "b.rs");
+        let go = Source::new("func shared() {}\n", "a.go");
+
+        let rust_a_query = rust_a.decl_query().unwrap() as *const Query;
+        let rust_b_query = rust_b.decl_query().unwrap() as *const Query;
+        let go_query = go.decl_query().unwrap() as *const Query;
+        assert_eq!(rust_a_query, rust_b_query);
+        assert_ne!(rust_a_query, go_query);
+        assert!(rust_a.resolve("fn shared").is_some());
+        assert!(go.resolve("func shared").is_some());
+
+        let html = Source::new("<p>nothing</p>", "a.html");
+        assert!(html.decl_query().is_none());
+        let unparsed = Source::new("func shared() {}", "a.swift");
+        assert!(matches!(
+            unparsed.resolve_detail("func shared"),
+            Resolution::Unparsed
+        ));
+    }
+
+    #[test]
+    fn sfc_comment_language_remains_independent_of_the_html_grammar() {
+        let source = Source::new("<script>\nlet x = 1;\n</script>\n", "E.svelte");
+        assert_eq!(
+            source.comment_language("#script"),
+            Some(tree_sitter_javascript::LANGUAGE.into())
+        );
+        assert_eq!(
+            source.comment_language("#style"),
+            Some(tree_sitter_css::LANGUAGE.into())
+        );
+        assert_eq!(
+            source.comment_language("#template"),
+            Some(tree_sitter_html::LANGUAGE.into())
+        );
     }
 }

--- a/crates/lane/src/worktree.rs
+++ b/crates/lane/src/worktree.rs
@@ -1,7 +1,7 @@
 //! Lane lifecycle: create, list, land, remove.
 
 use crate::cow;
-use crate::git::{git, git_ok, try_git};
+use crate::git::{git, git_ok, layout, try_git};
 use anyhow::{Context, Result, bail};
 use std::collections::HashSet;
 use std::io::Write;
@@ -13,14 +13,7 @@ const TREES_PATH: &str = ".lane/trees";
 
 /// Root of the primary worktree, even when called from inside a lane.
 pub fn main_root() -> Result<PathBuf> {
-    let common = git(
-        &["rev-parse", "--path-format=absolute", "--git-common-dir"],
-        None,
-    )?;
-    Ok(PathBuf::from(common)
-        .parent()
-        .map(Path::to_path_buf)
-        .unwrap_or_default())
+    Ok(layout(&std::env::current_dir()?)?.main_root)
 }
 
 pub fn trunk_name(root: &Path) -> String {

--- a/crates/lane/src/worktree.rs
+++ b/crates/lane/src/worktree.rs
@@ -3,10 +3,10 @@
 use crate::cow;
 use crate::git::{git, git_ok, layout, try_git};
 use anyhow::{Context, Result, bail};
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::io::Write;
 use std::path::{Path, PathBuf};
-use std::process::Command;
+use std::sync::{Mutex, OnceLock};
 
 const TREES_DIRNAME: &str = "trees";
 const TREES_PATH: &str = ".lane/trees";
@@ -17,6 +17,21 @@ pub fn main_root() -> Result<PathBuf> {
 }
 
 pub fn trunk_name(root: &Path) -> String {
+    static TRUNKS: OnceLock<Mutex<HashMap<PathBuf, String>>> = OnceLock::new();
+    let trunks = TRUNKS.get_or_init(|| Mutex::new(HashMap::new()));
+    let mut trunks = trunks
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    if let Some(trunk) = trunks.get(root) {
+        return trunk.clone();
+    }
+
+    let trunk = trunk_name_uncached(root);
+    trunks.insert(root.to_path_buf(), trunk.clone());
+    trunk
+}
+
+fn trunk_name_uncached(root: &Path) -> String {
     for candidate in ["main", "master", "trunk"] {
         if git_ok(&["rev-parse", "--verify", "--quiet", candidate], Some(root)) {
             return candidate.into();
@@ -50,17 +65,26 @@ fn ignored_entries(root: &Path) -> Vec<String> {
         .collect()
 }
 
-/// git 2.48+; older versions get absolute paths, which work in place but not after a move.
-fn relative_paths_supported(root: &Path) -> bool {
-    let Ok(output) = Command::new("git")
-        .args(["worktree", "add", "-h"])
-        .current_dir(root)
-        .output()
-    else {
-        return false;
-    };
-    String::from_utf8_lossy(&output.stdout).contains("relative-paths")
-        || String::from_utf8_lossy(&output.stderr).contains("relative-paths")
+/// git 2.48+ supports relative paths. Older versions reject just that option, then use
+/// absolute paths, which work in place but not after a move.
+fn add_worktree(root: &Path, args: &[&str]) -> Result<()> {
+    let mut relative_args = vec!["worktree", "add", "--relative-paths"];
+    relative_args.extend(args);
+    match git(&relative_args, Some(root)) {
+        Ok(_) => Ok(()),
+        Err(error) if rejects_relative_paths(&error) => {
+            let mut absolute_args = vec!["worktree", "add"];
+            absolute_args.extend(args);
+            git(&absolute_args, Some(root)).map(|_| ())
+        }
+        Err(error) => Err(error),
+    }
+}
+
+fn rejects_relative_paths(error: &anyhow::Error) -> bool {
+    let message = error.to_string();
+    message.contains("relative-paths")
+        && (message.contains("unknown option") || message.contains("unrecognized option"))
 }
 
 fn append_line(path: &Path, line: &str) -> Result<()> {
@@ -274,16 +298,12 @@ pub fn create(name: &str, base: Option<&str>, dirty: bool) -> Result<Created> {
         }
     }
     let dest_str = dest.to_string_lossy().to_string();
-    let relative_paths = relative_paths_supported(&root);
 
     let stats = match materialization(dirty, supported) {
         Materialization::Dirty => {
-            let mut args = vec!["worktree", "add", "--no-checkout"];
-            if relative_paths {
-                args.push("--relative-paths");
-            }
+            let mut args = vec!["--no-checkout"];
             args.extend(branch_args(adopt, name, &dest_str, &base));
-            git(&args, Some(&root))?;
+            add_worktree(&root, &args)?;
             let skip = |rel: &str, _is_dir: bool| {
                 rel == ".git"
                     || rel.starts_with(".git/")
@@ -318,12 +338,9 @@ pub fn create(name: &str, base: Option<&str>, dirty: bool) -> Result<Created> {
                 Vec::new()
             };
             let excluded = excluded(&root);
-            let mut args = vec!["worktree", "add"];
-            if relative_paths {
-                args.push("--relative-paths");
-            }
+            let mut args = Vec::new();
             args.extend(branch_args(adopt, name, &dest_str, &base));
-            git(&args, Some(&root))?;
+            add_worktree(&root, &args)?;
             let mut stats = cow::CloneStats::default();
             for entry in ignored {
                 if excluded.contains(&entry) {

--- a/scripts/bench.sh
+++ b/scripts/bench.sh
@@ -1,0 +1,239 @@
+#!/usr/bin/env bash
+# Benchmark harness. Builds one deterministic repo and times every command against it,
+# so a number means the same thing on Monday as it did on Friday.
+#
+# The fixture is generated, never the lane repo itself: the live repo's note count and
+# file sizes drift with every commit, which is exactly what a baseline must not do.
+#
+#   scripts/bench.sh                          time the current build
+#   scripts/bench.sh --out before.json        record a baseline
+#   scripts/bench.sh --compare before.json    time again and print the deltas
+#   scripts/bench.sh --bin path/to/lane       time a binary built elsewhere
+set -uo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+RUNS=${RUNS:-100}
+WARMUP=${WARMUP:-15}
+BIN=""
+OUT=""
+BASELINE=""
+FILTER=""
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --bin)     BIN="$2"; shift 2 ;;
+    --out)     OUT="$2"; shift 2 ;;
+    --compare) BASELINE="$2"; shift 2 ;;
+    --runs)    RUNS="$2"; shift 2 ;;
+    --only)    FILTER="$2"; shift 2 ;;
+    -h|--help) sed -n '2,12p' "$0" | sed 's/^# \?//'; exit 0 ;;
+    *) echo "unknown flag: $1" >&2; exit 2 ;;
+  esac
+done
+
+command -v hyperfine >/dev/null || { echo "bench needs hyperfine: brew install hyperfine" >&2; exit 1; }
+command -v jq >/dev/null || { echo "bench needs jq" >&2; exit 1; }
+
+if [ -z "$BIN" ]; then
+  cargo build --release --quiet --manifest-path "$ROOT/crates/lane/Cargo.toml" || exit 1
+  TARGET=$(cargo metadata --no-deps --format-version 1 --manifest-path "$ROOT/crates/lane/Cargo.toml" \
+    | jq -r .target_directory)
+  BIN="$TARGET/release/lane"
+fi
+[ -x "$BIN" ] || { echo "no binary at $BIN" >&2; exit 1; }
+BIN="$(cd "$(dirname "$BIN")" && pwd)/$(basename "$BIN")"
+
+TMP=$(mktemp -d); trap 'rm -rf "$TMP"' EXIT
+
+# ---------------------------------------------------------------------------
+# Fixture: 18 files across 5 grammars, ~180 KB, 30 notes, 3 lanes. Sized to sit
+# near this repo's own shape so a win here is a win in practice.
+# ---------------------------------------------------------------------------
+build_fixture() {
+  REPO="$TMP/repo"
+  mkdir -p "$REPO/src" "$REPO/scripts" "$REPO/docs"
+  cd "$REPO" || exit 1
+  git init -qb main . && git config user.email b@b.b && git config user.name b
+
+  python3 - "$REPO" <<'PY'
+import sys, pathlib
+root = pathlib.Path(sys.argv[1])
+
+def rust(n, decls):
+    out = ["//! generated fixture module\n"]
+    for i in range(decls):
+        out.append(f"""
+pub struct Item{i} {{
+    pub id: usize,
+    pub name: String,
+}}
+
+pub fn handle_{i}(item: &Item{i}) -> usize {{
+    let mut total = item.id;
+    for step in 0..8 {{
+        total = total.wrapping_add(step * item.name.len());
+    }}
+    total
+}}
+""")
+    return "".join(out)
+
+def bash(decls):
+    out = ["#!/usr/bin/env bash\nset -euo pipefail\n"]
+    for i in range(decls):
+        out.append(f"""
+run_step_{i}() {{
+  local input="$1"
+  if [ -z "$input" ]; then return 1; fi
+  printf '%s\\n' "$input"
+}}
+""")
+    return "".join(out)
+
+def markdown(sections):
+    out = ["# Fixture\n"]
+    for i in range(sections):
+        out.append(f"\n## Section {i}\n\nProse for section {i}. " * 3 + "\n")
+    return "".join(out)
+
+def typescript(decls):
+    out = ["export type Id = string;\n"]
+    for i in range(decls):
+        out.append(f"""
+export function transform{i}(input: Id): Id {{
+  const parts = input.split('-');
+  return parts.map((p) => p.trim()).join('/');
+}}
+""")
+    return "".join(out)
+
+# Eight rust files, deliberately uneven: one big file carries most anchors, which is
+# the shape that exposes per-note work repeated over one tree.
+for i, decls in enumerate([220, 130, 90, 65, 50, 40, 30, 20]):
+    (root / "src" / f"mod_{i}.rs").write_text(rust(i, decls))
+for i, decls in enumerate([170, 70, 35]):
+    (root / "scripts" / f"task_{i}.sh").write_text(bash(decls))
+for i in range(3):
+    (root / "docs" / f"page_{i}.md").write_text(markdown(60))
+for i, decls in enumerate([110, 55]):
+    (root / "src" / f"client_{i}.ts").write_text(typescript(decls))
+(root / "Cargo.toml").write_text('[package]\nname = "fixture"\nversion = "0.1.0"\n')
+(root / "README.md").write_text(markdown(4))
+PY
+
+  git add -A && git commit -qm init >/dev/null
+  "$BIN" init >/dev/null 2>&1
+  git add -A && git commit -qm "lane init" >/dev/null
+
+  # 30 notes, weighted onto mod_0.rs so one tree carries many anchors.
+  for i in 0 1 2 3 4 5 6 7 8 9 10 11; do
+    "$BIN" note -p src/mod_0.rs -a "fn handle_$i" "fixture note about handle_$i" >/dev/null 2>&1
+  done
+  for i in 0 1 2 3 4 5; do
+    "$BIN" note -p src/mod_1.rs -a "struct Item$i" "fixture note about Item$i" >/dev/null 2>&1
+  done
+  for i in 1 2 3 4 5 6 7; do
+    "$BIN" note -p "src/mod_$i.rs" -a "fn handle_0" "entry point for module $i" >/dev/null 2>&1
+  done
+  for i in 0 1 2; do
+    "$BIN" note -p "scripts/task_$i.sh" -a "run_step_0" "first step of task $i" >/dev/null 2>&1
+  done
+  "$BIN" note -p src/client_0.ts -a "function transform0" "id shape is dash separated" >/dev/null 2>&1
+  "$BIN" note -p docs/page_0.md -a "@file" "page zero is the entry doc" >/dev/null 2>&1
+  "$BIN" audit >/dev/null 2>&1
+  git add -A && git commit -qm "notes" >/dev/null
+
+  # Three lanes, so `ls` and `sweep` have something to walk.
+  for name in alpha beta gamma; do "$BIN" new "$name" >/dev/null 2>&1; done
+
+  NOTES=$(find .lane/memory -name '*.md' 2>/dev/null | wc -l | tr -d ' ')
+  BYTES=$(find src scripts docs -type f -exec cat {} + | wc -c | tr -d ' ')
+  echo "fixture: $NOTES notes, $BYTES bytes of source, 3 lanes" >&2
+}
+
+build_fixture
+cd "$REPO" || exit 1
+
+# name|command. Read-only unless marked; `new` gets a prepare step to stay honest.
+CASES=$(cat <<CASES
+version|$BIN --version
+ls|$BIN ls
+check|$BIN check
+check-json|$BIN check --json
+why-hot|$BIN why src/mod_0.rs
+why-cold|$BIN why src/mod_7.rs
+audit|$BIN audit
+sweep|$BIN sweep --dry-run
+shellenv|$BIN shellenv
+CASES
+)
+
+RESULTS="$TMP/results.json"
+echo '{}' > "$RESULTS"
+
+run_case() {
+  local name="$1" cmd="$2" prepare="${3:-}"
+  [ -n "$FILTER" ] && [[ "$name" != *"$FILTER"* ]] && return 0
+  local json="$TMP/$name.json"
+  local args=(-N --warmup "$WARMUP" --runs "$RUNS" --style none --export-json "$json")
+  [ -n "$prepare" ] && args+=(--prepare "$prepare")
+  if ! hyperfine "${args[@]}" "$cmd" >/dev/null 2>&1; then
+    echo "  !! $name failed to run" >&2
+    return 0
+  fi
+  local mean stddev user
+  mean=$(jq -r '.results[0].mean * 1000' "$json")
+  stddev=$(jq -r '.results[0].stddev * 1000' "$json")
+  user=$(jq -r '.results[0].user * 1000' "$json")
+  jq --arg n "$name" --argjson m "$mean" --argjson s "$stddev" --argjson u "$user" \
+    '.[$n] = {mean: $m, stddev: $s, user: $u}' "$RESULTS" > "$RESULTS.tmp" && mv "$RESULTS.tmp" "$RESULTS"
+  printf '  %-12s %8.1f ms  ± %5.1f   user %6.1f ms\n' "$name" "$mean" "$stddev" "$user" >&2
+}
+
+echo "" >&2
+echo "binary: $BIN ($(stat -f%z "$BIN" 2>/dev/null || stat -c%s "$BIN") bytes)" >&2
+echo "runs:   $RUNS (warmup $WARMUP)" >&2
+echo "" >&2
+
+while IFS='|' read -r name cmd; do
+  [ -z "$name" ] && continue
+  run_case "$name" "$cmd"
+done <<< "$CASES"
+
+# `new` mutates, so each run starts from a lane that is not there yet. Under -N there is
+# no shell to chain the reset, so it lives in a file.
+cat > "$TMP/reset-lane" <<RESET
+#!/usr/bin/env bash
+rm -rf "$REPO/.lane/trees/benchlane"
+git -C "$REPO" worktree prune
+git -C "$REPO" branch -D benchlane >/dev/null 2>&1
+exit 0
+RESET
+chmod +x "$TMP/reset-lane"
+run_case "new" "$BIN new benchlane" "$TMP/reset-lane"
+
+echo "" >&2
+
+if [ -n "$OUT" ]; then
+  cp "$RESULTS" "$OUT"
+  echo "wrote $OUT" >&2
+fi
+
+if [ -n "$BASELINE" ]; then
+  echo "" >&2
+  printf '  %-12s %>10s %>10s %>9s\n' "case" "before" "after" "delta" >&2 2>/dev/null || true
+  printf '  %-12s %10s %10s %9s\n' "case" "before" "after" "delta" >&2
+  printf '  %-12s %10s %10s %9s\n' "----" "------" "-----" "-----" >&2
+  jq -r --slurpfile base "$BASELINE" '
+    . as $after
+    | $base[0] as $before
+    | ($before | keys_unsorted) as $names
+    | $names[]
+    | select($after[.] != null)
+    | [., $before[.].mean, $after[.].mean] | @tsv
+  ' "$RESULTS" | while IFS=$'\t' read -r name b a; do
+    delta=$(python3 -c "print(f'{(($a-$b)/$b*100):+.1f}%')" 2>/dev/null || echo "n/a")
+    printf '  %-12s %9.1f %9.1f %9s\n' "$name" "$b" "$a" "$delta" >&2
+  done
+  echo "" >&2
+fi

--- a/scripts/bench.sh
+++ b/scripts/bench.sh
@@ -9,6 +9,7 @@
 #   scripts/bench.sh --out before.json        record a baseline
 #   scripts/bench.sh --compare before.json    time again and print the deltas
 #   scripts/bench.sh --bin path/to/lane       time a binary built elsewhere
+#   scripts/bench.sh --fixture DIR            build the fixture there and stop, for profiling
 set -uo pipefail
 
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"
@@ -18,6 +19,7 @@ BIN=""
 OUT=""
 BASELINE=""
 FILTER=""
+FIXTURE_ONLY=""
 
 while [ $# -gt 0 ]; do
   case "$1" in
@@ -26,6 +28,7 @@ while [ $# -gt 0 ]; do
     --compare) BASELINE="$2"; shift 2 ;;
     --runs)    RUNS="$2"; shift 2 ;;
     --only)    FILTER="$2"; shift 2 ;;
+    --fixture) FIXTURE_ONLY="$2"; shift 2 ;;
     -h|--help) sed -n '2,12p' "$0" | sed 's/^# \?//'; exit 0 ;;
     *) echo "unknown flag: $1" >&2; exit 2 ;;
   esac
@@ -43,7 +46,11 @@ fi
 [ -x "$BIN" ] || { echo "no binary at $BIN" >&2; exit 1; }
 BIN="$(cd "$(dirname "$BIN")" && pwd)/$(basename "$BIN")"
 
-TMP=$(mktemp -d); trap 'rm -rf "$TMP"' EXIT
+if [ -n "$FIXTURE_ONLY" ]; then
+  TMP="$FIXTURE_ONLY"; mkdir -p "$TMP"; rm -rf "${TMP:?}/repo"
+else
+  TMP=$(mktemp -d); trap 'rm -rf "$TMP"' EXIT
+fi
 
 # ---------------------------------------------------------------------------
 # Fixture: 18 files across 5 grammars, ~180 KB, 30 notes, 3 lanes. Sized to sit
@@ -154,6 +161,11 @@ PY
 build_fixture
 cd "$REPO" || exit 1
 
+if [ -n "$FIXTURE_ONLY" ]; then
+  echo "fixture kept at $REPO" >&2
+  exit 0
+fi
+
 # name|command. Read-only unless marked; `new` gets a prepare step to stay honest.
 CASES=$(cat <<CASES
 version|$BIN --version
@@ -221,7 +233,6 @@ fi
 
 if [ -n "$BASELINE" ]; then
   echo "" >&2
-  printf '  %-12s %>10s %>10s %>9s\n' "case" "before" "after" "delta" >&2 2>/dev/null || true
   printf '  %-12s %10s %10s %9s\n' "case" "before" "after" "delta" >&2
   printf '  %-12s %10s %10s %9s\n' "----" "------" "-----" "-----" >&2
   jq -r --slurpfile base "$BASELINE" '

--- a/scripts/bench.sh
+++ b/scripts/bench.sh
@@ -10,6 +10,7 @@
 #   scripts/bench.sh --compare before.json    time again and print the deltas
 #   scripts/bench.sh --bin path/to/lane       time a binary built elsewhere
 #   scripts/bench.sh --fixture DIR            build the fixture there and stop, for profiling
+#   scripts/bench.sh --against old-lane       A/B both binaries in one run, immune to drift
 set -uo pipefail
 
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"
@@ -20,6 +21,7 @@ OUT=""
 BASELINE=""
 FILTER=""
 FIXTURE_ONLY=""
+AGAINST=""
 
 while [ $# -gt 0 ]; do
   case "$1" in
@@ -29,6 +31,7 @@ while [ $# -gt 0 ]; do
     --runs)    RUNS="$2"; shift 2 ;;
     --only)    FILTER="$2"; shift 2 ;;
     --fixture) FIXTURE_ONLY="$2"; shift 2 ;;
+    --against) AGAINST="$2"; shift 2 ;;
     -h|--help) sed -n '2,12p' "$0" | sed 's/^# \?//'; exit 0 ;;
     *) echo "unknown flag: $1" >&2; exit 2 ;;
   esac
@@ -166,22 +169,53 @@ if [ -n "$FIXTURE_ONLY" ]; then
   exit 0
 fi
 
-# name|command. Read-only unless marked; `new` gets a prepare step to stay honest.
-CASES=$(cat <<CASES
-version|$BIN --version
-ls|$BIN ls
-check|$BIN check
-check-json|$BIN check --json
-why-hot|$BIN why src/mod_0.rs
-why-cold|$BIN why src/mod_7.rs
-audit|$BIN audit
-sweep|$BIN sweep --dry-run
-shellenv|$BIN shellenv
+# name|args. Read-only unless marked; `new` gets a prepare step to stay honest.
+CASES=$(cat <<'CASES'
+version|--version
+ls|ls
+check|check
+check-json|check --json
+why-hot|why src/mod_0.rs
+why-cold|why src/mod_7.rs
+audit|audit
+sweep|sweep --dry-run
+shellenv|shellenv
 CASES
 )
 
+# `new` mutates, so each run starts from a lane that is not there yet. Under -N there is
+# no shell to chain the reset, so it lives in a file.
+cat > "$TMP/reset-lane" <<RESET
+#!/usr/bin/env bash
+rm -rf "$REPO/.lane/trees/benchlane"
+git -C "$REPO" worktree prune
+git -C "$REPO" branch -D benchlane >/dev/null 2>&1
+exit 0
+RESET
+chmod +x "$TMP/reset-lane"
+
 RESULTS="$TMP/results.json"
 echo '{}' > "$RESULTS"
+
+# A quiet machine is not a given. --against times both binaries inside ONE hyperfine
+# invocation per case, so load that drifts between runs hits both sides equally; the
+# earlier --compare reads a file recorded minutes ago and cannot do that.
+run_ab() {
+  local name="$1" args="$2" prepare="${3:-}"
+  [ -n "$FILTER" ] && [[ "$name" != *"$FILTER"* ]] && return 0
+  local json="$TMP/ab-$name.json"
+  local hf=(-N --warmup "$WARMUP" --runs "$RUNS" --style none --export-json "$json")
+  [ -n "$prepare" ] && hf+=(--prepare "$prepare")
+  if ! hyperfine "${hf[@]}" "$AGAINST $args" "$BIN $args" >/dev/null 2>&1; then
+    echo "  !! $name failed to run" >&2
+    return 0
+  fi
+  local before after delta
+  before=$(jq -r '.results[0].mean * 1000' "$json")
+  after=$(jq -r '.results[1].mean * 1000' "$json")
+  delta=$(python3 -c "print(f'{(($after-$before)/$before*100):+.1f}%')")
+  printf '  %-12s %9.1f %9.1f %9s\n' "$name" "$before" "$after" "$delta" >&2
+}
 
 run_case() {
   local name="$1" cmd="$2" prepare="${3:-}"
@@ -207,21 +241,23 @@ echo "binary: $BIN ($(stat -f%z "$BIN" 2>/dev/null || stat -c%s "$BIN") bytes)" 
 echo "runs:   $RUNS (warmup $WARMUP)" >&2
 echo "" >&2
 
-while IFS='|' read -r name cmd; do
+if [ -n "$AGAINST" ]; then
+  printf '  %-12s %9s %9s %9s\n' "case" "before" "after" "delta" >&2
+  printf '  %-12s %9s %9s %9s\n' "----" "------" "-----" "-----" >&2
+  while IFS='|' read -r name args; do
+    [ -z "$name" ] && continue
+    run_ab "$name" "$args"
+  done <<< "$CASES"
+  run_ab "new" "new benchlane" "$TMP/reset-lane"
+  echo "" >&2
+  exit 0
+fi
+
+while IFS='|' read -r name args; do
   [ -z "$name" ] && continue
-  run_case "$name" "$cmd"
+  run_case "$name" "$BIN $args"
 done <<< "$CASES"
 
-# `new` mutates, so each run starts from a lane that is not there yet. Under -N there is
-# no shell to chain the reset, so it lives in a file.
-cat > "$TMP/reset-lane" <<RESET
-#!/usr/bin/env bash
-rm -rf "$REPO/.lane/trees/benchlane"
-git -C "$REPO" worktree prune
-git -C "$REPO" branch -D benchlane >/dev/null 2>&1
-exit 0
-RESET
-chmod +x "$TMP/reset-lane"
 run_case "new" "$BIN new benchlane" "$TMP/reset-lane"
 
 echo "" >&2


### PR DESCRIPTION
Cuts `ls` by 65%, `audit` and `sweep` by half, and `check` by a third — by spawning git less, and by scanning each file once instead of once per note. Prepared with `lane done --no-merge`.

## What was actually slow

`/usr/bin/git` costs **~20 ms just to reach `main()`** on macOS. `git --version`, with no repository and no work, measures 20.4 ms. So the number that moved wall time here was the *count* of subprocesses, not what any of them asked for.

`lane ls` was 4 fixed spawns plus 3 per lane. Two of those three per-lane spawns — `rev-parse --git-path lane/id` and `lane/pending.jsonl` — were pure path arithmetic against a common dir the first spawn had already fetched.

| command | spawns before | after |
|---|---:|---:|
| `ls` | 13 | 6 |
| `sweep` | 9 | 4 |
| `audit` | 5 | 1 |
| `check` | 1 | 0 |

## Results

Both binaries timed inside a single `hyperfine` invocation, so machine drift hits both sides equally:

| case | before | after | delta |
|---|---:|---:|---:|
| **ls** | 295.6 ms | 102.6 ms | **−65.3%** |
| **why-cold** | 34.4 | 11.7 | **−66.2%** |
| **audit** | 202.4 | 99.8 | **−50.7%** |
| **sweep** | 191.0 | 94.4 | **−50.6%** |
| check | 117.6 | 75.1 | −36.2% |
| why-hot | 60.9 | 39.7 | −34.7% |
| check-json | 116.0 | 76.7 | −33.9% |
| new | 263.0 | 211.1 | −19.7% |

`version` and `shellenv` sit at ~5 ms and bounce ±30% between runs. They do no repository work, so that is their noise floor, not a result.

## The four commits that change behaviour

**`perf(git): resolve layout on disk`** — one resolver for `git_dir`, `common_dir`, `repo_root` and `main_root`, read from `.git`, the `gitdir:` pointer and `commondir`. Five call sites stop shelling out.

Two `--git-path` calls deliberately stay subprocesses: `info/exclude`, because `info/` is on git's shared-path list, and `hooks`, because git honours `core.hooksPath`. Path arithmetic would be wrong for both, and neither is hot.

`repo_root()` and `main_root()` differ inside a lane, and this repo has shipped a bug conflating them before, so there is a test asserting they differ.

**`perf(syntax): index lines once`** — every span lookup rescanned the file from byte zero, and `hashes` does one per note, so a 31-note repo paid for that scan 31 times. A line-start index answers by subscript. Declaration queries also compiled once per *file* rather than once per *grammar*; eight rust files compiled the identical query eight times.

**`perf(ls): overlap the status calls`** — the per-lane `git status` probes are independent and read-only, so they run together and join in lane order. `trunk_name` is memoized per root (`sweep` asked twice), the landing lock takes its directory from the resolver, and `new` drops a `worktree add -h` probe that spawned git purely to grep its help text, retrying without `--relative-paths` only when git says it does not know the option.

## The invariant this could have broken

`span_text` feeds the `sig`/`body_hash`/`raw_hash` fingerprints every stored note compares against. A one-byte shift — a newline included or dropped — would silently mark **every note in every user's repo** as drifted.

So the line index is tested against a verbatim copy of the old scan (`legacy_span_text`) over CRLF, multi-byte UTF-8, and out-of-range and inverted spans, rather than against fresh expectations that would encode the change's own blind spot.

End to end: `lane check --json` over the benchmark fixture is **byte-identical** to a binary built before any of these commits. `lane ls` output is byte-identical after parallelising.

## The benchmark is part of the change

`scripts/bench.sh` builds its own repository — 224 KB across five grammars, 31 notes, 3 lanes — rather than timing this one, whose note count and file sizes drift with every commit. Notes are weighted onto a single file on purpose: that is the shape that exposes work repeated per note over one parsed tree.

```
scripts/bench.sh --out before.json     record a baseline
scripts/bench.sh --against ./old-lane  A/B both binaries in one run
scripts/bench.sh --fixture DIR         keep the repo, for a profiler or a spawn counter
```

`--against` exists because `--compare` reads a file recorded minutes earlier. Under load that reads as a code regression: one run reported `check` and `why` 6–15% slower when neither had changed, and reported the same for `--version`, which does no repository work at all. Timing both binaries in one invocation removes the question.

## Test plan

- [x] `cargo test` — 123 pass (was 114; 9 new)
- [x] `./test_lane.sh` — 150 assertions pass
- [x] `cargo clippy --all-targets -- -D warnings` and `cargo fmt --check` — clean
- [x] `check --json` byte-identical to a pre-change binary over the fixture
- [x] `ls` output byte-identical after parallelising
- [x] Spawn counts confirmed with a counting shim on `PATH`
- [ ] Decide whether `ls` should cap its thread count; it currently spawns one per lane, which is fine at today's scale and unbounded in principle

## Not done, on purpose

`opt-level` stays at 3. `"s"` would take another 528 KB off the binary for ~7% more CPU on `lane check`, and `"z"` 870 KB for +35% wall — the tree-sitter grammars are both most of the binary and the hot path, so size and speed trade directly.
