### PR TITLE
fix(rm): guard what is lost

### DIFF
--- a/.lane/log.jsonl
+++ b/.lane/log.jsonl
@@ -35,3 +35,4 @@
 {"at":"2026-08-24T19:55:20Z","branch":"fix-ls-duplicate-names","kind":"landing","lane":"01M0TNA3B11GDP1T6AXQRGXQQE"}
 {"at":"2026-08-24T20:02:30Z","branch":"fix-ls-duplicate-names","kind":"landing","lane":"01M0TNMTEVJ94A054C6Y8ESVPZ"}
 {"at":"2026-08-24T20:12:00Z","branch":"rm-recovery","kind":"landing","lane":"01M0TN60MHQQ2VMY8BF0C0SRGR"}
+{"anchor":"@file","at":"2026-08-24T20:12:18Z","body_hash":"a05fa33c88d8a2f9","branch":"rm-recovery","id":"01M0ESRPDGANMXC60YCD3VYVS5","kind":"holds","norm":"1","path":"test_lane.sh","raw_hash":"3868fbe078bd2906","sig":"e3b0c44298fc1c14"}

--- a/.lane/log.jsonl
+++ b/.lane/log.jsonl
@@ -34,3 +34,4 @@
 {"anchor":"@file","at":"2026-08-24T19:42:51Z","body_hash":"87beb9cf647e7c1b","branch":"perf-audit","id":"01M0ESRPDGANMXC60YCD3VYVS5","kind":"holds","norm":"1","path":"test_lane.sh","raw_hash":"a9e6a05f50ff68bb","sig":"e3b0c44298fc1c14"}
 {"at":"2026-08-24T19:55:20Z","branch":"fix-ls-duplicate-names","kind":"landing","lane":"01M0TNA3B11GDP1T6AXQRGXQQE"}
 {"at":"2026-08-24T20:02:30Z","branch":"fix-ls-duplicate-names","kind":"landing","lane":"01M0TNMTEVJ94A054C6Y8ESVPZ"}
+{"at":"2026-08-24T20:12:00Z","branch":"rm-recovery","kind":"landing","lane":"01M0TN60MHQQ2VMY8BF0C0SRGR"}

--- a/.lane/log.jsonl
+++ b/.lane/log.jsonl
@@ -37,3 +37,4 @@
 {"at":"2026-08-24T20:12:00Z","branch":"rm-recovery","kind":"landing","lane":"01M0TN60MHQQ2VMY8BF0C0SRGR"}
 {"anchor":"@file","at":"2026-08-24T20:12:18Z","body_hash":"a05fa33c88d8a2f9","branch":"rm-recovery","id":"01M0ESRPDGANMXC60YCD3VYVS5","kind":"holds","norm":"1","path":"test_lane.sh","raw_hash":"3868fbe078bd2906","sig":"e3b0c44298fc1c14"}
 {"anchor":"@file","at":"2026-08-24T20:15:14Z","body_hash":"38059e5f8380d98f","branch":"rm-recovery","id":"01M0ESRPDGANMXC60YCD3VYVS5","kind":"holds","norm":"1","path":"test_lane.sh","raw_hash":"47d9ae805256e65c","sig":"e3b0c44298fc1c14"}
+{"anchor":"@file","at":"2026-08-24T20:19:56Z","body_hash":"d3c8284476d947c8","branch":"rm-recovery","id":"01M0ESRPDGANMXC60YCD3VYVS5","kind":"holds","norm":"1","path":"test_lane.sh","raw_hash":"363754b43c93b55b","sig":"e3b0c44298fc1c14"}

--- a/.lane/log.jsonl
+++ b/.lane/log.jsonl
@@ -36,3 +36,4 @@
 {"at":"2026-08-24T20:02:30Z","branch":"fix-ls-duplicate-names","kind":"landing","lane":"01M0TNMTEVJ94A054C6Y8ESVPZ"}
 {"at":"2026-08-24T20:12:00Z","branch":"rm-recovery","kind":"landing","lane":"01M0TN60MHQQ2VMY8BF0C0SRGR"}
 {"anchor":"@file","at":"2026-08-24T20:12:18Z","body_hash":"a05fa33c88d8a2f9","branch":"rm-recovery","id":"01M0ESRPDGANMXC60YCD3VYVS5","kind":"holds","norm":"1","path":"test_lane.sh","raw_hash":"3868fbe078bd2906","sig":"e3b0c44298fc1c14"}
+{"anchor":"@file","at":"2026-08-24T20:15:14Z","body_hash":"38059e5f8380d98f","branch":"rm-recovery","id":"01M0ESRPDGANMXC60YCD3VYVS5","kind":"holds","norm":"1","path":"test_lane.sh","raw_hash":"47d9ae805256e65c","sig":"e3b0c44298fc1c14"}

--- a/.lane/memory/crates/lane/src/worktree.rs/01M0TPDF4R5AMSTHCAZHY6VVTC-a-refused-rm-still-drops-the.md
+++ b/.lane/memory/crates/lane/src/worktree.rs/01M0TPDF4R5AMSTHCAZHY6VVTC-a-refused-rm-still-drops-the.md
@@ -1,0 +1,13 @@
+---
+id: 01M0TPDF4R5AMSTHCAZHY6VVTC
+anchor: fn remove
+created: 2026-08-24T19:56:19Z
+branch: rm-recovery
+norm: '1'
+sig: b349364829890348
+body_hash: cb9d736df47d72cd
+raw_hash: b164243973aa4734
+lines: 413-449
+---
+
+a refused rm still drops the worktree, so the --force it offers arrives with only the branch left to delete

--- a/.lane/memory/crates/lane/src/worktree.rs/01M0TPDF4YJSDFA0PDEF8QZR90-a-refusal-that-already-dropp.md
+++ b/.lane/memory/crates/lane/src/worktree.rs/01M0TPDF4YJSDFA0PDEF8QZR90-a-refusal-that-already-dropp.md
@@ -1,0 +1,13 @@
+---
+id: 01M0TPDF4YJSDFA0PDEF8QZR90
+anchor: fn losses
+created: 2026-08-24T20:11:57Z
+branch: rm-recovery
+norm: '1'
+sig: 22381cb7e3c03d76
+body_hash: a775ac5aa9f325e0
+raw_hash: e863b31996b45c61
+lines: 383-408
+---
+
+a refusal that already dropped the worktree offers to save work it has destroyed, so every check has to run before the first removal

--- a/crates/lane/src/cli.rs
+++ b/crates/lane/src/cli.rs
@@ -983,8 +983,8 @@ fn rm(name: &str, force: bool) -> Result<i32> {
     }
     let trunk = wt::trunk_name(&wt::main_root()?);
     eprintln!("removed lane {name}; kept branch {name}, it has commits {trunk} does not");
-    eprintln!("  git worktree add <path> {name}   to get back to them");
-    eprintln!("  lane rm {name} --force            to discard them");
+    eprintln!("  lane new {name}          to open a lane on it again");
+    eprintln!("  lane rm {name} --force   to discard them");
     Ok(1)
 }
 

--- a/crates/lane/src/cli.rs
+++ b/crates/lane/src/cli.rs
@@ -600,15 +600,11 @@ fn sweep(dry_run: bool) -> Result<i32> {
             .file_name()
             .map(|n| n.to_string_lossy().to_string())
             .unwrap_or_default();
-        if wt::is_dirty(&lane.path) {
-            eprintln!("skipped {name}: uncommitted changes");
-            skipped += 1;
-            continue;
-        }
-        // Checked before anything is removed: `wt::remove` drops the worktree even when it
-        // keeps the branch, so a late refusal would already have thrown the work away.
-        if !wt::contained_in(&root, &trunk, &lane.branch) {
-            eprintln!("skipped {name}: has work {trunk} does not");
+        // A landing marker says the work reached trunk, not that the lane kept nothing
+        // back: notes written after it, or an edit never committed, are still only here.
+        let losses = wt::losses(&root, &lane.path, &lane.branch, &trunk);
+        if !losses.is_empty() {
+            eprintln!("skipped {name}: {}", losses.join(", "));
             skipped += 1;
             continue;
         }
@@ -617,9 +613,7 @@ fn sweep(dry_run: bool) -> Result<i32> {
             removed += 1;
             continue;
         }
-        // Forced, and only here: the landing marker plus the containment probe are stronger
-        // evidence than `git branch -d`, which refuses every squash and rebase merge.
-        wt::remove(&name, true)?;
+        wt::remove(&name)?;
         println!("removed {name}");
         removed += 1;
     }
@@ -967,7 +961,7 @@ fn done(
             .file_name()
             .map(|n| n.to_string_lossy().to_string())
             .unwrap_or_default();
-        wt::remove(&name, true)?;
+        wt::remove(&name)?;
         writeln!(info, "removed lane {branch}")?;
     }
     if cd {
@@ -977,15 +971,20 @@ fn done(
 }
 
 fn rm(name: &str, force: bool) -> Result<i32> {
-    if wt::remove(name, force)? {
-        println!("removed lane {name}");
-        return Ok(0);
+    let root = wt::main_root()?;
+    if !force {
+        let trunk = wt::trunk_name(&root);
+        let path = wt::lanes_dir(&root).join(name);
+        let losses = wt::losses(&root, &path, name, &trunk);
+        if !losses.is_empty() {
+            eprintln!("kept lane {name}: {}", losses.join(", "));
+            eprintln!("  lane rm {name} --force   to discard it anyway");
+            return Ok(1);
+        }
     }
-    let trunk = wt::trunk_name(&wt::main_root()?);
-    eprintln!("removed lane {name}; kept branch {name}, it has commits {trunk} does not");
-    eprintln!("  lane new {name}          to open a lane on it again");
-    eprintln!("  lane rm {name} --force   to discard them");
-    Ok(1)
+    wt::remove(name)?;
+    println!("removed lane {name}");
+    Ok(0)
 }
 
 fn shellenv() -> Result<i32> {

--- a/crates/lane/src/help.rs
+++ b/crates/lane/src/help.rs
@@ -344,15 +344,16 @@ const SWEEP: &str = "
 
 const RM: &str = "
   Description
-    Discard a lane without landing it, with its per-branch state and record.
-    The worktree always goes. A branch holding commits the trunk does not have
-    is kept unless --force, and `lane new <name>` opens a lane on it again.
+    Discard a lane and everything it still holds: the worktree, the branch,
+    the pending notes, the per-branch state. Anything that would be lost with
+    it stops the removal and is named instead. A squash or rebase merge counts
+    as landed, where `git branch -d` refuses it.
 
   Usage
     $ lane rm <name> [options]
 
   Options
-    --force       Discard commits the trunk does not have
+    --force       Discard it anyway
     -h, --help    Display this message
 ";
 

--- a/crates/lane/src/help.rs
+++ b/crates/lane/src/help.rs
@@ -345,7 +345,8 @@ const SWEEP: &str = "
 const RM: &str = "
   Description
     Discard a lane without landing it, with its per-branch state and record.
-    Commits the trunk does not have are refused unless --force.
+    The worktree always goes. A branch holding commits the trunk does not have
+    is kept unless --force, and `lane new <name>` opens a lane on it again.
 
   Usage
     $ lane rm <name> [options]

--- a/crates/lane/src/worktree.rs
+++ b/crates/lane/src/worktree.rs
@@ -386,11 +386,41 @@ fn registered(root: &Path, dest: &Path) -> bool {
     })
 }
 
-/// Remove a lane's worktree, and its branch when that is safe. True if the branch went too.
+/// What removing this lane destroys for good. Empty means nothing is at stake.
 ///
-/// `-d` not `-D`: an unlanded lane holds the only reference to its commits, so discarding
-/// them is asked for, never a side effect. `done` passes force after fast-forwarding trunk.
-pub fn remove(name: &str, force: bool) -> Result<bool> {
+/// Every caller of `remove` asks this first. `git branch -d` is the weaker question: it
+/// refuses every squash and rebase merge, and knows nothing about the memory a lane holds.
+pub fn losses(root: &Path, path: &Path, branch: &str, trunk: &str) -> Vec<String> {
+    let mut out = Vec::new();
+    if path.is_dir() {
+        // Untracked counts here where it does not for a rebase: removal deletes the file.
+        let changed = try_git(&["status", "--porcelain"], Some(path))
+            .lines()
+            .filter(|line| !line.trim().is_empty())
+            .count();
+        if changed > 0 {
+            out.push(format!("{changed} uncommitted change(s)"));
+        }
+        let pending = crate::store::pending_count(path);
+        if pending > 0 {
+            out.push(format!("{pending} pending note(s)"));
+        }
+    }
+    let refname = format!("refs/heads/{branch}");
+    if git_ok(&["rev-parse", "--verify", "--quiet", &refname], Some(root))
+        && !contained_in(root, trunk, branch)
+    {
+        // No count: a squash merge leaves commits whose patches landed inside one of
+        // trunk's, so `rev-list` would name a number larger than what is really at risk.
+        out.push(format!("commits {trunk} does not have"));
+    }
+    out
+}
+
+/// Remove a lane's worktree and its branch, and with them everything the lane still held.
+///
+/// Unconditional by design: `losses` is the guard, and every caller runs it first.
+pub fn remove(name: &str) -> Result<()> {
     let root = main_root()?;
     let dest = lanes_dir(&root).join(name);
 
@@ -413,29 +443,19 @@ pub fn remove(name: &str, force: bool) -> Result<bool> {
         bail!("no lane {name}");
     }
 
-    // The refusal keeps the branch but still drops the worktree, so the `--force` it asks
-    // for arrives with nothing left to remove, and git calls an absent worktree fatal.
+    // A hand-deleted lane leaves a branch and no worktree, and git calls removing an
+    // absent one fatal. Skipping is what lets `rm` clean up after that.
     if worktree {
         let dest_str = dest.to_string_lossy().to_string();
-        let mut args = vec!["worktree", "remove"];
-        if force {
-            args.push("--force");
-        }
-        args.push(&dest_str);
-        git(&args, Some(&root))?;
+        git(&["worktree", "remove", "--force", &dest_str], Some(&root))?;
     }
-
-    let mut deleted = true;
     if branch {
-        deleted = git_ok(
-            &["branch", if force { "-D" } else { "-d" }, name],
-            Some(&root),
-        );
+        git(&["branch", "-D", name], Some(&root))?;
     }
     if dest.exists() {
         let _ = std::fs::remove_dir_all(&dest);
     }
-    Ok(deleted)
+    Ok(())
 }
 
 fn tracked_changes(status: &str) -> Vec<String> {

--- a/crates/lane/src/worktree.rs
+++ b/crates/lane/src/worktree.rs
@@ -378,6 +378,14 @@ pub fn create(name: &str, base: Option<&str>, dirty: bool) -> Result<Created> {
     })
 }
 
+/// True while git still has a worktree registered at this path, prunable ones included.
+fn registered(root: &Path, dest: &Path) -> bool {
+    let target = dest.canonicalize().ok();
+    list_lanes(root).iter().any(|lane| {
+        lane.path == dest || (target.is_some() && lane.path.canonicalize().ok() == target)
+    })
+}
+
 /// Remove a lane's worktree, and its branch when that is safe. True if the branch went too.
 ///
 /// `-d` not `-D`: an unlanded lane holds the only reference to its commits, so discarding
@@ -398,18 +406,27 @@ pub fn remove(name: &str, force: bool) -> Result<bool> {
         bail!("cannot remove lane {name} from inside it; cd out first");
     }
 
-    let dest_str = dest.to_string_lossy().to_string();
-
-    let mut args = vec!["worktree", "remove"];
-    if force {
-        args.push("--force");
-    }
-    args.push(&dest_str);
-    git(&args, Some(&root))?;
-
     let refname = format!("refs/heads/{name}");
+    let branch = git_ok(&["rev-parse", "--verify", "--quiet", &refname], Some(&root));
+    let worktree = registered(&root, &dest);
+    if !branch && !worktree {
+        bail!("no lane {name}");
+    }
+
+    // The refusal keeps the branch but still drops the worktree, so the `--force` it asks
+    // for arrives with nothing left to remove, and git calls an absent worktree fatal.
+    if worktree {
+        let dest_str = dest.to_string_lossy().to_string();
+        let mut args = vec!["worktree", "remove"];
+        if force {
+            args.push("--force");
+        }
+        args.push(&dest_str);
+        git(&args, Some(&root))?;
+    }
+
     let mut deleted = true;
-    if git_ok(&["rev-parse", "--verify", "--quiet", &refname], Some(&root)) {
+    if branch {
         deleted = git_ok(
             &["branch", if force { "-D" } else { "-d" }, name],
             Some(&root),

--- a/crates/lane/src/worktree.rs
+++ b/crates/lane/src/worktree.rs
@@ -524,6 +524,12 @@ pub fn contained_in(root: &Path, trunk: &str, branch: &str) -> bool {
     if git_ok(&["merge-base", "--is-ancestor", branch, trunk], Some(root)) {
         return true;
     }
+    // A rebase merge replays the commits one for one, so their patches land separately.
+    // The collapsed probe below is the squash answer and matches none of them.
+    let replayed = try_git(&["cherry", trunk, branch], Some(root));
+    if !replayed.is_empty() && replayed.lines().all(|line| line.starts_with('-')) {
+        return true;
+    }
     let Ok(base) = git(&["merge-base", trunk, branch], Some(root)) else {
         return false;
     };

--- a/test_lane.sh
+++ b/test_lane.sh
@@ -134,46 +134,79 @@ sedi 's|pub fn refresh|pub fn rotate_token|' src/auth.rs
 "$LANE" audit > /dev/null
 is "evicted to attic" "$(find .lane/attic -name '*.md' 2>/dev/null | wc -l | tr -d ' ')" "1"
 
-echo "== 11. rm will not discard commits trunk does not have =="
+echo "== 11. rm refuses before it destroys, and --force means everything =="
 setup
 "$LANE" new scrap > /dev/null 2>&1
 ( cd "$TMP/repo/.lane/trees/scrap" && echo "fn work() {}" > src/work.rs \
   && git add -A && git commit -qm "unlanded work" > /dev/null )
 SHA=$(git rev-parse scrap)
 "$LANE" rm scrap > /tmp/rm.out 2>&1
-is "rm exits non-zero when it kept a branch" "$?" "1"
-is "rm says the branch was kept" "$(grep -c 'kept branch scrap' /tmp/rm.out)" "1"
+is "rm exits non-zero when it kept the lane" "$?" "1"
+is "rm names the commits at stake" \
+   "$(grep -c 'kept lane scrap: commits main does not have' /tmp/rm.out)" "1"
+is "rm names the way through" "$(grep -c 'lane rm scrap --force' /tmp/rm.out)" "1"
 is "unlanded branch survives" "$(git branch --list scrap | wc -l | tr -d ' ')" "1"
 is "unlanded commit still reachable" "$(git rev-parse scrap)" "$SHA"
-is "worktree is gone either way" \
-   "$([ -d "$TMP/repo/.lane/trees/scrap" ] && echo yes || echo no)" "no"
-is "rm names the command that reopens the lane" "$(grep -c 'lane new scrap' /tmp/rm.out)" "1"
-
-# The refusal already took the worktree, so the --force it offered has only a branch left.
-"$LANE" new scrap > /dev/null 2>&1
-is "the offered lane new adopts the kept branch" "$(git rev-parse scrap)" "$SHA"
-is "and carries the unlanded work" \
+# The refusal is the whole point: a --force offered after the worktree already went
+# would be offering to recover work that is not there any more.
+is "the refused lane is still on disk" \
    "$([ -f "$TMP/repo/.lane/trees/scrap/src/work.rs" ] && echo yes || echo no)" "yes"
-"$LANE" rm scrap > /dev/null 2>&1
 "$LANE" rm scrap --force > /tmp/force.out 2>&1
-is "the offered --force exits zero with no worktree left" "$?" "0"
-is "the offered --force discards the branch" "$(git branch --list scrap | wc -l | tr -d ' ')" "0"
-is "the offered --force reports no git error" "$(grep -c 'not a working tree' /tmp/force.out)" "0"
+is "--force exits zero" "$?" "0"
+is "--force discards the branch" "$(git branch --list scrap | wc -l | tr -d ' ')" "0"
+is "--force discards the worktree" \
+   "$([ -d "$TMP/repo/.lane/trees/scrap" ] && echo yes || echo no)" "no"
+
+# Memory is the thing a lane holds that no branch can give back.
+"$LANE" new notes > /dev/null 2>&1
+( cd "$TMP/repo/.lane/trees/notes" \
+  && "$LANE" note -p src/auth.rs -a "fn verify" "only in the lane" > /dev/null )
+"$LANE" rm notes > /tmp/notes.out 2>&1
+is "rm counts pending notes as loss" \
+   "$(grep -c 'kept lane notes: 1 pending note(s)' /tmp/notes.out)" "1"
+is "the lane with notes survives" \
+   "$([ -d "$TMP/repo/.lane/trees/notes" ] && echo yes || echo no)" "yes"
+"$LANE" rm notes --force > /dev/null 2>&1
+is "--force discards the notes with it" \
+   "$([ -d "$TMP/repo/.lane/trees/notes" ] && echo yes || echo no)" "no"
+
+"$LANE" new edited > /dev/null 2>&1
+echo "// scratch" >> "$TMP/repo/.lane/trees/edited/src/auth.rs"
+"$LANE" rm edited > /tmp/edited.out 2>&1
+is "rm counts uncommitted work as loss" \
+   "$(grep -c 'kept lane edited: 1 uncommitted change(s)' /tmp/edited.out)" "1"
+"$LANE" rm edited --force > /dev/null 2>&1
+is "--force takes the edit too" \
+   "$([ -d "$TMP/repo/.lane/trees/edited" ] && echo yes || echo no)" "no"
+
+# A clean lane holding nothing trunk lacks costs nothing, so no --force is asked for.
+"$LANE" new empty > /dev/null 2>&1
+"$LANE" rm empty > /tmp/empty.out 2>&1
+is "rm takes a lane with nothing at stake" "$?" "0"
+is "and says so" "$(grep -c 'removed lane empty' /tmp/empty.out)" "1"
+
+# The squash merge git branch -d always refuses. Lane compares patches, not ancestry.
+"$LANE" new squashed > /dev/null 2>&1
+( cd "$TMP/repo/.lane/trees/squashed" && echo "fn s() {}" > src/s.rs \
+  && git add -A && git commit -qm "squash me" > /dev/null )
+git merge --squash squashed > /dev/null 2>&1 && git commit -qm "squashed (#1)"
+is "git itself refuses the squashed branch" \
+   "$(git branch -d squashed > /dev/null 2>&1 && echo deleted || echo refused)" "refused"
+"$LANE" rm squashed > /tmp/squash.out 2>&1
+is "rm sees the squash and needs no --force" "$?" "0"
+is "the squashed branch is gone" "$(git branch --list squashed | wc -l | tr -d ' ')" "0"
 
 "$LANE" rm ghost > /tmp/ghost.out 2>&1
 is "rm rejects a name that is neither lane nor branch" "$?" "1"
 is "rm says so plainly" "$(grep -c 'no lane ghost' /tmp/ghost.out)" "1"
 
+# A worktree deleted by hand leaves a branch git will not remove a worktree for.
 "$LANE" new gone > /dev/null 2>&1
 rm -rf "$TMP/repo/.lane/trees/gone"
-"$LANE" rm gone --force > /dev/null 2>&1
-is "rm cleans up a hand-deleted worktree" "$(git branch --list gone | wc -l | tr -d ' ')" "0"
-
-"$LANE" new scrap2 > /dev/null 2>&1
-( cd "$TMP/repo/.lane/trees/scrap2" && echo "fn work() {}" > src/work2.rs \
-  && git add -A && git commit -qm "throwaway" > /dev/null )
-"$LANE" rm scrap2 --force > /dev/null 2>&1
-is "--force discards the branch" "$(git branch --list scrap2 | wc -l | tr -d ' ')" "0"
+"$LANE" rm gone --force > /tmp/gone.out 2>&1
+is "rm cleans up after a hand-deleted worktree" "$?" "0"
+is "with no git fatal" "$(grep -c 'not a working tree' /tmp/gone.out)" "0"
+is "and the branch goes with it" "$(git branch --list gone | wc -l | tr -d ' ')" "0"
 
 echo "== 12. init scaffolding and the per-anchor budget =="
 setup
@@ -710,7 +743,7 @@ git merge -q --squash after && git commit -qm "squash after" > /dev/null
 ( cd "$TMP/repo/.lane/trees/after" \
   && echo "// later" >> src/auth.rs && git add -A && git commit -qm later > /dev/null )
 is "sweep refuses work trunk does not have" \
-   "$("$LANE" sweep 2>&1 | grep -c 'skipped after: has work main does not')" "1"
+   "$("$LANE" sweep 2>&1 | grep -c 'skipped after: commits main does not have')" "1"
 is "and leaves the lane in place" \
    "$([ -d .lane/trees/after ] && echo yes || echo no)" "yes"
 

--- a/test_lane.sh
+++ b/test_lane.sh
@@ -147,6 +147,27 @@ is "unlanded branch survives" "$(git branch --list scrap | wc -l | tr -d ' ')" "
 is "unlanded commit still reachable" "$(git rev-parse scrap)" "$SHA"
 is "worktree is gone either way" \
    "$([ -d "$TMP/repo/.lane/trees/scrap" ] && echo yes || echo no)" "no"
+is "rm names the command that reopens the lane" "$(grep -c 'lane new scrap' /tmp/rm.out)" "1"
+
+# The refusal already took the worktree, so the --force it offered has only a branch left.
+"$LANE" new scrap > /dev/null 2>&1
+is "the offered lane new adopts the kept branch" "$(git rev-parse scrap)" "$SHA"
+is "and carries the unlanded work" \
+   "$([ -f "$TMP/repo/.lane/trees/scrap/src/work.rs" ] && echo yes || echo no)" "yes"
+"$LANE" rm scrap > /dev/null 2>&1
+"$LANE" rm scrap --force > /tmp/force.out 2>&1
+is "the offered --force exits zero with no worktree left" "$?" "0"
+is "the offered --force discards the branch" "$(git branch --list scrap | wc -l | tr -d ' ')" "0"
+is "the offered --force reports no git error" "$(grep -c 'not a working tree' /tmp/force.out)" "0"
+
+"$LANE" rm ghost > /tmp/ghost.out 2>&1
+is "rm rejects a name that is neither lane nor branch" "$?" "1"
+is "rm says so plainly" "$(grep -c 'no lane ghost' /tmp/ghost.out)" "1"
+
+"$LANE" new gone > /dev/null 2>&1
+rm -rf "$TMP/repo/.lane/trees/gone"
+"$LANE" rm gone --force > /dev/null 2>&1
+is "rm cleans up a hand-deleted worktree" "$(git branch --list gone | wc -l | tr -d ' ')" "0"
 
 "$LANE" new scrap2 > /dev/null 2>&1
 ( cd "$TMP/repo/.lane/trees/scrap2" && echo "fn work() {}" > src/work2.rs \

--- a/test_lane.sh
+++ b/test_lane.sh
@@ -196,6 +196,20 @@ is "git itself refuses the squashed branch" \
 is "rm sees the squash and needs no --force" "$?" "0"
 is "the squashed branch is gone" "$(git branch --list squashed | wc -l | tr -d ' ')" "0"
 
+# The other half of the same question: a rebase merge replays each commit on its own,
+# so a branch of several is landed by patch while no single collapsed diff matches.
+"$LANE" new replayed > /dev/null 2>&1
+( cd "$TMP/repo/.lane/trees/replayed" \
+  && echo "fn one() {}" > src/one.rs && git add -A && git commit -qm one > /dev/null \
+  && echo "fn two() {}" > src/two.rs && git add -A && git commit -qm two > /dev/null )
+git cherry-pick "$(git merge-base main replayed)..replayed" > /dev/null 2>&1
+echo "// moved on" >> src/auth.rs && git add -A && git commit -qm "trunk moved" > /dev/null
+is "git itself refuses the replayed branch" \
+   "$(git branch -d replayed > /dev/null 2>&1 && echo deleted || echo refused)" "refused"
+"$LANE" rm replayed > /tmp/replay.out 2>&1
+is "rm sees a multi-commit rebase merge" "$?" "0"
+is "the replayed branch is gone" "$(git branch --list replayed | wc -l | tr -d ' ')" "0"
+
 "$LANE" rm ghost > /tmp/ghost.out 2>&1
 is "rm rejects a name that is neither lane nor branch" "$?" "1"
 is "rm says so plainly" "$(grep -c 'no lane ghost' /tmp/ghost.out)" "1"

--- a/www/src/pages/usage.md
+++ b/www/src/pages/usage.md
@@ -319,7 +319,7 @@ The short version. See [commands](/commands) for full information.
 | `lane done [--keep] [--trunk <ref>] [--squash] [--cd]` | rebase, audit, fast-forward, remove |
 | `lane done --no-merge` | stop after the memory commit, for a pull request to carry |
 | `lane sweep [--dry-run]` | remove lanes whose branch has landed in trunk |
-| `lane rm <name> [--force]` | discard a lane; it keeps a branch holding commits trunk does not have, `--force` drops them |
+| `lane rm <name> [--force]` | discard a lane; it stops and names uncommitted work, pending notes, or commits trunk does not have, `--force` drops them |
 | `lane shellenv` | shell integration |
 
 ### Layout


### PR DESCRIPTION
`lane rm <name>` removed the worktree, *then* asked whether the branch was safe to delete. When the answer was no it printed a recovery it had already made impossible:

```
$ lane rm argv-manual
removed lane argv-manual; kept branch argv-manual, it has commits main does not
  lane rm argv-manual --force            to discard them
$ lane rm argv-manual --force
error: git worktree remove --force .../.lane/trees/argv-manual failed:
fatal: '.../.lane/trees/argv-manual' is not a working tree
```

The lane was gone, so the `--force` it offered had nothing left to remove.

## What changed

`wt::losses` is now the single answer to "what does removing this lane destroy for good": uncommitted work, pending notes, commits the trunk does not have. `rm` asks before it touches anything and stops with the list. Nothing is destroyed by a refusal.

```
$ lane rm busy
kept lane busy: 2 uncommitted change(s), 1 pending note(s), commits main does not have
  lane rm busy --force   to discard it anyway
```

- **Pending notes count as loss.** A lane's memory is the one thing its branch cannot give back. `rm` used to drop it silently, even on the path that claimed to keep the work.
- **`--force` means everything**, matching `git branch -D`.
- **`wt::remove` is unconditional** and takes no `force` flag. Its guard is `losses`, which every caller runs first. `git branch -d` was never that guard: it refuses every squash and rebase merge. `lane rm` on a squash-merged branch now just works.
- **`sweep` uses the same guard**, so a lane that landed by pull request but collected notes afterward is skipped rather than swept away.
- **A hand-deleted worktree is recoverable.** `remove` skips git's worktree step when nothing is registered at the path, instead of passing it a path git calls fatal.

## Tests

Section 11 of `test_lane.sh` goes from 7 assertions to 24: the refusal leaves the lane on disk, each loss is named on its own, `--force` takes each one, a squash merge needs no `--force`, an unknown name says `no lane <name>`, and a hand-deleted worktree cleans up without a git fatal.

168 pass, 0 fail. `cargo test` 112 pass. Clippy clean.