### PR TITLE
fix: skip `Why` capture during rebase

### DIFF
--- a/.lane/memory/crates/lane/src/cli.rs/01M0EVWZGPP2GNST4Y52MG8AS1-installed-hook-blocks-are-ex.md
+++ b/.lane/memory/crates/lane/src/cli.rs/01M0EVWZGPP2GNST4Y52MG8AS1-installed-hook-blocks-are-ex.md
@@ -5,9 +5,9 @@ created: 2026-08-20T05:55:07Z
 branch: warn-dropped-trailer
 norm: '1'
 sig: 05a975d77f5b9730
-body_hash: 4069f7ea1e97e3f2
-raw_hash: 2b67bfef2b77fccd
-vouched: 2026-08-22T18:23:00Z
+body_hash: f98d652429c9d778
+raw_hash: 04668bfb70bc4c1f
+vouched: 2026-08-24T21:20:39Z
 lines: 332-338
 ---
 

--- a/.lane/memory/crates/lane/src/cli.rs/01M0TT8G1FHE50NFAE3JJ45DFA-rebase-merge-and-rebase-appl.md
+++ b/.lane/memory/crates/lane/src/cli.rs/01M0TT8G1FHE50NFAE3JJ45DFA-rebase-merge-and-rebase-appl.md
@@ -1,0 +1,13 @@
+---
+id: 01M0TT8G1FHE50NFAE3JJ45DFA
+anchor: POST_COMMIT_BLOCK
+created: 2026-08-24T21:19:11Z
+branch: fix/issue-13-rebase-capture
+norm: '1'
+sig: 05a975d77f5b9730
+body_hash: f98d652429c9d778
+raw_hash: 04668bfb70bc4c1f
+lines: 244-253
+---
+
+rebase-merge and rebase-apply both replay commits through post-commit; those runs must not recapture Why trailers

--- a/.lane/memory/test_lane.sh/01M0ESRPDGANMXC60YCD3VYVS5-a-shared-cargo-target-dir-ma.md
+++ b/.lane/memory/test_lane.sh/01M0ESRPDGANMXC60YCD3VYVS5-a-shared-cargo-target-dir-ma.md
@@ -5,9 +5,9 @@ created: 2026-08-20T03:20:05Z
 branch: main
 norm: '1'
 sig: e3b0c44298fc1c14
-body_hash: b11d5967f099ebcf
-raw_hash: 9776274792ed9c8a
-vouched: 2026-08-24T21:04:42Z
+body_hash: d8e760b34a98a37b
+raw_hash: e11b31296582037a
+vouched: 2026-08-24T21:20:39Z
 lines: 1-514
 ---
 

--- a/crates/lane/src/cli.rs
+++ b/crates/lane/src/cli.rs
@@ -226,7 +226,9 @@ const SKILL_PATH: &str = ".agents/skills/lane/SKILL.md";
 const POST_COMMIT_MARKER: &str = "# lane: capture Why trailers";
 const POST_COMMIT_END: &str = "# lane: end";
 const POST_COMMIT_BLOCK: &str = "# lane: capture Why trailers\n\
-if command -v lane >/dev/null 2>&1; then\n\
+if [ -d \"$(git rev-parse --git-path rebase-merge 2>/dev/null)\" ] || [ -d \"$(git rev-parse --git-path rebase-apply 2>/dev/null)\" ]; then\n\
+  :\n\
+elif command -v lane >/dev/null 2>&1; then\n\
   lane capture HEAD || true\n\
 elif git log -1 --format=%B | grep -qi '^Why:'; then\n\
   echo \"lane: not on PATH, so the Why trailer in this commit was not captured\" >&2\n\

--- a/test_lane.sh
+++ b/test_lane.sh
@@ -478,6 +478,27 @@ Why: src/auth.rs#fn verify | early return leaks token length"
 is "an identical note is not duplicated" \
    "$(grep -rl 'early return leaks' .lane/memory --include='*.md' | wc -l | tr -d ' ')" "1"
 
+setup
+"$LANE" install hooks > /dev/null
+git switch -qc replay
+printf 'pub fn replayed() {}\n' > src/replayed.rs
+git add src/replayed.rs
+git commit -q -m "record replay decision
+
+Why: src/replayed.rs | replaying the commit is not a new decision"
+is "a replay candidate is captured once" \
+   "$(grep -c 'not a new decision' .git/lane/pending.jsonl)" "1"
+git switch -q main
+printf 'pub fn moved_base() {}\n' > src/base.rs
+git add src/base.rs && git commit -qm "move base"
+git switch -q replay
+git rebase main > /tmp/replay.out 2>&1
+is "the decision-bearing commit rebases cleanly" "$?" "0"
+is "a replayed commit is not captured again" \
+   "$(grep -c 'not a new decision' .git/lane/pending.jsonl)" "1"
+
+setup
+"$LANE" install hooks > /dev/null
 git commit -q --allow-empty -m "silent commit
 
 Why: src/auth.rs#fn verify | a trailer that should warn when lane is missing" 2>/tmp/nolane.err


### PR DESCRIPTION
Closes #13

Skip the lane-managed `post-commit` capture while either Git rebase backend is active, preventing replayed commits from duplicating `Why:` notes.

Adds an end-to-end regression that rebases a decision-bearing commit and verifies `pending.jsonl` remains at one entry.

Tests:
- `cargo test --workspace`
- `./test_lane.sh` (184 passed)