### PR TITLE
Fix duplicate names in lane ls

### DIFF
--- a/.lane/log.jsonl
+++ b/.lane/log.jsonl
@@ -32,3 +32,4 @@
 {"anchor":"fn acquire","at":"2026-08-24T19:42:51Z","body_hash":"bac6a3e1e712e18d","branch":"perf-audit","id":"01M0G14CMHEQQ05FRZT0PZA5EG","kind":"holds","norm":"1","path":"crates/lane/src/cli.rs","raw_hash":"e484b52dcbe99ef9","sig":"0bff83f9aaa042a1"}
 {"anchor":"fn create","at":"2026-08-24T19:42:51Z","body_hash":"bfc1cf40b1329b34","branch":"perf-audit","id":"01M0EXNVCK4JP9328P47M4W2C1","kind":"holds","norm":"1","path":"crates/lane/src/worktree.rs","raw_hash":"00e7afe49321a755","sig":"2a21aaf08379e25a"}
 {"anchor":"@file","at":"2026-08-24T19:42:51Z","body_hash":"87beb9cf647e7c1b","branch":"perf-audit","id":"01M0ESRPDGANMXC60YCD3VYVS5","kind":"holds","norm":"1","path":"test_lane.sh","raw_hash":"a9e6a05f50ff68bb","sig":"e3b0c44298fc1c14"}
+{"at":"2026-08-24T19:55:20Z","branch":"fix-ls-duplicate-names","kind":"landing","lane":"01M0TNA3B11GDP1T6AXQRGXQQE"}

--- a/.lane/log.jsonl
+++ b/.lane/log.jsonl
@@ -33,3 +33,4 @@
 {"anchor":"fn create","at":"2026-08-24T19:42:51Z","body_hash":"bfc1cf40b1329b34","branch":"perf-audit","id":"01M0EXNVCK4JP9328P47M4W2C1","kind":"holds","norm":"1","path":"crates/lane/src/worktree.rs","raw_hash":"00e7afe49321a755","sig":"2a21aaf08379e25a"}
 {"anchor":"@file","at":"2026-08-24T19:42:51Z","body_hash":"87beb9cf647e7c1b","branch":"perf-audit","id":"01M0ESRPDGANMXC60YCD3VYVS5","kind":"holds","norm":"1","path":"test_lane.sh","raw_hash":"a9e6a05f50ff68bb","sig":"e3b0c44298fc1c14"}
 {"at":"2026-08-24T19:55:20Z","branch":"fix-ls-duplicate-names","kind":"landing","lane":"01M0TNA3B11GDP1T6AXQRGXQQE"}
+{"at":"2026-08-24T20:02:30Z","branch":"fix-ls-duplicate-names","kind":"landing","lane":"01M0TNMTEVJ94A054C6Y8ESVPZ"}

--- a/.lane/memory/crates/lane/src/cli.rs/01M0TNEY0TKC1RY8396A3NB47X-the-worktree-basename-is-the.md
+++ b/.lane/memory/crates/lane/src/cli.rs/01M0TNEY0TKC1RY8396A3NB47X-the-worktree-basename-is-the.md
@@ -1,0 +1,13 @@
+---
+id: 01M0TNEY0TKC1RY8396A3NB47X
+anchor: fn ls
+created: 2026-08-24T19:55:15Z
+branch: fix-ls-duplicate-names
+norm: '1'
+sig: 5a116c9621df3b1f
+body_hash: 01dc76460178eb2b
+raw_hash: 8e734990c84bb70f
+lines: 538-570
+---
+
+the worktree basename is the lane's display identity; its normally identical branch belongs to lifecycle checks, not a second output column

--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ marks it `landed` once trunk carries its landing record, and `lane sweep` remove
 
 ```
 $ lane ls
-fix-login    fix-login    landed   clean   0 pending note(s)
+fix-login    landed   clean   0 pending note(s)
 $ lane sweep
 removed fix-login
 ```

--- a/crates/lane/src/cli.rs
+++ b/crates/lane/src/cli.rs
@@ -563,8 +563,7 @@ fn ls() -> Result<i32> {
             "open"
         };
         println!(
-            "{name:<20} {:<24} {state:<7} {dirty:<6} {} pending note(s)",
-            lane.branch,
+            "{name:<20} {state:<7} {dirty:<6} {} pending note(s)",
             store::pending_count(&lane.path)
         );
     }

--- a/crates/lane/src/help.rs
+++ b/crates/lane/src/help.rs
@@ -178,8 +178,8 @@ const NEW: &str = "
 
 const LS: &str = "
   Description
-    Every lane's name, the branch it carries, whether it is clean, and how
-    many notes it has yet to land.
+    Every lane's name, whether it has landed, whether it is clean, and how many
+    notes it has yet to land.
 
   Usage
     $ lane ls

--- a/test_lane.sh
+++ b/test_lane.sh
@@ -50,6 +50,8 @@ is "warm dir present in lane iff reflink" \
    "$([ -f "$LP/node_modules/pkg/blob.bin" ] && echo yes || echo no)" "$(want)"
 is "tracked file present" "$([ -f "$LP/src/auth.rs" ] && echo yes)" "yes"
 is "lane status clean" "$(git -C "$LP" status --porcelain | wc -l | tr -d ' ')" "0"
+is "ls prints the lane name once" \
+   "$("$LANE" ls | awk '$1 == "fix-login" && $2 == "open" && $3 == "clean" && $4 == "0" { n++ } END { print n + 0 }')" "1"
 is "reflink verdict reported" "$(grep -c 'reflink:' /tmp/new.out)" "1"
 is "tracked files not re-cloned" \
    "$(grep -o 'cloned' /tmp/new.out | head -1)" "cloned"

--- a/www/src/data/commands.ts
+++ b/www/src/data/commands.ts
@@ -48,9 +48,9 @@ export let commands: Command[] = [
 	{
 		name: "ls",
 		usage: "lane ls",
-		summary: "lists every lane with its branch, whether it has landed, dirty state, and pending note count.",
+		summary: "lists every lane's landing state, dirty state, and pending note count.",
 		options: [],
-		example: "$ lane ls\nagent-a    agent-a    open     clean   3 pending note(s)\nagent-b    agent-b    landed   dirty   1 pending note(s)",
+		example: "$ lane ls\nagent-a    open     clean   3 pending note(s)\nagent-b    landed   dirty   1 pending note(s)",
 	},
 	{
 		name: "path",

--- a/www/src/pages/usage.md
+++ b/www/src/pages/usage.md
@@ -287,8 +287,8 @@ Run several agents at once:
 ```bash
 $ lane new agent-a && lane new agent-b && lane new agent-c
 $ lane ls
-  agent-a    agent-a    open     clean   3 pending note(s)
-  agent-b    agent-b    landed   dirty   1 pending note(s)
+  agent-a    open     clean   3 pending note(s)
+  agent-b    landed   dirty   1 pending note(s)
 ```
 
 Each has its own warm build cache at no disk cost. They can annotate the same
@@ -307,7 +307,7 @@ The short version. See [commands](/commands) for full information.
 |---|---|
 | `lane init` | scaffold, probe reflink |
 | `lane new <name> [--dirty] [--base <ref>]` | create a lane |
-| `lane ls` | lanes, branch, whether they landed, dirt, pending notes |
+| `lane ls` | lanes, whether they landed, dirt, pending notes |
 | `lane path <name>` | print a lane's path |
 | `lane note -p <file> -a <anchor> [--supersedes <id>] "<text>"` | record or replace a finding |
 | `lane install skill|hooks` | install the agent skill, or the commit decision capture hooks |


### PR DESCRIPTION
## Summary

- remove the redundant branch column from `lane ls` output
- update CLI and website documentation examples
- add an end-to-end regression assertion

## Verification

- `cargo test --manifest-path crates/lane/Cargo.toml`
- `./test_lane.sh` (151 passed)