### PR TITLE
chore: simplify `lane why` output

### DIFF
--- a/.lane/attic/crates/lane/Cargo.toml/01M0RP813WRK018HGY8ATHW0XT-pico-args-ships-eq-separator.md
+++ b/.lane/attic/crates/lane/Cargo.toml/01M0RP813WRK018HGY8ATHW0XT-pico-args-ships-eq-separator.md
@@ -2,7 +2,6 @@
 id: 01M0RP813WRK018HGY8ATHW0XT
 anchor: pico-args
 created: 2026-08-24T01:30:25Z
-branch: argv-manual
 norm: '1'
 ---
 

--- a/.lane/attic/crates/lane/src/audit.rs/01M0G385NZ15M1WP4CD247MVE8-unresolved-drift-must-retain.md
+++ b/.lane/attic/crates/lane/src/audit.rs/01M0G385NZ15M1WP4CD247MVE8-unresolved-drift-must-retain.md
@@ -2,7 +2,6 @@
 id: 01M0G385NZ15M1WP4CD247MVE8
 anchor: fn record_state
 created: 2026-08-20T17:14:14Z
-branch: preserve-baseline
 norm: '1'
 sig: a9b2e6777f4eda6c
 body_hash: 17ec747716b6005a

--- a/.lane/attic/crates/lane/src/cli.rs/01M0ESRPE01X3PWQH9H3DTD5VB-init-never-rewrites-an-exist.md
+++ b/.lane/attic/crates/lane/src/cli.rs/01M0ESRPE01X3PWQH9H3DTD5VB-init-never-rewrites-an-exist.md
@@ -2,7 +2,6 @@
 id: 01M0ESRPE01X3PWQH9H3DTD5VB
 anchor: fn init
 created: 2026-08-20T04:50:54Z
-branch: main
 norm: '1'
 sig: 9a89d112d0fe97ca
 body_hash: ba757fee94513afb

--- a/.lane/attic/crates/lane/src/cli.rs/01M0TQYBPCHTWG41WA1PMS1G4Y-rejected-landings-must-retai.md
+++ b/.lane/attic/crates/lane/src/cli.rs/01M0TQYBPCHTWG41WA1PMS1G4Y-rejected-landings-must-retai.md
@@ -2,7 +2,6 @@
 id: 01M0TQYBPCHTWG41WA1PMS1G4Y
 anchor: fn done
 created: 2026-08-24T19:20:47Z
-branch: push-command
 norm: '1'
 sig: 52d46897eab5ba03
 body_hash: f1dfb7472ddc41b0

--- a/.lane/attic/crates/lane/src/cli.rs/01M0TRRKQE397F7WNHV66M08JQ-done-exits-2-outside-a-lane.md
+++ b/.lane/attic/crates/lane/src/cli.rs/01M0TRRKQE397F7WNHV66M08JQ-done-exits-2-outside-a-lane.md
@@ -2,7 +2,6 @@
 id: 01M0TRRKQE397F7WNHV66M08JQ
 anchor: fn done
 created: 2026-08-24T20:52:56Z
-branch: push-command
 norm: '1'
 sig: 52d46897eab5ba03
 body_hash: f1dfb7472ddc41b0

--- a/.lane/attic/crates/lane/src/store.rs/01M0GFVWN31756XJ6E56B8N99V-state-replacement-must-stay.md
+++ b/.lane/attic/crates/lane/src/store.rs/01M0GFVWN31756XJ6E56B8N99V-state-replacement-must-stay.md
@@ -2,7 +2,6 @@
 id: 01M0GFVWN31756XJ6E56B8N99V
 anchor: fn write_state_file
 created: 2026-08-20T21:02:13Z
-branch: atomic-state
 norm: '1'
 sig: f09ef98a4172a45d
 body_hash: c43fe525540e8b65

--- a/.lane/attic/crates/lane/src/worktree.rs/01M0TQYBQVSRHXXA7M83H5GE1A-must-return-a-local-branch-l.md
+++ b/.lane/attic/crates/lane/src/worktree.rs/01M0TQYBQVSRHXXA7M83H5GE1A-must-return-a-local-branch-l.md
@@ -2,7 +2,6 @@
 id: 01M0TQYBQVSRHXXA7M83H5GE1A
 anchor: fn trunk_name
 created: 2026-08-24T20:33:01Z
-branch: push-command
 norm: '1'
 sig: 6388df923cf25623
 body_hash: 1fe611ea9801b789

--- a/.lane/attic/crates/lane/src/worktree.rs/01M0TRRKSWK26RY06J8DX6AQEY-sweep-ls-and-the-landing-loc.md
+++ b/.lane/attic/crates/lane/src/worktree.rs/01M0TRRKSWK26RY06J8DX6AQEY-sweep-ls-and-the-landing-loc.md
@@ -2,7 +2,6 @@
 id: 01M0TRRKSWK26RY06J8DX6AQEY
 anchor: fn trunk_name
 created: 2026-08-24T20:52:56Z
-branch: push-command
 norm: '1'
 sig: 6388df923cf25623
 body_hash: 1fe611ea9801b789

--- a/.lane/attic/scripts/check-linux.sh/01M0EY6QRVZSWS021QT5B8N5E9-bash-3-2-treats-an-empty-arr.md
+++ b/.lane/attic/scripts/check-linux.sh/01M0EY6QRVZSWS021QT5B8N5E9-bash-3-2-treats-an-empty-arr.md
@@ -2,7 +2,6 @@
 id: 01M0EY6QRVZSWS021QT5B8N5E9
 anchor: podman run
 created: 2026-08-20T06:30:09Z
-branch: fix-linux-gate
 norm: '1'
 ---
 

--- a/.lane/attic/scripts/check-linux.sh/01M0EY6QRYZN40BQYKQW99NN9Y-a-linked-worktree-git-file-m.md
+++ b/.lane/attic/scripts/check-linux.sh/01M0EY6QRYZN40BQYKQW99NN9Y-a-linked-worktree-git-file-m.md
@@ -2,7 +2,6 @@
 id: 01M0EY6QRYZN40BQYKQW99NN9Y
 anchor: '@file'
 created: 2026-08-20T06:35:46Z
-branch: fix-linux-gate
 norm: '1'
 sig: e3b0c44298fc1c14
 body_hash: 77794c69145518a9

--- a/.lane/attic/test_lane.sh/01M0ESRPDGANMXC60YCD3VYVS5-a-shared-cargo-target-dir-ma.md
+++ b/.lane/attic/test_lane.sh/01M0ESRPDGANMXC60YCD3VYVS5-a-shared-cargo-target-dir-ma.md
@@ -2,7 +2,6 @@
 id: 01M0ESRPDGANMXC60YCD3VYVS5
 anchor: '@file'
 created: 2026-08-20T03:20:05Z
-branch: main
 norm: '1'
 sig: e3b0c44298fc1c14
 body_hash: 9da6b6636c9b2b1b

--- a/.lane/attic/test_lane.sh/01M0G14CMAP84D2TJ2NJT6B87M-a-landing-marker-and-one-com.md
+++ b/.lane/attic/test_lane.sh/01M0G14CMAP84D2TJ2NJT6B87M-a-landing-marker-and-one-com.md
@@ -2,7 +2,6 @@
 id: 01M0G14CMAP84D2TJ2NJT6B87M
 anchor: 28. landings are serialized and marked
 created: 2026-08-20T16:41:06Z
-branch: landing-lock
 norm: '1'
 ---
 

--- a/.lane/attic/test_lane.sh/01M0G385P4059C8WYT7HCSPN5S-baseline-preservation-must-b.md
+++ b/.lane/attic/test_lane.sh/01M0G385P4059C8WYT7HCSPN5S-baseline-preservation-must-b.md
@@ -2,7 +2,6 @@
 id: 01M0G385P4059C8WYT7HCSPN5S
 anchor: drift survives a landing
 created: 2026-08-20T17:17:00Z
-branch: preserve-baseline
 norm: '1'
 ---
 

--- a/.lane/memory/.github/workflows/ci.yml/01M0THM3E8J7FS0WE1PEAA168Y-a-cache-key-is-never-overwri.md
+++ b/.lane/memory/.github/workflows/ci.yml/01M0THM3E8J7FS0WE1PEAA168Y-a-cache-key-is-never-overwri.md
@@ -2,7 +2,6 @@
 id: 01M0THM3E8J7FS0WE1PEAA168Y
 anchor: '@file'
 created: 2026-08-24T18:48:09Z
-branch: ci-cache-prune
 norm: '1'
 sig: eb0ffc2134160f8f
 body_hash: e331d477641683c3

--- a/.lane/memory/.ignore/01M0GHGRQ9HSVAXMC2B5CFA10A-gitignore-here-would-break-t.md
+++ b/.lane/memory/.ignore/01M0GHGRQ9HSVAXMC2B5CFA10A-gitignore-here-would-break-t.md
@@ -2,7 +2,6 @@
 id: 01M0GHGRQ9HSVAXMC2B5CFA10A
 anchor: '@file'
 created: 2026-08-20T21:19:29Z
-branch: main
 norm: '1'
 sig: f85394d43f137fa6
 body_hash: e3b0c44298fc1c14

--- a/.lane/memory/AGENTS.md/01M0EWMNDA5DS5F6Z5R46N4TCP-lane-owns-the-region-between.md
+++ b/.lane/memory/AGENTS.md/01M0EWMNDA5DS5F6Z5R46N4TCP-lane-owns-the-region-between.md
@@ -2,7 +2,6 @@
 id: 01M0EWMNDA5DS5F6Z5R46N4TCP
 anchor: '@file'
 created: 2026-08-20T05:25:59Z
-branch: main
 norm: '1'
 sig: cd3ddeb4b8ef600f
 body_hash: 18b52311bd5a90fa

--- a/.lane/memory/crates/lane-tour/src/scenes.rs/01M0G7KM8AG8KKWH24PMQHFXCJ-every-command-here-is-echoed.md
+++ b/.lane/memory/crates/lane-tour/src/scenes.rs/01M0G7KM8AG8KKWH24PMQHFXCJ-every-command-here-is-echoed.md
@@ -2,7 +2,6 @@
 id: 01M0G7KM8AG8KKWH24PMQHFXCJ
 anchor: '@file'
 created: 2026-08-20T18:38:40Z
-branch: tour
 norm: '1'
 sig: e3b0c44298fc1c14
 body_hash: bfd7bc9f8f300b32

--- a/.lane/memory/crates/lane/Cargo.toml/01M0V0CJJ6TDCGYRRGQSVH5101-pico-args-ships-eq-separator.md
+++ b/.lane/memory/crates/lane/Cargo.toml/01M0V0CJJ6TDCGYRRGQSVH5101-pico-args-ships-eq-separator.md
@@ -1,0 +1,13 @@
+---
+id: 01M0V0CJJ6TDCGYRRGQSVH5101
+anchor: '@file'
+created: 2026-08-24T23:06:16Z
+norm: '1'
+sig: 70acf00586aa7b90
+body_hash: 9aef453ab469f78d
+raw_hash: eec213dc7e417838
+lines: 1-68
+supersedes: 01M0RP813WRK018HGY8ATHW0XT
+---
+
+pico-args ships eq-separator and short-space-opt off by default, so an unfeatured dependency makes --base=main fail because --base has no associated value; both features are named in the manifest on purpose

--- a/.lane/memory/crates/lane/assets/skill.md/01M0ER1X7801FW524YV2G8TNQQ-ships-via-include-str-so-an.md
+++ b/.lane/memory/crates/lane/assets/skill.md/01M0ER1X7801FW524YV2G8TNQQ-ships-via-include-str-so-an.md
@@ -2,12 +2,11 @@
 id: 01M0ER1X7801FW524YV2G8TNQQ
 anchor: '@file'
 created: 2026-08-20T04:23:47Z
-branch: install-skill
 norm: '1'
 sig: cb3f91d54eee30e5
-body_hash: 6d5ff985e1b1da70
-raw_hash: bf43cc4d723b8d3f
-vouched: 2026-08-24T21:39:42Z
+body_hash: 0f90e137ed23d0cc
+raw_hash: d4b15ce95efd02db
+vouched: 2026-08-24T23:11:24Z
 lines: 1-86
 ---
 

--- a/.lane/memory/crates/lane/src/args.rs/01M0RP813X90RVC2J9FEMBECX0-pico-args-has-no-handling-of.md
+++ b/.lane/memory/crates/lane/src/args.rs/01M0RP813X90RVC2J9FEMBECX0-pico-args-has-no-handling-of.md
@@ -2,7 +2,6 @@
 id: 01M0RP813X90RVC2J9FEMBECX0
 anchor: fn terminated
 created: 2026-08-24T01:30:25Z
-branch: argv-manual
 norm: '1'
 sig: 7b60764a4d3b6ee8
 body_hash: 9c08eb1b1627f4b2

--- a/.lane/memory/crates/lane/src/audit.rs/01M0FTSGYPQDM34YWCBXT9ZYA8-a-stored-fingerprint-records.md
+++ b/.lane/memory/crates/lane/src/audit.rs/01M0FTSGYPQDM34YWCBXT9ZYA8-a-stored-fingerprint-records.md
@@ -2,12 +2,11 @@
 id: 01M0FTSGYPQDM34YWCBXT9ZYA8
 anchor: run
 created: 2026-08-20T14:48:26Z
-branch: drift-stays-flagged
 norm: '1'
 sig: 2f3bd298b9e785b1
-body_hash: f92c7af0bbff83ca
-raw_hash: 07998294cf83bc5b
-vouched: 2026-08-24T21:04:42Z
+body_hash: 6d2b3c337f5f5dd1
+raw_hash: 54603717ad54d256
+vouched: 2026-08-24T23:11:24Z
 lines: 80-221
 ---
 

--- a/.lane/memory/crates/lane/src/audit.rs/01M0FTSGYPQDM34YWCBXT9ZYA8-a-stored-fingerprint-records.md
+++ b/.lane/memory/crates/lane/src/audit.rs/01M0FTSGYPQDM34YWCBXT9ZYA8-a-stored-fingerprint-records.md
@@ -4,9 +4,9 @@ anchor: run
 created: 2026-08-20T14:48:26Z
 norm: '1'
 sig: 2f3bd298b9e785b1
-body_hash: 6d2b3c337f5f5dd1
-raw_hash: 54603717ad54d256
-vouched: 2026-08-24T23:11:24Z
+body_hash: f92c7af0bbff83ca
+raw_hash: 07998294cf83bc5b
+vouched: 2026-08-24T23:24:26Z
 lines: 80-221
 ---
 

--- a/.lane/memory/crates/lane/src/capture.rs/01M0ESRPDVY1HE58A16HGPM0Q0-the-hook-is-a-no-op-when-lan.md
+++ b/.lane/memory/crates/lane/src/capture.rs/01M0ESRPDVY1HE58A16HGPM0Q0-the-hook-is-a-no-op-when-lan.md
@@ -2,7 +2,6 @@
 id: 01M0ESRPDVY1HE58A16HGPM0Q0
 anchor: fn capture
 created: 2026-08-20T04:23:02Z
-branch: main
 norm: '1'
 sig: d6eb344e91ff262a
 body_hash: e27981f13bd675d7

--- a/.lane/memory/crates/lane/src/cli.rs/01M0ESPFENGV6K4TS7B4SMERA8-marker-boundaries-must-delim.md
+++ b/.lane/memory/crates/lane/src/cli.rs/01M0ESPFENGV6K4TS7B4SMERA8-marker-boundaries-must-delim.md
@@ -2,7 +2,6 @@
 id: 01M0ESPFENGV6K4TS7B4SMERA8
 anchor: PROTOCOL
 created: 2026-08-20T05:09:06Z
-branch: repair-protocol
 norm: '1'
 sig: ebf04d00814343a4
 body_hash: 99408de2e8eb5879

--- a/.lane/memory/crates/lane/src/cli.rs/01M0ESPFEX4KWAVB5BN4ZJ2ZWX-only-lane-owned-protocol-tex.md
+++ b/.lane/memory/crates/lane/src/cli.rs/01M0ESPFEX4KWAVB5BN4ZJ2ZWX-only-lane-owned-protocol-tex.md
@@ -2,7 +2,6 @@
 id: 01M0ESPFEX4KWAVB5BN4ZJ2ZWX
 anchor: write_protocol
 created: 2026-08-20T05:11:25Z
-branch: repair-protocol
 norm: '1'
 sig: a4bcd7d4c565b528
 body_hash: e28cfd34ac7069dc

--- a/.lane/memory/crates/lane/src/cli.rs/01M0ESPFFA6RKDW9EPAF7YGQ3V-existing-agents-md-files-wit.md
+++ b/.lane/memory/crates/lane/src/cli.rs/01M0ESPFFA6RKDW9EPAF7YGQ3V-existing-agents-md-files-wit.md
@@ -2,7 +2,6 @@
 id: 01M0ESPFFA6RKDW9EPAF7YGQ3V
 anchor: protocol_action
 created: 2026-08-20T05:17:18Z
-branch: repair-protocol
 norm: '1'
 sig: b91957dbbe5addac
 body_hash: 7468bcb03e0028a9

--- a/.lane/memory/crates/lane/src/cli.rs/01M0ET212YPCXNBNFFGK5EMV0W-protocol-rewrites-at-eof-mus.md
+++ b/.lane/memory/crates/lane/src/cli.rs/01M0ET212YPCXNBNFFGK5EMV0W-protocol-rewrites-at-eof-mus.md
@@ -2,7 +2,6 @@
 id: 01M0ET212YPCXNBNFFGK5EMV0W
 anchor: fn replace_protocol
 created: 2026-08-20T05:22:49Z
-branch: protocol-newline
 norm: '1'
 sig: 8a140faca048dedd
 body_hash: 2cfbfbeede2b42a2

--- a/.lane/memory/crates/lane/src/cli.rs/01M0EVWZGPP2GNST4Y52MG8AS1-installed-hook-blocks-are-ex.md
+++ b/.lane/memory/crates/lane/src/cli.rs/01M0EVWZGPP2GNST4Y52MG8AS1-installed-hook-blocks-are-ex.md
@@ -2,7 +2,6 @@
 id: 01M0EVWZGPP2GNST4Y52MG8AS1
 anchor: POST_COMMIT_BLOCK
 created: 2026-08-20T05:55:07Z
-branch: warn-dropped-trailer
 norm: '1'
 sig: 05a975d77f5b9730
 body_hash: f98d652429c9d778

--- a/.lane/memory/crates/lane/src/cli.rs/01M0EWMNDC9P82RZ0Z6VMNC3VP-it-splices-out-the-delimited.md
+++ b/.lane/memory/crates/lane/src/cli.rs/01M0EWMNDC9P82RZ0Z6VMNC3VP-it-splices-out-the-delimited.md
@@ -2,7 +2,6 @@
 id: 01M0EWMNDC9P82RZ0Z6VMNC3VP
 anchor: hooks_uninstall
 created: 2026-08-20T06:09:31Z
-branch: main
 norm: '1'
 sig: 6fcce5fc87cb3571
 body_hash: 872bb1a7c1049dc6

--- a/.lane/memory/crates/lane/src/cli.rs/01M0G14CMHEQQ05FRZT0PZA5EG-the-file-names-the-shared-lo.md
+++ b/.lane/memory/crates/lane/src/cli.rs/01M0G14CMHEQQ05FRZT0PZA5EG-the-file-names-the-shared-lo.md
@@ -2,7 +2,6 @@
 id: 01M0G14CMHEQQ05FRZT0PZA5EG
 anchor: fn acquire
 created: 2026-08-20T16:41:29Z
-branch: landing-lock
 norm: '1'
 sig: 0bff83f9aaa042a1
 body_hash: bac6a3e1e712e18d

--- a/.lane/memory/crates/lane/src/cli.rs/01M0G248G7Z4VF20CD6MMDFTVN-the-file-must-outlive-the-la.md
+++ b/.lane/memory/crates/lane/src/cli.rs/01M0G248G7Z4VF20CD6MMDFTVN-the-file-must-outlive-the-la.md
@@ -2,7 +2,6 @@
 id: 01M0G248G7Z4VF20CD6MMDFTVN
 anchor: LandingLock
 created: 2026-08-20T16:47:49Z
-branch: main
 norm: '1'
 sig: e38974ba210b0ef5
 body_hash: f056f87c972d2f0b

--- a/.lane/memory/crates/lane/src/cli.rs/01M0TMPTS17M4SC4911BATBKA3-per-lane-status-probes-may-f.md
+++ b/.lane/memory/crates/lane/src/cli.rs/01M0TMPTS17M4SC4911BATBKA3-per-lane-status-probes-may-f.md
@@ -2,7 +2,6 @@
 id: 01M0TMPTS17M4SC4911BATBKA3
 anchor: fn ls
 created: 2026-08-24T19:21:38Z
-branch: perf-audit
 norm: '1'
 sig: 5a116c9621df3b1f
 body_hash: 6297f131b8b3f00e

--- a/.lane/memory/crates/lane/src/cli.rs/01M0TNEY0TKC1RY8396A3NB47X-the-worktree-basename-is-the.md
+++ b/.lane/memory/crates/lane/src/cli.rs/01M0TNEY0TKC1RY8396A3NB47X-the-worktree-basename-is-the.md
@@ -2,7 +2,6 @@
 id: 01M0TNEY0TKC1RY8396A3NB47X
 anchor: fn ls
 created: 2026-08-24T19:55:15Z
-branch: fix-ls-duplicate-names
 norm: '1'
 sig: 5a116c9621df3b1f
 body_hash: 6297f131b8b3f00e

--- a/.lane/memory/crates/lane/src/cli.rs/01M0TT8G1FHE50NFAE3JJ45DFA-rebase-merge-and-rebase-appl.md
+++ b/.lane/memory/crates/lane/src/cli.rs/01M0TT8G1FHE50NFAE3JJ45DFA-rebase-merge-and-rebase-appl.md
@@ -2,7 +2,6 @@
 id: 01M0TT8G1FHE50NFAE3JJ45DFA
 anchor: POST_COMMIT_BLOCK
 created: 2026-08-24T21:19:11Z
-branch: fix/issue-13-rebase-capture
 norm: '1'
 sig: 05a975d77f5b9730
 body_hash: f98d652429c9d778

--- a/.lane/memory/crates/lane/src/cli.rs/01M0TVF10VM7DTYH3E4BCHP9MH-merge-exits-2-outside-a-lane.md
+++ b/.lane/memory/crates/lane/src/cli.rs/01M0TVF10VM7DTYH3E4BCHP9MH-merge-exits-2-outside-a-lane.md
@@ -2,7 +2,6 @@
 id: 01M0TVF10VM7DTYH3E4BCHP9MH
 anchor: fn merge
 created: 2026-08-24T21:39:42Z
-branch: rename-done-to-merge
 norm: '1'
 sig: beef067f589982b9
 body_hash: f1dfb7472ddc41b0

--- a/.lane/memory/crates/lane/src/cow.rs/01M0ESYXZH9H0Z631FGCPND97V-lanes-must-not-retain-absolu.md
+++ b/.lane/memory/crates/lane/src/cow.rs/01M0ESYXZH9H0Z631FGCPND97V-lanes-must-not-retain-absolu.md
@@ -2,7 +2,6 @@
 id: 01M0ESYXZH9H0Z631FGCPND97V
 anchor: fn retarget
 created: 2026-08-20T05:14:25Z
-branch: symlink-retarget
 norm: '1'
 sig: 6b7dd66fe2601cc3
 body_hash: a7328eb6dd52ef1d

--- a/.lane/memory/crates/lane/src/cow.rs/01M0ESYXZVNY1SVCQJRZ51K409-macos-exposes-the-same-root.md
+++ b/.lane/memory/crates/lane/src/cow.rs/01M0ESYXZVNY1SVCQJRZ51K409-macos-exposes-the-same-root.md
@@ -2,7 +2,6 @@
 id: 01M0ESYXZVNY1SVCQJRZ51K409
 anchor: fn root_spellings
 created: 2026-08-20T05:21:14Z
-branch: symlink-retarget
 norm: '1'
 sig: 11a3ed632b3c2ed9
 body_hash: 39b5e7f985e6c07b

--- a/.lane/memory/crates/lane/src/cow.rs/01M0EXNVCE1Y0CS6BJX3V2NJ67-nested-destinations-must-be.md
+++ b/.lane/memory/crates/lane/src/cow.rs/01M0EXNVCE1Y0CS6BJX3V2NJ67-nested-destinations-must-be.md
@@ -2,7 +2,6 @@
 id: 01M0EXNVCE1Y0CS6BJX3V2NJ67
 anchor: fn clone_tree_rooted
 created: 2026-08-20T06:23:22Z
-branch: nested-lanes
 norm: '1'
 sig: 62aedd2f3e646c47
 body_hash: e554abcffe94d843

--- a/.lane/memory/crates/lane/src/git.rs/01M0TMPTRNJVJYQ52G0CF8ZV5J-on-macos-usr-bin-git-costs-2.md
+++ b/.lane/memory/crates/lane/src/git.rs/01M0TMPTRNJVJYQ52G0CF8ZV5J-on-macos-usr-bin-git-costs-2.md
@@ -2,7 +2,6 @@
 id: 01M0TMPTRNJVJYQ52G0CF8ZV5J
 anchor: fn layout
 created: 2026-08-24T19:14:32Z
-branch: perf-audit
 norm: '1'
 sig: 8d764c9bac251436
 body_hash: 3626ff17a60c7fc3

--- a/.lane/memory/crates/lane/src/git.rs/01M0TMPTRQ3T4E9ZAVYT7G7E6Y-git-dir-is-per-worktree-and.md
+++ b/.lane/memory/crates/lane/src/git.rs/01M0TMPTRQ3T4E9ZAVYT7G7E6Y-git-dir-is-per-worktree-and.md
@@ -2,7 +2,6 @@
 id: 01M0TMPTRQ3T4E9ZAVYT7G7E6Y
 anchor: struct RepoLayout
 created: 2026-08-24T19:14:32Z
-branch: perf-audit
 norm: '1'
 sig: 096b5de33f51b8a7
 body_hash: 4f4e2f70126b3686

--- a/.lane/memory/crates/lane/src/help.rs/01M0RP8141K78K4HX605TH4W8E-the-parse-errors-quote-this.md
+++ b/.lane/memory/crates/lane/src/help.rs/01M0RP8141K78K4HX605TH4W8E-the-parse-errors-quote-this.md
@@ -2,7 +2,6 @@
 id: 01M0RP8141K78K4HX605TH4W8E
 anchor: fn usage
 created: 2026-08-24T01:30:25Z
-branch: argv-manual
 norm: '1'
 sig: b118a8f064d37898
 body_hash: ec4c4b19b5a2ad6c

--- a/.lane/memory/crates/lane/src/syntax.rs/01M0TMPTR29GTK9N5MA1Z0PHKD-line-starts-must-preserve-st.md
+++ b/.lane/memory/crates/lane/src/syntax.rs/01M0TMPTR29GTK9N5MA1Z0PHKD-line-starts-must-preserve-st.md
@@ -2,7 +2,6 @@
 id: 01M0TMPTR29GTK9N5MA1Z0PHKD
 anchor: struct Source
 created: 2026-08-24T19:09:49Z
-branch: perf-audit
 norm: '1'
 sig: 7877fe79130c24bf
 body_hash: ea97b192f427557c

--- a/.lane/memory/crates/lane/src/syntax.rs/01M0TMPTRSMCPHAKVYK4FMJJ3K-span-text-feeds-the-note-fin.md
+++ b/.lane/memory/crates/lane/src/syntax.rs/01M0TMPTRSMCPHAKVYK4FMJJ3K-span-text-feeds-the-note-fin.md
@@ -2,7 +2,6 @@
 id: 01M0TMPTRSMCPHAKVYK4FMJJ3K
 anchor: fn byte_range
 created: 2026-08-24T19:14:32Z
-branch: perf-audit
 norm: '1'
 sig: 651739647cf1a22b
 body_hash: 465d8737e0d68b54

--- a/.lane/memory/crates/lane/src/worktree.rs/01M0ESYXZNKCATJMA29RKWE8JH-ignored-subtrees-can-contain.md
+++ b/.lane/memory/crates/lane/src/worktree.rs/01M0ESYXZNKCATJMA29RKWE8JH-ignored-subtrees-can-contain.md
@@ -2,7 +2,6 @@
 id: 01M0ESYXZNKCATJMA29RKWE8JH
 anchor: fn clone_entry
 created: 2026-08-20T05:21:14Z
-branch: symlink-retarget
 norm: '1'
 sig: a7fad34c8e29d463
 body_hash: d27cde9210629f49

--- a/.lane/memory/crates/lane/src/worktree.rs/01M0EXNVCK4JP9328P47M4W2C1-dirty-materialization-must-e.md
+++ b/.lane/memory/crates/lane/src/worktree.rs/01M0EXNVCK4JP9328P47M4W2C1-dirty-materialization-must-e.md
@@ -2,7 +2,6 @@
 id: 01M0EXNVCK4JP9328P47M4W2C1
 anchor: fn create
 created: 2026-08-20T06:23:22Z
-branch: nested-lanes
 norm: '1'
 sig: 2a21aaf08379e25a
 body_hash: 32e7fbd5d02bd28d

--- a/.lane/memory/crates/lane/src/worktree.rs/01M0TPDF4R5AMSTHCAZHY6VVTC-a-refused-rm-still-drops-the.md
+++ b/.lane/memory/crates/lane/src/worktree.rs/01M0TPDF4R5AMSTHCAZHY6VVTC-a-refused-rm-still-drops-the.md
@@ -2,7 +2,6 @@
 id: 01M0TPDF4R5AMSTHCAZHY6VVTC
 anchor: fn remove
 created: 2026-08-24T19:56:19Z
-branch: rm-recovery
 norm: '1'
 sig: b349364829890348
 body_hash: cb9d736df47d72cd

--- a/.lane/memory/crates/lane/src/worktree.rs/01M0TPDF4YJSDFA0PDEF8QZR90-a-refusal-that-already-dropp.md
+++ b/.lane/memory/crates/lane/src/worktree.rs/01M0TPDF4YJSDFA0PDEF8QZR90-a-refusal-that-already-dropp.md
@@ -2,7 +2,6 @@
 id: 01M0TPDF4YJSDFA0PDEF8QZR90
 anchor: fn losses
 created: 2026-08-24T20:11:57Z
-branch: rm-recovery
 norm: '1'
 sig: 22381cb7e3c03d76
 body_hash: a775ac5aa9f325e0

--- a/.lane/memory/crates/lane/src/worktree.rs/01M0TTST4PCRRDRJKDN0501XVS-prune-ls-and-the-landing-loc.md
+++ b/.lane/memory/crates/lane/src/worktree.rs/01M0TTST4PCRRDRJKDN0501XVS-prune-ls-and-the-landing-loc.md
@@ -2,7 +2,6 @@
 id: 01M0TTST4PCRRDRJKDN0501XVS
 anchor: fn trunk_name
 created: 2026-08-24T21:27:24Z
-branch: rename-sweep-prune
 norm: '1'
 sig: 6388df923cf25623
 body_hash: 1fe611ea9801b789

--- a/.lane/memory/scripts/bench.sh/01M0TMPTRYPFSM840B8F3VVSX1-the-fixture-is-generated-rat.md
+++ b/.lane/memory/scripts/bench.sh/01M0TMPTRYPFSM840B8F3VVSX1-the-fixture-is-generated-rat.md
@@ -2,7 +2,6 @@
 id: 01M0TMPTRYPFSM840B8F3VVSX1
 anchor: '@file'
 created: 2026-08-24T19:14:40Z
-branch: perf-audit
 norm: '1'
 sig: e3b0c44298fc1c14
 body_hash: 1a9b8c52682cd708

--- a/.lane/memory/scripts/check-linux.sh/01M0TWC5X2MRPG4V2MSSEFPZGA-a-linked-worktree-git-file-m.md
+++ b/.lane/memory/scripts/check-linux.sh/01M0TWC5X2MRPG4V2MSSEFPZGA-a-linked-worktree-git-file-m.md
@@ -2,7 +2,6 @@
 id: 01M0TWC5X2MRPG4V2MSSEFPZGA
 anchor: '@file'
 created: 2026-08-24T21:56:09Z
-branch: scripts-and-readme
 norm: '1'
 sig: e3b0c44298fc1c14
 body_hash: 4739ec245ff7190e

--- a/.lane/memory/scripts/test.sh/01M0TWCNXMN78W0QRM93WYJFDW-a-shared-cargo-target-dir-ca.md
+++ b/.lane/memory/scripts/test.sh/01M0TWCNXMN78W0QRM93WYJFDW-a-shared-cargo-target-dir-ca.md
@@ -2,11 +2,11 @@
 id: 01M0TWCNXMN78W0QRM93WYJFDW
 anchor: '@file'
 created: 2026-08-24T21:56:26Z
-branch: scripts-and-readme
 norm: '1'
 sig: e3b0c44298fc1c14
-body_hash: c2c499ae45095bd2
-raw_hash: 0fabad15014070b4
+body_hash: 1155821ac057d4b6
+raw_hash: 05764211695c40fd
+vouched: 2026-08-24T23:11:25Z
 lines: 1-884
 ---
 

--- a/crates/lane/assets/skill.md
+++ b/crates/lane/assets/skill.md
@@ -25,7 +25,8 @@ Where trunk is protected, `lane push` rebases, audits, commits memory, and sends
 lane why src/auth.rs
 ```
 
-Do this for every file you are about to change. The mark on a line is freshness: blank is current, `~` the implementation moved, `!` the described thing changed shape, `x` the symbol is gone, `?` the file's language has no grammar so nothing was checked. A `~` note is often still true — the words are what matter, not the hash.
+Do this for every file you are about to change. `lane why` is the compact reading view;
+run `lane check` when you need freshness and the ids of notes that require action.
 
 Before `lane merge`, run `lane check`. It lists every note that is not fresh, each with the id you need next. Read the note and its current span, then take exactly one action:
 

--- a/crates/lane/src/audit.rs
+++ b/crates/lane/src/audit.rs
@@ -16,8 +16,6 @@ pub struct Options {
 
 pub struct Outcome {
     pub created: Vec<Note>,
-    /// Notes rewritten to remove obsolete branch provenance.
-    pub migrated: usize,
     /// (old path, new path, notes moved) for source files that were renamed, not deleted.
     pub moved: Vec<(String, String, usize)>,
     /// Notes whose baseline predated a normalization change and could not be compared.
@@ -62,7 +60,6 @@ fn eviction_key(
 pub fn run(root: &Path, opts: &Options) -> Result<Outcome> {
     store::fold_legacy_log(root)?;
     let created = store::promote_pending(root)?;
-    let migrated = store::strip_legacy_branches(root)?;
     let touched: HashSet<String> = if opts.base.is_empty() {
         HashSet::new()
     } else {
@@ -151,7 +148,6 @@ pub fn run(root: &Path, opts: &Options) -> Result<Outcome> {
 
     Ok(Outcome {
         created,
-        migrated,
         moved,
         stats,
         rebaselined,
@@ -172,14 +168,6 @@ pub fn report(out: &Outcome, w: &mut dyn Write) -> std::io::Result<()> {
         n(SIG),
         n(MISSING)
     )?;
-
-    if out.migrated > 0 {
-        writeln!(
-            w,
-            "  removed branch provenance from {} note(s)",
-            out.migrated
-        )?;
-    }
 
     if out.rebaselined > 0 {
         writeln!(

--- a/crates/lane/src/audit.rs
+++ b/crates/lane/src/audit.rs
@@ -16,6 +16,8 @@ pub struct Options {
 
 pub struct Outcome {
     pub created: Vec<Note>,
+    /// Notes rewritten to remove obsolete branch provenance.
+    pub migrated: usize,
     /// (old path, new path, notes moved) for source files that were renamed, not deleted.
     pub moved: Vec<(String, String, usize)>,
     /// Notes whose baseline predated a normalization change and could not be compared.
@@ -60,6 +62,7 @@ fn eviction_key(
 pub fn run(root: &Path, opts: &Options) -> Result<Outcome> {
     store::fold_legacy_log(root)?;
     let created = store::promote_pending(root)?;
+    let migrated = store::strip_legacy_branches(root)?;
     let touched: HashSet<String> = if opts.base.is_empty() {
         HashSet::new()
     } else {
@@ -148,6 +151,7 @@ pub fn run(root: &Path, opts: &Options) -> Result<Outcome> {
 
     Ok(Outcome {
         created,
+        migrated,
         moved,
         stats,
         rebaselined,
@@ -168,6 +172,14 @@ pub fn report(out: &Outcome, w: &mut dyn Write) -> std::io::Result<()> {
         n(SIG),
         n(MISSING)
     )?;
+
+    if out.migrated > 0 {
+        writeln!(
+            w,
+            "  removed branch provenance from {} note(s)",
+            out.migrated
+        )?;
+    }
 
     if out.rebaselined > 0 {
         writeln!(

--- a/crates/lane/src/capture.rs
+++ b/crates/lane/src/capture.rs
@@ -110,7 +110,6 @@ fn capture_rev(rev: &str) -> Result<()> {
     let message = git(&["log", "-1", "--format=%B", rev], None)?;
     let subject = git(&["log", "-1", "--format=%s", rev], None)?;
     let root = git::repo_root()?;
-    let branch = git::current_branch();
 
     for result in parse_trailers(&message) {
         let captured = match result {
@@ -159,7 +158,6 @@ fn capture_rev(rev: &str) -> Result<()> {
             text: captured.text,
             path: rel.clone(),
             anchor: captured.anchor.clone(),
-            branch: branch.clone(),
             at: now_iso(),
             supersedes: String::new(),
         };

--- a/crates/lane/src/cli.rs
+++ b/crates/lane/src/cli.rs
@@ -644,7 +644,6 @@ fn note(text: &str, path: &str, anchor: &str, supersedes: Option<&str>) -> Resul
             text: text.to_string(),
             path: rel.clone(),
             anchor: anchor.to_string(),
-            branch: git::current_branch(),
             at: now_iso(),
             supersedes: supersedes.clone(),
         },
@@ -676,32 +675,23 @@ fn why(path: Option<&str>, anchor: Option<&str>) -> Result<i32> {
             .push(note);
     }
 
-    let mut checker = store::Checker::new(&root);
-    for ((file, anchor), mut group) in groups {
-        println!("\n{file}#{anchor}");
+    for (index, ((file, anchor), mut group)) in groups.into_iter().enumerate() {
+        if index > 0 {
+            println!();
+        }
+        if rel.is_some() {
+            println!("[{anchor}]");
+        } else {
+            println!("[{file}@{anchor}]");
+        }
         group.sort_by(|a, b| a.meta.id.cmp(&b.meta.id));
         for note in group {
-            let tier = checker.check(&note).tier;
-            let mark = mark(tier);
-            let tail = if tier == FRESH {
-                String::new()
-            } else {
-                format!("   [{tier}]")
-            };
             println!(
-                "  {mark} {}{tail}",
-                note.body.trim().replace('\n', "\n    ")
-            );
-            println!(
-                "      {} · {} · {}",
+                "  - {} · {}",
                 &note.meta.id[..10.min(note.meta.id.len())],
-                if note.meta.branch.is_empty() {
-                    "?"
-                } else {
-                    &note.meta.branch
-                },
                 note.meta.created.get(..10).unwrap_or("?")
             );
+            println!("    {}", note.body.trim().replace('\n', "\n    "));
         }
     }
     Ok(0)
@@ -1243,7 +1233,6 @@ mod tests {
                     text: text.into(),
                     path: path.into(),
                     anchor: anchor.into(),
-                    branch: "main".into(),
                     at: "2026-08-21T00:00:00Z".into(),
                     supersedes: String::new(),
                 },

--- a/crates/lane/src/note.rs
+++ b/crates/lane/src/note.rs
@@ -15,8 +15,6 @@ pub struct Meta {
     #[serde(default, skip_serializing_if = "String::is_empty")]
     pub created: String,
     #[serde(default, skip_serializing_if = "String::is_empty")]
-    pub branch: String,
-    #[serde(default, skip_serializing_if = "String::is_empty")]
     pub norm: String,
     #[serde(default, skip_serializing_if = "String::is_empty")]
     pub sig: String,
@@ -75,6 +73,37 @@ impl Note {
         }
         std::fs::write(path, self.render())?;
         Ok(())
+    }
+
+    /// Remove provenance written by older Lane versions without disturbing any other
+    /// frontmatter, including fields this binary may not know about yet.
+    pub fn strip_legacy_branch(&mut self) -> Result<bool> {
+        if self.unreadable {
+            return Ok(false);
+        }
+        let Some(rest) = self.raw.strip_prefix("---\n") else {
+            return Ok(false);
+        };
+        let Some(end) = rest.find("\n---") else {
+            return Ok(false);
+        };
+        let front = &rest[..end];
+        if !front.lines().any(|line| line.starts_with("branch:")) {
+            return Ok(false);
+        }
+        let kept = front
+            .lines()
+            .filter(|line| !line.starts_with("branch:"))
+            .collect::<Vec<_>>()
+            .join("\n");
+        let rewritten = format!("---\n{kept}{}", &rest[end..]);
+        let file = self
+            .file
+            .as_deref()
+            .ok_or_else(|| anyhow::anyhow!("note {} has no file", self.meta.id))?;
+        std::fs::write(file, &rewritten)?;
+        self.raw = rewritten;
+        Ok(true)
     }
 }
 
@@ -181,6 +210,25 @@ mod tests {
         let parsed = parse(&file).unwrap();
         assert!(!parsed.unreadable);
         assert_eq!(parsed.render(), parsed.raw);
+    }
+
+    #[test]
+    fn legacy_branch_is_removed_without_losing_unknown_frontmatter() {
+        let root = tempfile::tempdir().unwrap();
+        let file = write_note(root.path(), "src/auth.rs", "seed: constant time");
+        let text = std::fs::read_to_string(&file).unwrap().replacen(
+            "created: 2026-08-19T00:00:00Z\n",
+            "created: 2026-08-19T00:00:00Z\nbranch: fix-login\nfuture: preserved\n",
+            1,
+        );
+        std::fs::write(&file, text).unwrap();
+
+        let mut parsed = parse(&file).unwrap();
+        assert!(parsed.strip_legacy_branch().unwrap());
+        let migrated = std::fs::read_to_string(file).unwrap();
+        assert!(!migrated.contains("branch:"));
+        assert!(migrated.contains("future: preserved"));
+        assert!(migrated.ends_with("seed: constant time\n"));
     }
 
     #[test]

--- a/crates/lane/src/note.rs
+++ b/crates/lane/src/note.rs
@@ -74,37 +74,6 @@ impl Note {
         std::fs::write(path, self.render())?;
         Ok(())
     }
-
-    /// Remove provenance written by older Lane versions without disturbing any other
-    /// frontmatter, including fields this binary may not know about yet.
-    pub fn strip_legacy_branch(&mut self) -> Result<bool> {
-        if self.unreadable {
-            return Ok(false);
-        }
-        let Some(rest) = self.raw.strip_prefix("---\n") else {
-            return Ok(false);
-        };
-        let Some(end) = rest.find("\n---") else {
-            return Ok(false);
-        };
-        let front = &rest[..end];
-        if !front.lines().any(|line| line.starts_with("branch:")) {
-            return Ok(false);
-        }
-        let kept = front
-            .lines()
-            .filter(|line| !line.starts_with("branch:"))
-            .collect::<Vec<_>>()
-            .join("\n");
-        let rewritten = format!("---\n{kept}{}", &rest[end..]);
-        let file = self
-            .file
-            .as_deref()
-            .ok_or_else(|| anyhow::anyhow!("note {} has no file", self.meta.id))?;
-        std::fs::write(file, &rewritten)?;
-        self.raw = rewritten;
-        Ok(true)
-    }
 }
 
 /// A note we cannot parse still has to be visible, so fall back to the whole file as body.
@@ -210,25 +179,6 @@ mod tests {
         let parsed = parse(&file).unwrap();
         assert!(!parsed.unreadable);
         assert_eq!(parsed.render(), parsed.raw);
-    }
-
-    #[test]
-    fn legacy_branch_is_removed_without_losing_unknown_frontmatter() {
-        let root = tempfile::tempdir().unwrap();
-        let file = write_note(root.path(), "src/auth.rs", "seed: constant time");
-        let text = std::fs::read_to_string(&file).unwrap().replacen(
-            "created: 2026-08-19T00:00:00Z\n",
-            "created: 2026-08-19T00:00:00Z\nbranch: fix-login\nfuture: preserved\n",
-            1,
-        );
-        std::fs::write(&file, text).unwrap();
-
-        let mut parsed = parse(&file).unwrap();
-        assert!(parsed.strip_legacy_branch().unwrap());
-        let migrated = std::fs::read_to_string(file).unwrap();
-        assert!(!migrated.contains("branch:"));
-        assert!(migrated.contains("future: preserved"));
-        assert!(migrated.ends_with("seed: constant time\n"));
     }
 
     #[test]

--- a/crates/lane/src/store.rs
+++ b/crates/lane/src/store.rs
@@ -265,7 +265,6 @@ pub struct PendingNote {
     pub text: String,
     pub path: String,
     pub anchor: String,
-    pub branch: String,
     pub at: String,
     #[serde(default, skip_serializing_if = "String::is_empty")]
     pub supersedes: String,
@@ -313,7 +312,6 @@ pub fn promote_pending(root: &Path) -> Result<Vec<Note>> {
             id: ulid(),
             anchor: rec.anchor.clone(),
             created: rec.at,
-            branch: rec.branch,
             norm: crate::syntax::NORM_VERSION.into(),
             supersedes: rec.supersedes.clone(),
             ..Default::default()
@@ -373,6 +371,30 @@ pub fn resolve_id(root: &Path, id: &str) -> Result<Note> {
             anyhow::bail!("{id} matches {n} notes:\n  {}", shown.join("\n  "))
         }
     }
+}
+
+/// Remove obsolete branch provenance from both active and retired notes.
+pub fn strip_legacy_branches(root: &Path) -> Result<usize> {
+    let mut migrated = 0;
+    for tree in [NOTES, ATTIC] {
+        let base = root.join(LANE_DIR).join(tree);
+        if !base.exists() {
+            continue;
+        }
+        for entry in walkdir::WalkDir::new(base)
+            .into_iter()
+            .filter_map(|e| e.ok())
+        {
+            if !entry.file_type().is_file()
+                || !entry.path().extension().is_some_and(|ext| ext == "md")
+            {
+                continue;
+            }
+            let mut note = note::parse(entry.path())?;
+            migrated += usize::from(note.strip_legacy_branch()?);
+        }
+    }
+    Ok(migrated)
 }
 
 /// The replacement carries its own creation fingerprint, so nothing is inherited: a
@@ -916,12 +938,16 @@ mod tests {
             text: "early return leaks token length".into(),
             path: "src/auth.rs".into(),
             anchor: "fn verify".into(),
-            branch: "main".into(),
             at: "2026-08-19T00:00:00Z".into(),
             supersedes: String::new(),
         };
 
         append_pending(root.path(), &pending).unwrap();
+        assert!(
+            !std::fs::read_to_string(pending_path(root.path()))
+                .unwrap()
+                .contains("\"branch\"")
+        );
         assert_eq!(promote_pending(root.path()).unwrap().len(), 1);
         append_pending(root.path(), &pending).unwrap();
         assert!(promote_pending(root.path()).unwrap().is_empty());
@@ -929,17 +955,34 @@ mod tests {
     }
 
     #[test]
+    fn old_pending_records_with_a_branch_still_promote() {
+        let root = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(root.path().join("src")).unwrap();
+        std::fs::write(root.path().join("src/auth.rs"), "pub fn verify() {}\n").unwrap();
+        let pending = pending_path(root.path());
+        std::fs::create_dir_all(pending.parent().unwrap()).unwrap();
+        std::fs::write(
+            &pending,
+            r#"{"text":"legacy","path":"src/auth.rs","anchor":"fn verify","branch":"old-lane","at":"2026-08-19T00:00:00Z"}
+"#,
+        )
+        .unwrap();
+
+        let promoted = promote_pending(root.path()).unwrap();
+        assert_eq!(promoted.len(), 1);
+        assert!(!promoted[0].render().contains("branch:"));
+    }
+
+    #[test]
     fn pending_supersede_links_and_attics_its_predecessor() {
         let root = tempfile::tempdir().unwrap();
         let old = fixture(root.path(), "pub fn v() {}\n");
-        let branch = git::current_branch();
         append_pending(
             root.path(),
             &PendingNote {
                 text: "replacement note".into(),
                 path: "src/a.rs".into(),
                 anchor: "@file".into(),
-                branch,
                 at: "2026-08-21T00:00:00Z".into(),
                 supersedes: old.meta.id.clone(),
             },

--- a/crates/lane/src/store.rs
+++ b/crates/lane/src/store.rs
@@ -373,30 +373,6 @@ pub fn resolve_id(root: &Path, id: &str) -> Result<Note> {
     }
 }
 
-/// Remove obsolete branch provenance from both active and retired notes.
-pub fn strip_legacy_branches(root: &Path) -> Result<usize> {
-    let mut migrated = 0;
-    for tree in [NOTES, ATTIC] {
-        let base = root.join(LANE_DIR).join(tree);
-        if !base.exists() {
-            continue;
-        }
-        for entry in walkdir::WalkDir::new(base)
-            .into_iter()
-            .filter_map(|e| e.ok())
-        {
-            if !entry.file_type().is_file()
-                || !entry.path().extension().is_some_and(|ext| ext == "md")
-            {
-                continue;
-            }
-            let mut note = note::parse(entry.path())?;
-            migrated += usize::from(note.strip_legacy_branch()?);
-        }
-    }
-    Ok(migrated)
-}
-
 /// The replacement carries its own creation fingerprint, so nothing is inherited: a
 /// confirmation of the old id vouched for the old sentence, not this one.
 pub fn supersede(root: &Path, old: &mut Note, fresh: &Note) -> Result<()> {
@@ -952,25 +928,6 @@ mod tests {
         append_pending(root.path(), &pending).unwrap();
         assert!(promote_pending(root.path()).unwrap().is_empty());
         assert_eq!(load_notes(root.path(), Some("src/auth.rs")).len(), 1);
-    }
-
-    #[test]
-    fn old_pending_records_with_a_branch_still_promote() {
-        let root = tempfile::tempdir().unwrap();
-        std::fs::create_dir_all(root.path().join("src")).unwrap();
-        std::fs::write(root.path().join("src/auth.rs"), "pub fn verify() {}\n").unwrap();
-        let pending = pending_path(root.path());
-        std::fs::create_dir_all(pending.parent().unwrap()).unwrap();
-        std::fs::write(
-            &pending,
-            r#"{"text":"legacy","path":"src/auth.rs","anchor":"fn verify","branch":"old-lane","at":"2026-08-19T00:00:00Z"}
-"#,
-        )
-        .unwrap();
-
-        let promoted = promote_pending(root.path()).unwrap();
-        assert_eq!(promoted.len(), 1);
-        assert!(!promoted[0].render().contains("branch:"));
     }
 
     #[test]

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -643,6 +643,18 @@ echo "== 29. reading context does not modify the tree =="
 setup
 "$LANE" note -p src/auth.rs -a "fn verify" "must stay constant-time" > /dev/null
 "$LANE" audit > /dev/null
+WHY_NOTE=$(find .lane/memory/src/auth.rs -type f -name '*.md' | head -n 1)
+WHY_ID=$(basename "$WHY_NOTE" | cut -c1-10)
+WHY_DATE=$(awk '/^created:/{print substr($2, 1, 10); exit}' "$WHY_NOTE")
+is "lane why uses the compact note format" \
+  "$("$LANE" why src/auth.rs)" \
+  "[fn verify]
+  - $WHY_ID · $WHY_DATE
+    must stay constant-time"
+is "the whole-store view keeps paths unambiguous" \
+  "$("$LANE" why | head -n 1)" "[src/auth.rs@fn verify]"
+is "new notes do not track their branch" \
+  "$(grep -R '^branch:' .lane/memory .lane/attic 2>/dev/null || true)" ""
 git add -A .lane && git commit -qm "memory" > /dev/null
 "$LANE" why src/auth.rs > /dev/null
 is "lane why leaves the tree clean" "$(git status --porcelain)" ""

--- a/www/src/data/commands.ts
+++ b/www/src/data/commands.ts
@@ -73,11 +73,11 @@ export let commands: Command[] = [
 	{
 		name: "why",
 		usage: "lane why [<path>] [-a <anchor>]",
-		summary: "prints the notes for a path, each with a freshness mark. A pure read; it changes nothing.",
+		summary: "prints the notes for a path in compact form. A pure read; it changes nothing.",
 		options: [
 			{ flag: "-a, --anchor", arg: "<anchor>", about: "show only the notes on this anchor." },
 		],
-		example: "$ lane why src/auth.rs\n\nsrc/auth.rs#fn verify\n    must stay constant-time; early return leaks length\n      01M0B9MBYB · fix-login · 2026-08-14\n  ~ callers rely on false-on-expiry   [content-changed]\n      01M0B4KQTX · rate-limit · 2026-07-30",
+		example: "$ lane why src/auth.rs\n\n[fn verify]\n  - 01M0B4KQTX · 2026-07-30\n    callers rely on false-on-expiry\n  - 01M0B9MBYB · 2026-08-14\n    must stay constant-time; early return leaks length",
 	},
 	{
 		name: "holds",

--- a/www/src/pages/index.astro
+++ b/www/src/pages/index.astro
@@ -162,9 +162,9 @@ noted -&gt; src/auth.rs#fn verify
 
 <span class="p">$ </span><b>lane why src/auth.rs</b>
 
-src/auth.rs#fn verify
-    must stay constant-time; early return leaks token length
-      01M0B9MBYB · fix-login · 2026-08-14</pre>
+[fn verify]
+  - 01M0B9MBYB · 2026-08-14
+    must stay constant-time; early return leaks token length</pre>
 
 				<p class="lede">
 					Or leave it in the commit you were already writing. <b>lane install hooks</b> reads one
@@ -238,11 +238,11 @@ src/auth.rs#fn verify
 				</p>
 				<pre class="block"><span class="p">$ </span><b>lane why src/auth.rs</b>
 
-src/auth.rs#fn verify
+[fn verify]
+  - 01M0B9MBYB · 2026-08-14
     must stay constant-time; early return leaks token length
-      01M0B9MBYB · agent-b · 2026-08-14
-    the token bytes must never reach a log, even at debug
-      01M0B9MZQ4 · agent-c · 2026-08-14</pre>
+  - 01M0B9MZQ4 · 2026-08-14
+    the token bytes must never reach a log, even at debug</pre>
 				<p class="note">
 					<b>lane init</b> writes a four-line protocol into <b>AGENTS.md</b> so the notes are already
 					in context. Notes are plain markdown at predictable paths — an agent finds them with no

--- a/www/src/pages/memory.md
+++ b/www/src/pages/memory.md
@@ -64,9 +64,9 @@ made by hand:
 ```
 $ lane why src/auth.rs
 
-src/auth.rs#fn verify
+[fn verify]
+  - 01M0B9MBYB · 2026-08-19
     early return leaks token length
-      01M0B9MBYB · main · 2026-08-19
 ```
 
 ### Hand the line to an agent

--- a/www/src/pages/usage.md
+++ b/www/src/pages/usage.md
@@ -128,16 +128,17 @@ command with no taxonomy decision.
 ```bash
 $ lane why src/auth.rs
 
-src/auth.rs#fn verify
+[fn verify]
+  - 01M0B4KQTX · 2026-07-30
+    callers rely on false-on-expiry, not an error
+  - 01M0B9MBYB · 2026-08-14
     must stay constant-time; early return leaks token length
-      01M0B9MBYB · fix-login · 2026-08-14
-  ~ callers rely on false-on-expiry, not an error
-      01M0B4KQTX · rate-limit · 2026-07-30   [content-changed]
 ```
 
-The leading mark is freshness: blank is fresh, `~` drifted, `!` the signature
-changed, `x` the anchor is gone. Reading a note is not a vote for it: you often
-read one to find out it is wrong.
+The path is omitted from headers because the command already names it. The whole-store
+form, `lane why`, keeps `path@anchor` in each header so groups remain unambiguous.
+`lane why` changes nothing and carries no branch provenance. Run `lane check` to see
+whether a note's anchored code has drifted and get the id needed to resolve it.
 
 ### Close the lane
 


### PR DESCRIPTION
## Summary

- render path-scoped lane why groups as [anchor], with short id and date before the note
- retain path@anchor only in the whole-store view
- stop recording Git branches in pending or promoted notes and remove branch keys from this repository memory
- replace the unverifiable Cargo.toml note with a whole-file note and refresh docs

## Testing

- cargo test --workspace
- ./scripts/test.sh (188 passed)
- cd www && bun run build
- cargo run --quiet -p lane -- check (37 fresh)