### PR TITLE
feat: add guided note editing

### DIFF
--- a/.lane/memory/crates/lane/src/cli.rs/01M0VDBT5Q5PRNNTXM9V05H9BB-interactive-edit-delegates-t.md
+++ b/.lane/memory/crates/lane/src/cli.rs/01M0VDBT5Q5PRNNTXM9V05H9BB-interactive-edit-delegates-t.md
@@ -4,8 +4,9 @@ anchor: fn edit
 created: 2026-08-25T02:52:32Z
 norm: '1'
 sig: 56ae3c36773512c5
-body_hash: a4ca38e4d24ff7f2
-raw_hash: c54994c13327b600
+body_hash: cdb2b0a16e096114
+raw_hash: 33ce2f89361a3924
+vouched: 2026-08-25T04:11:56Z
 lines: 912-961
 ---
 

--- a/.lane/memory/crates/lane/src/cli.rs/01M0VDBT5Q5PRNNTXM9V05H9BB-interactive-edit-delegates-t.md
+++ b/.lane/memory/crates/lane/src/cli.rs/01M0VDBT5Q5PRNNTXM9V05H9BB-interactive-edit-delegates-t.md
@@ -1,0 +1,12 @@
+---
+id: 01M0VDBT5Q5PRNNTXM9V05H9BB
+anchor: fn edit
+created: 2026-08-25T02:52:32Z
+norm: '1'
+sig: 56ae3c36773512c5
+body_hash: a4ca38e4d24ff7f2
+raw_hash: c54994c13327b600
+lines: 912-961
+---
+
+Interactive edit delegates to lifecycle verbs so replacement preserves immutable-note semantics and every guard stays shared.

--- a/.lane/memory/crates/lane/src/cli.rs/01M0VHWP13ADE2AFDFDQQMBWZ3-unreadable-frontmatter-erase.md
+++ b/.lane/memory/crates/lane/src/cli.rs/01M0VHWP13ADE2AFDFDQQMBWZ3-unreadable-frontmatter-erase.md
@@ -1,0 +1,12 @@
+---
+id: 01M0VHWP13ADE2AFDFDQQMBWZ3
+anchor: fn note_replace
+created: 2026-08-25T04:11:50Z
+norm: '1'
+sig: 024fddbb2ab04902
+body_hash: cf187d54dfcce943
+raw_hash: 5abd5e7379db9594
+lines: 723-751
+---
+
+Unreadable frontmatter erases anchor metadata; replacement must refuse it or the recovered empty anchor canonicalizes to @file.

--- a/crates/lane/assets/skill.md
+++ b/crates/lane/assets/skill.md
@@ -38,6 +38,10 @@ Before `lane merge`, run `lane check`. It lists every note that is not fresh, ea
 - `lane note replace <id> "<rewrite>"` when the subject is still right but the sentence is wrong. It inherits the predecessor's path and anchor unless you override them.
 - `lane note retire <id>` when the constraint is gone.
 
+At a terminal, `lane note edit <id>` shows the live note and guides a human through
+the same actions, including pin or unpin. Agents and scripts should use the direct
+commands above so they never depend on prompts.
+
 Any unambiguous prefix of an id works, so the ten characters `lane check` and `lane why` print are enough. `lane check --json` carries the same rows plus each note's body and current span, for when you would rather not open the files.
 
 A `?` cannot be resolved because the file has no grammar. An `x` means the symbol is gone; let audit move that note to the attic instead of vouching for it.

--- a/crates/lane/src/args.rs
+++ b/crates/lane/src/args.rs
@@ -37,7 +37,7 @@ const COMMANDS: &[&str] = &[
 ];
 
 const NOTE_COMMANDS: &[&str] = &[
-    "add", "replace", "confirm", "retire", "restore", "pin", "unpin",
+    "add", "edit", "replace", "confirm", "retire", "restore", "pin", "unpin",
 ];
 
 /// How much memory one `(path, anchor)` may keep. Shared by `audit` and `merge`,
@@ -89,6 +89,7 @@ pub struct NoteReplaceArgs {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum NoteCommand {
     Add(NoteAddArgs),
+    Edit { id: String },
     Replace(NoteReplaceArgs),
     Confirm { id: String },
     Retire { id: String },
@@ -347,6 +348,7 @@ fn parse_note(raw: Vec<OsString>) -> Result<Parsed> {
     let head = raw.first().and_then(|a| a.to_str()).map(str::to_owned);
     match head.as_deref() {
         Some("add") => parse_note_add(rest(raw)),
+        Some("edit") => parse_note_id(rest(raw), Help::NoteEdit, |id| NoteCommand::Edit { id }),
         Some("replace") => parse_note_replace(rest(raw)),
         Some("confirm") => parse_note_id(rest(raw), Help::NoteConfirm, |id| NoteCommand::Confirm {
             id,

--- a/crates/lane/src/cli.rs
+++ b/crates/lane/src/cli.rs
@@ -52,6 +52,7 @@ pub fn run() -> Result<i32> {
         Parsed::Anchors { path, json } => anchors(&path, json),
         Parsed::Note(command) => match command {
             NoteCommand::Add(args) => note_add(args),
+            NoteCommand::Edit { id } => edit(&id),
             NoteCommand::Replace(args) => note_replace(args),
             NoteCommand::Confirm { id } => confirm(&id),
             NoteCommand::Retire { id } => retire(&id),
@@ -906,6 +907,57 @@ fn confirm(id: &str) -> Result<i32> {
     // The whole id, not the prefix you typed, so you can see which note you confirmed.
     println!("confirmed -> {}", audit::confirm(&git::repo_root()?, id)?);
     Ok(0)
+}
+
+fn edit(id: &str) -> Result<i32> {
+    let root = git::repo_root()?;
+    let note = store::resolve_id(&root, id)?;
+    let stdin = std::io::stdin();
+    let stderr = std::io::stderr();
+    if !stdin.is_terminal() || !stderr.is_terminal() {
+        bail!(
+            "note edit requires stdin and stderr terminals; use a direct `lane note <action>` command instead"
+        );
+    }
+
+    let full_id = note.meta.id.clone();
+    let path = note.path();
+    let status = if note.unreadable {
+        "unreadable"
+    } else {
+        store::Checker::new(&root).check(&note).tier
+    };
+    let pinned = note.meta.pinned;
+    let mut input = stdin.lock();
+    let mut output = stderr.lock();
+    writeln!(output, "Editing {full_id}")?;
+    writeln!(output, "  {path}#{}", note.meta.anchor)?;
+    writeln!(
+        output,
+        "  status: {status}{}",
+        if pinned { ", pinned" } else { "" }
+    )?;
+    writeln!(output, "  {}", note.body.trim().replace('\n', "\n  "))?;
+    let action = prompt::select_edit_action(&mut input, &mut output, pinned)?;
+    let replacement = if action == prompt::EditAction::Replace {
+        Some(prompt::read_replacement(&mut input, &mut output)?)
+    } else {
+        None
+    };
+    drop(output);
+    drop(input);
+
+    match action {
+        prompt::EditAction::Confirm => confirm(&full_id),
+        prompt::EditAction::Replace => note_replace(NoteReplaceArgs {
+            id: full_id,
+            text: replacement,
+            path: None,
+            anchor: None,
+        }),
+        prompt::EditAction::Retire => retire(&full_id),
+        prompt::EditAction::SetPinned(pinned) => pin(&full_id, pinned),
+    }
 }
 
 fn retire(id: &str) -> Result<i32> {

--- a/crates/lane/src/cli.rs
+++ b/crates/lane/src/cli.rs
@@ -724,6 +724,9 @@ fn note_replace(args: NoteReplaceArgs) -> Result<i32> {
     let root = git::repo_root()?;
     let predecessor = store::resolve_id(&root, &args.id)?;
     let predecessor_id = predecessor.meta.id.clone();
+    if predecessor.unreadable {
+        bail!("cannot replace note {predecessor_id}: frontmatter is unreadable");
+    }
     let (path, anchor) = replacement_target(&predecessor, args.path, args.anchor);
     let rel = store::rel_to_repo(&root, &path)?;
     if !root.join(&rel).exists() {
@@ -910,8 +913,6 @@ fn confirm(id: &str) -> Result<i32> {
 }
 
 fn edit(id: &str) -> Result<i32> {
-    let root = git::repo_root()?;
-    let note = store::resolve_id(&root, id)?;
     let stdin = std::io::stdin();
     let stderr = std::io::stderr();
     if !stdin.is_terminal() || !stderr.is_terminal() {
@@ -920,13 +921,16 @@ fn edit(id: &str) -> Result<i32> {
         );
     }
 
+    let root = git::repo_root()?;
+    let note = store::resolve_id(&root, id)?;
     let full_id = note.meta.id.clone();
+    if note.unreadable {
+        bail!(
+            "cannot edit note {full_id}: frontmatter is unreadable; use `lane note retire {full_id}` to preserve it unchanged"
+        );
+    }
     let path = note.path();
-    let status = if note.unreadable {
-        "unreadable"
-    } else {
-        store::Checker::new(&root).check(&note).tier
-    };
+    let status = store::Checker::new(&root).check(&note).tier;
     let pinned = note.meta.pinned;
     let mut input = stdin.lock();
     let mut output = stderr.lock();

--- a/crates/lane/src/help.rs
+++ b/crates/lane/src/help.rs
@@ -18,6 +18,7 @@ pub enum Help {
     Anchors,
     Note,
     NoteAdd,
+    NoteEdit,
     NoteReplace,
     NoteConfirm,
     NoteRetire,
@@ -48,6 +49,7 @@ impl Help {
             Help::Anchors => ANCHORS,
             Help::Note => NOTE,
             Help::NoteAdd => NOTE_ADD,
+            Help::NoteEdit => NOTE_EDIT,
             Help::NoteReplace => NOTE_REPLACE,
             Help::NoteConfirm => NOTE_CONFIRM,
             Help::NoteRetire => NOTE_RETIRE,
@@ -78,6 +80,7 @@ impl Help {
             Help::Anchors => "lane anchors [--json] <PATH>",
             Help::Note => "lane note <COMMAND>",
             Help::NoteAdd => "lane note add [OPTIONS] <PATH> [TEXT]",
+            Help::NoteEdit => "lane note edit <ID>",
             Help::NoteReplace => "lane note replace [OPTIONS] <ID> [TEXT]",
             Help::NoteConfirm => "lane note confirm <ID>",
             Help::NoteRetire => "lane note retire <ID>",
@@ -120,6 +123,7 @@ impl Help {
             Help::Anchors => "lane anchors",
             Help::Note => "lane note",
             Help::NoteAdd => "lane note add",
+            Help::NoteEdit => "lane note edit",
             Help::NoteReplace => "lane note replace",
             Help::NoteConfirm => "lane note confirm",
             Help::NoteRetire => "lane note retire",
@@ -251,19 +255,33 @@ const ANCHORS: &str = "
 
 const NOTE: &str = "
   Description
-    Add, replace, confirm, retire, restore, pin, or unpin a note.
+    Add or interactively edit a note, or apply one lifecycle action directly.
 
   Usage
     $ lane note <command>
 
   Commands
     add        Record a finding
+    edit       Choose a lifecycle action interactively
     replace    Queue a replacement
     confirm    Confirm a drifted note is still true
     retire     Move a live note to the attic
     restore    Restore a retired note
     pin        Protect a live note from eviction
     unpin      Remove eviction protection
+
+  Options
+    -h, --help    Display this message
+";
+
+const NOTE_EDIT: &str = "
+  Description
+    Show a live note and interactively choose to confirm it, replace its text,
+    retire it, or toggle its eviction protection. Text replacement creates a
+    successor instead of rewriting the existing note.
+
+  Usage
+    $ lane note edit <id>
 
   Options
     -h, --help    Display this message

--- a/crates/lane/src/prompt.rs
+++ b/crates/lane/src/prompt.rs
@@ -2,6 +2,14 @@ use crate::syntax::Anchor;
 use anyhow::{Result, bail};
 use std::io::{BufRead, Write};
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum EditAction {
+    Confirm,
+    Replace,
+    Retire,
+    SetPinned(bool),
+}
+
 pub(crate) fn select_anchor<R: BufRead, W: Write>(
     input: &mut R,
     output: &mut W,
@@ -44,7 +52,18 @@ pub(crate) fn select_anchor<R: BufRead, W: Write>(
 }
 
 pub(crate) fn read_note<R: BufRead, W: Write>(input: &mut R, output: &mut W) -> Result<String> {
-    write!(output, "Note: ")?;
+    read_text(input, output, "Note")
+}
+
+pub(crate) fn read_replacement<R: BufRead, W: Write>(
+    input: &mut R,
+    output: &mut W,
+) -> Result<String> {
+    read_text(input, output, "Replacement")
+}
+
+fn read_text<R: BufRead, W: Write>(input: &mut R, output: &mut W, label: &str) -> Result<String> {
+    write!(output, "{label}: ")?;
     output.flush()?;
     let mut line = String::new();
     if input.read_line(&mut line)? == 0 {
@@ -55,6 +74,39 @@ pub(crate) fn read_note<R: BufRead, W: Write>(input: &mut R, output: &mut W) -> 
         bail!("note text cannot be empty");
     }
     Ok(text.to_string())
+}
+
+pub(crate) fn select_edit_action<R: BufRead, W: Write>(
+    input: &mut R,
+    output: &mut W,
+    pinned: bool,
+) -> Result<EditAction> {
+    let (pin_verb, pin_description) = if pinned {
+        ("unpin", "remove eviction protection")
+    } else {
+        ("pin", "protect from eviction")
+    };
+    writeln!(output, "Action:")?;
+    writeln!(output, "  1. confirm — still true")?;
+    writeln!(output, "  2. replace — change the text")?;
+    writeln!(output, "  3. retire — no longer applies")?;
+    writeln!(output, "  4. {pin_verb} — {pin_description}")?;
+
+    loop {
+        write!(output, "Choose [1-4]: ")?;
+        output.flush()?;
+        let mut line = String::new();
+        if input.read_line(&mut line)? == 0 {
+            bail!("no edit action selected");
+        }
+        match line.trim() {
+            "1" => return Ok(EditAction::Confirm),
+            "2" => return Ok(EditAction::Replace),
+            "3" => return Ok(EditAction::Retire),
+            "4" => return Ok(EditAction::SetPinned(!pinned)),
+            _ => writeln!(output, "Enter a number from 1 to 4.")?,
+        }
+    }
 }
 
 #[cfg(test)]
@@ -142,5 +194,51 @@ mod tests {
             "no note text entered"
         );
         assert_eq!(String::from_utf8(eof_output).unwrap(), "Note: ");
+    }
+
+    #[test]
+    fn edit_selects_an_action_and_labels_the_pin_toggle() {
+        let mut input = Cursor::new(b"2\n");
+        let mut output = Vec::new();
+        assert_eq!(
+            select_edit_action(&mut input, &mut output, false).unwrap(),
+            EditAction::Replace
+        );
+        assert_eq!(
+            String::from_utf8(output).unwrap(),
+            concat!(
+                "Action:\n",
+                "  1. confirm — still true\n",
+                "  2. replace — change the text\n",
+                "  3. retire — no longer applies\n",
+                "  4. pin — protect from eviction\n",
+                "Choose [1-4]: "
+            )
+        );
+
+        let mut input = Cursor::new(b"4\n");
+        let mut output = Vec::new();
+        assert_eq!(
+            select_edit_action(&mut input, &mut output, true).unwrap(),
+            EditAction::SetPinned(false)
+        );
+        assert!(String::from_utf8(output).unwrap().contains("4. unpin —"));
+    }
+
+    #[test]
+    fn edit_retries_an_invalid_action_and_reads_replacement_text() {
+        let mut input = Cursor::new(b"nope\n2\nreplacement text\n");
+        let mut output = Vec::new();
+        assert_eq!(
+            select_edit_action(&mut input, &mut output, false).unwrap(),
+            EditAction::Replace
+        );
+        assert_eq!(
+            read_replacement(&mut input, &mut output).unwrap(),
+            "replacement text"
+        );
+        let output = String::from_utf8(output).unwrap();
+        assert!(output.contains("Choose [1-4]: Enter a number from 1 to 4.\nChoose [1-4]: "));
+        assert!(output.ends_with("Replacement: "));
     }
 }

--- a/crates/lane/tests/args.rs
+++ b/crates/lane/tests/args.rs
@@ -226,6 +226,7 @@ fn note_family_and_leaf_help_route_to_their_own_screens() {
     assert_eq!(ok(&["note", "--help"]), Parsed::Help(Help::Note));
     for (verb, screen) in [
         ("add", Help::NoteAdd),
+        ("edit", Help::NoteEdit),
         ("replace", Help::NoteReplace),
         ("confirm", Help::NoteConfirm),
         ("retire", Help::NoteRetire),
@@ -302,6 +303,12 @@ fn note_replace_parses_an_id_optional_text_and_overrides() {
 fn note_id_verbs_take_exactly_one_id() {
     for (verb, expected) in [
         (
+            "edit",
+            NoteCommand::Edit {
+                id: "01M0G2".into(),
+            },
+        ),
+        (
             "confirm",
             NoteCommand::Confirm {
                 id: "01M0G2".into(),
@@ -351,9 +358,11 @@ fn note_double_dash_preserves_text_that_starts_with_a_dash() {
 #[test]
 fn note_commands_refuse_missing_and_extra_values() {
     assert_eq!(absent(&["note", "add"]), ["<PATH>"]);
+    assert_eq!(absent(&["note", "edit"]), ["<ID>"]);
     assert_eq!(absent(&["note", "confirm"]), ["<ID>"]);
     assert!(err(&["note", "add", "one", "two", "three"]).contains("'three'"));
     assert!(err(&["note", "pin", "one", "two"]).contains("'two'"));
+    assert!(err(&["note", "edit", "one", "two"]).contains("'two'"));
     assert!(err(&["note", "replace", "one", "two", "three"]).contains("'three'"));
     assert!(err(&["note", "retier", "01M0G2"]).contains("'retire'"));
 }

--- a/readme.md
+++ b/readme.md
@@ -113,6 +113,7 @@ lane new spike --dirty               # carry uncommitted work too
 lane ls
 lane anchors src/auth.rs             # discover canonical anchors and line ranges
 lane note add src/auth.rs -a "fn verify" "..."  # record a finding
+lane note edit <id>                              # choose a lifecycle action interactively
 lane note replace <id> "replacement text"       # queue a successor
 lane note confirm <id>                           # re-vouch for a drifted note
 lane note retire <id>                            # move a live note to the attic
@@ -159,6 +160,9 @@ lane note confirm <id>
 lane note replace <id> '<replacement>'
 lane note retire <id>
 ```
+
+Run `lane note edit <id>` for a guided terminal menu over the same actions,
+including pinning or unpinning the note.
 
 Replacement inherits the live note's path and anchor. Retire and restore move bytes unchanged between live memory and the attic; pin and unpin control eviction. For a new note, supplied text never prompts and defaults to `@file` without `-a`; omit text to opt into the interactive anchor selector and one-line prompt.
 

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -777,6 +777,12 @@ BEFORE=$(cksum < "$F")
 is "confirm refuses damaged frontmatter" \
    "$("$LANE" note confirm "$ID" 2>&1 | grep -c 'frontmatter is unreadable')" "1"
 is "confirm leaves damaged frontmatter byte-identical" "$(cksum < "$F")" "$BEFORE"
+BEFORE_PENDING=$(pending_lines)
+"$LANE" note replace "$ID" "replacement must not lose its anchor" > /tmp/damaged-replace.out 2>&1
+is "replace refuses damaged frontmatter without changing bytes or pending notes" \
+   "$([ "$?" -eq 1 ] && grep -q 'frontmatter is unreadable' /tmp/damaged-replace.out \
+      && [ "$(cksum < "$F")" = "$BEFORE" ] && [ "$(pending_lines)" = "$BEFORE_PENDING" ] \
+      && echo yes)" "yes"
 
 echo "== 31c. the explicit note lifecycle is guarded and reversible =="
 setup
@@ -800,7 +806,7 @@ is "missing text over non-terminal stdin fails without appending" \
 "$LANE" audit > /dev/null
 OLD_FILE=$(find .lane/memory/src/auth.rs -name '*.md' | head -1)
 OLD_ID=$(basename "$OLD_FILE" | cut -d- -f1)
-"$LANE" note edit "$OLD_ID" < /dev/null > /tmp/nonterminal-edit.out 2>&1
+"$LANE" note edit NOT-A-NOTE < /dev/null > /tmp/nonterminal-edit.out 2>&1
 is "note edit refuses non-terminal use with direct-command guidance" \
    "$([ "$?" -eq 1 ] && grep -q 'requires stdin and stderr terminals' /tmp/nonterminal-edit.out \
       && grep -q 'lane note <action>' /tmp/nonterminal-edit.out && echo yes)" "yes"

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -800,6 +800,10 @@ is "missing text over non-terminal stdin fails without appending" \
 "$LANE" audit > /dev/null
 OLD_FILE=$(find .lane/memory/src/auth.rs -name '*.md' | head -1)
 OLD_ID=$(basename "$OLD_FILE" | cut -d- -f1)
+"$LANE" note edit "$OLD_ID" < /dev/null > /tmp/nonterminal-edit.out 2>&1
+is "note edit refuses non-terminal use with direct-command guidance" \
+   "$([ "$?" -eq 1 ] && grep -q 'requires stdin and stderr terminals' /tmp/nonterminal-edit.out \
+      && grep -q 'lane note <action>' /tmp/nonterminal-edit.out && echo yes)" "yes"
 "$LANE" note replace "$OLD_ID" "replacement rule" > /dev/null
 is "replace inherits the predecessor path" \
    "$(python3 -c 'import json; print(json.loads(open(".git/lane/pending.jsonl").readline())["path"])')" \

--- a/www/src/data/commands.ts
+++ b/www/src/data/commands.ts
@@ -80,6 +80,13 @@ export let commands: Command[] = [
 		example: "$ lane note add src/auth.rs -a \"fn verify\" \\\n    \"must stay constant-time; early return leaks length\"\nnoted -> src/auth.rs#fn verify",
 	},
 	{
+		name: "note edit",
+		usage: "lane note edit <id>",
+		summary: "shows a live note and interactively chooses one lifecycle action: confirm, replace text, retire, or toggle pinning.",
+		options: [],
+		example: "$ lane note edit 01M0B4KQTX\nEditing 01M0B4KQTX7H3EZ8FE7S6BJ91N\n  src/auth.rs#fn verify\n  status: content-changed\n  must stay constant-time\nAction:\n  1. confirm — still true\n  2. replace — change the text\n  3. retire — no longer applies\n  4. pin — protect from eviction\nChoose [1-4]: 1\nconfirmed -> 01M0B4KQTX7H3EZ8FE7S6BJ91N",
+	},
+	{
 		name: "note replace",
 		usage: "lane note replace [-p <path>] [-a <anchor>] <id> [text]",
 		summary: "queues a successor that inherits the live predecessor's path and anchor; promotion retires the predecessor.",

--- a/www/src/pages/usage.md
+++ b/www/src/pages/usage.md
@@ -246,7 +246,8 @@ Read the note and the code it points at, then take one action: `lane note confir
 <id>` when the sentence remains true; `lane note replace <id> "<rewrite>"` when
 the subject is right but the sentence must change; or `lane note retire <id>`
 when the constraint is gone. Replacement inherits the predecessor's path and
-anchor unless you override them. Lane never calls a model.
+anchor unless you override them. At a terminal, `lane note edit <id>` presents
+these actions plus pin/unpin as a guided menu. Lane never calls a model.
 
 Any unambiguous prefix of an id works, so the ten characters above are enough;
 an ambiguous one is refused and names what it matched. Add `--json` for the same
@@ -342,6 +343,7 @@ The short version. See [commands](/commands) for full information.
 | `lane path <name>` | print a lane's path |
 | `lane anchors <file> [--json]` | list canonical anchors and line ranges |
 | `lane note add <file> [-a <anchor>] [<text>]` | record a finding; omit text for interaction |
+| `lane note edit <id>` | interactively confirm, replace, retire, pin, or unpin a live note |
 | `lane note replace <id> [<text>]` | queue a successor, inheriting path and anchor |
 | `lane note confirm <id>` | re-vouch for a resolved live note |
 | `lane note retire <id>` | move a live note to the attic |


### PR DESCRIPTION
## Summary
- add an interactive lane note edit <id> action menu
- delegate confirm, replace, retire, and pin/unpin to existing lifecycle operations
- keep prompts terminal-only and on stderr
- document the command in built-in help, README, shipped skill, and website

## Verification
- cargo fmt --all --check
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test --workspace
- ./scripts/test.sh (222 passed, 0 failed)
- cd www && bun run build
- pseudo-terminal smoke tests for pin and text replacement