### PR TITLE
fix: guard interactive note editing

### DIFF
--- a/.lane/memory/crates/lane/src/cli.rs/01M0VDBT5Q5PRNNTXM9V05H9BB-interactive-edit-delegates-t.md
+++ b/.lane/memory/crates/lane/src/cli.rs/01M0VDBT5Q5PRNNTXM9V05H9BB-interactive-edit-delegates-t.md
@@ -4,8 +4,9 @@ anchor: fn edit
 created: 2026-08-25T02:52:32Z
 norm: '1'
 sig: 56ae3c36773512c5
-body_hash: a4ca38e4d24ff7f2
-raw_hash: c54994c13327b600
+body_hash: cdb2b0a16e096114
+raw_hash: 33ce2f89361a3924
+vouched: 2026-08-25T04:11:56Z
 lines: 912-961
 ---
 

--- a/.lane/memory/crates/lane/src/cli.rs/01M0VHWP13ADE2AFDFDQQMBWZ3-unreadable-frontmatter-erase.md
+++ b/.lane/memory/crates/lane/src/cli.rs/01M0VHWP13ADE2AFDFDQQMBWZ3-unreadable-frontmatter-erase.md
@@ -1,0 +1,12 @@
+---
+id: 01M0VHWP13ADE2AFDFDQQMBWZ3
+anchor: fn note_replace
+created: 2026-08-25T04:11:50Z
+norm: '1'
+sig: 024fddbb2ab04902
+body_hash: cf187d54dfcce943
+raw_hash: 5abd5e7379db9594
+lines: 723-751
+---
+
+Unreadable frontmatter erases anchor metadata; replacement must refuse it or the recovered empty anchor canonicalizes to @file.

--- a/crates/lane/src/cli.rs
+++ b/crates/lane/src/cli.rs
@@ -724,6 +724,9 @@ fn note_replace(args: NoteReplaceArgs) -> Result<i32> {
     let root = git::repo_root()?;
     let predecessor = store::resolve_id(&root, &args.id)?;
     let predecessor_id = predecessor.meta.id.clone();
+    if predecessor.unreadable {
+        bail!("cannot replace note {predecessor_id}: frontmatter is unreadable");
+    }
     let (path, anchor) = replacement_target(&predecessor, args.path, args.anchor);
     let rel = store::rel_to_repo(&root, &path)?;
     if !root.join(&rel).exists() {
@@ -910,8 +913,6 @@ fn confirm(id: &str) -> Result<i32> {
 }
 
 fn edit(id: &str) -> Result<i32> {
-    let root = git::repo_root()?;
-    let note = store::resolve_id(&root, id)?;
     let stdin = std::io::stdin();
     let stderr = std::io::stderr();
     if !stdin.is_terminal() || !stderr.is_terminal() {
@@ -920,13 +921,16 @@ fn edit(id: &str) -> Result<i32> {
         );
     }
 
+    let root = git::repo_root()?;
+    let note = store::resolve_id(&root, id)?;
     let full_id = note.meta.id.clone();
+    if note.unreadable {
+        bail!(
+            "cannot edit note {full_id}: frontmatter is unreadable; use `lane note retire {full_id}` to preserve it unchanged"
+        );
+    }
     let path = note.path();
-    let status = if note.unreadable {
-        "unreadable"
-    } else {
-        store::Checker::new(&root).check(&note).tier
-    };
+    let status = store::Checker::new(&root).check(&note).tier;
     let pinned = note.meta.pinned;
     let mut input = stdin.lock();
     let mut output = stderr.lock();

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -777,6 +777,12 @@ BEFORE=$(cksum < "$F")
 is "confirm refuses damaged frontmatter" \
    "$("$LANE" note confirm "$ID" 2>&1 | grep -c 'frontmatter is unreadable')" "1"
 is "confirm leaves damaged frontmatter byte-identical" "$(cksum < "$F")" "$BEFORE"
+BEFORE_PENDING=$(pending_lines)
+"$LANE" note replace "$ID" "replacement must not lose its anchor" > /tmp/damaged-replace.out 2>&1
+is "replace refuses damaged frontmatter without changing bytes or pending notes" \
+   "$([ "$?" -eq 1 ] && grep -q 'frontmatter is unreadable' /tmp/damaged-replace.out \
+      && [ "$(cksum < "$F")" = "$BEFORE" ] && [ "$(pending_lines)" = "$BEFORE_PENDING" ] \
+      && echo yes)" "yes"
 
 echo "== 31c. the explicit note lifecycle is guarded and reversible =="
 setup
@@ -800,7 +806,7 @@ is "missing text over non-terminal stdin fails without appending" \
 "$LANE" audit > /dev/null
 OLD_FILE=$(find .lane/memory/src/auth.rs -name '*.md' | head -1)
 OLD_ID=$(basename "$OLD_FILE" | cut -d- -f1)
-"$LANE" note edit "$OLD_ID" < /dev/null > /tmp/nonterminal-edit.out 2>&1
+"$LANE" note edit NOT-A-NOTE < /dev/null > /tmp/nonterminal-edit.out 2>&1
 is "note edit refuses non-terminal use with direct-command guidance" \
    "$([ "$?" -eq 1 ] && grep -q 'requires stdin and stderr terminals' /tmp/nonterminal-edit.out \
       && grep -q 'lane note <action>' /tmp/nonterminal-edit.out && echo yes)" "yes"


### PR DESCRIPTION
## Summary
- reject unreadable notes before replacement can lose their recovered anchor
- fail terminal-only note edit calls before repository and note-store lookup
- preserve damaged note bytes and pending state on refusal

## Verification
- cargo fmt --all --check
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test --workspace
- ./scripts/test.sh (223 passed, 0 failed)
- cd www && bun run build
- pseudo-terminal smoke test for unreadable edit refusal

Stacked on #19.