### PR TITLE
feat: read notes by directory

### DIFF
--- a/.lane/memory/crates/lane/src/cli.rs/01M0WV1SPFZBRR59DAR0F3GHWR-the-bare-anchor-header-is-ea.md
+++ b/.lane/memory/crates/lane/src/cli.rs/01M0WV1SPFZBRR59DAR0F3GHWR-the-bare-anchor-header-is-ea.md
@@ -1,0 +1,12 @@
+---
+id: 01M0WV1SPFZBRR59DAR0F3GHWR
+anchor: fn why
+created: 2026-08-25T15:58:31Z
+norm: '1'
+sig: 99a1328e8d59200d
+body_hash: f3c205db4e3ff5bb
+raw_hash: fc54df7b2f6f0406
+lines: 841-912
+---
+
+the bare [anchor] header is earned by the argument matching a note's own path, not by a path being supplied; a directory argument that happens to hold one file still needs the path

--- a/crates/lane/assets/skill.md
+++ b/crates/lane/assets/skill.md
@@ -26,11 +26,13 @@ multiple lanes.
 
 ```bash
 lane why src/auth.rs
+lane why src/            # every note beneath a directory
 ```
 
 Do this for every file you are about to change. `lane why` is the compact reading view;
-`lane why --json` returns full ids, paths, anchors, timestamps, and note text. Run
-`lane check` when you need freshness and the ids of notes that require action.
+`lane why --json` returns full ids, paths, anchors, timestamps, and note text. Give it a
+directory to survey an area before you know which file you need. Run `lane check` when
+you need freshness and the ids of notes that require action.
 
 Before `lane merge`, run `lane check`. It lists every note that is not fresh, each with the id you need next. Read the note and its current span, then take exactly one action:
 

--- a/crates/lane/src/cli.rs
+++ b/crates/lane/src/cli.rs
@@ -841,7 +841,7 @@ struct WhyRow {
 fn why(path: Option<&str>, anchor: Option<&str>, json: bool) -> Result<i32> {
     let root = git::repo_root()?;
     let rel = match path {
-        Some(p) => Some(store::rel_to_repo(&root, p)?),
+        Some(p) => store::rel_scope(&root, p)?,
         None => None,
     };
     let mut notes = store::load_notes(&root, rel.as_deref());
@@ -876,6 +876,11 @@ fn why(path: Option<&str>, anchor: Option<&str>, json: bool) -> Result<i32> {
         return Ok(0);
     }
 
+    // Only an argument that is itself a note's path named one file; a directory never does.
+    let one_file = rel
+        .as_deref()
+        .is_some_and(|rel| notes.iter().any(|n| n.path() == rel));
+
     let mut groups: std::collections::BTreeMap<(String, String), Vec<_>> = Default::default();
     for note in notes {
         groups
@@ -888,10 +893,10 @@ fn why(path: Option<&str>, anchor: Option<&str>, json: bool) -> Result<i32> {
         if index > 0 {
             println!();
         }
-        if rel.is_some() {
+        if one_file {
             println!("[{anchor}]");
         } else {
-            println!("[{file}@{anchor}]");
+            println!("[{file}#{anchor}]");
         }
         group.sort_by(|a, b| a.meta.id.cmp(&b.meta.id));
         for note in group {

--- a/crates/lane/src/help.rs
+++ b/crates/lane/src/help.rs
@@ -408,7 +408,8 @@ const UNINSTALL: &str = "
 const WHY: &str = "
   Description
     Print what earlier lanes learned about a path, each note with the id you
-    need to re-vouch for it. With no path, report the whole store.
+    need to re-vouch for it. A directory reports every note beneath it, and no
+    path at all reports the whole store.
 
   Usage
     $ lane why [path] [options]
@@ -421,6 +422,7 @@ const WHY: &str = "
   Examples
     $ lane why src/auth.rs
     $ lane why src/auth.rs -a 'fn verify'
+    $ lane why src/
 ";
 
 const CHECK: &str = "

--- a/crates/lane/src/help.rs
+++ b/crates/lane/src/help.rs
@@ -158,7 +158,7 @@ const ROOT: &str = "
     ls           List lanes
     path         Print a lane's path
     anchors      List addressable anchors in a file
-    note         Record a finding
+    note         Manage memory notes
     install      Install lane's agent integrations
     uninstall    Remove lane's agent integrations
     why          Show context for a path

--- a/crates/lane/src/store.rs
+++ b/crates/lane/src/store.rs
@@ -116,6 +116,9 @@ pub fn attic_dir(root: &Path, path: &str) -> PathBuf {
 }
 
 /// Live notes only; the attic is a sibling of the reserved tree, never inside it.
+///
+/// A filter holds the notes at that path and every note beneath it, so a directory
+/// reads as the whole subtree.
 pub fn load_notes(root: &Path, filter: Option<&str>) -> Vec<Note> {
     load_note_tree(root, NOTES, filter)
 }
@@ -141,8 +144,17 @@ fn load_note_tree(root: &Path, tree: &str, filter: Option<&str>) -> Vec<Note> {
     files
         .iter()
         .filter_map(|p| note::parse(p).ok())
-        .filter(|n| filter.is_none_or(|f| n.path() == f))
+        .filter(|n| filter.is_none_or(|f| within(&n.path(), f)))
         .collect()
+}
+
+/// Whether a note path is the filter itself or sits under it. The boundary is a
+/// whole path component, so `src` never claims `src-gen/lib.rs`.
+pub fn within(path: &str, filter: &str) -> bool {
+    path == filter
+        || path
+            .strip_prefix(filter)
+            .is_some_and(|rest| rest.starts_with('/'))
 }
 
 fn field(entry: &serde_json::Value, key: &str) -> String {
@@ -627,15 +639,22 @@ fn resolved(path: &Path) -> Result<PathBuf> {
 
 /// Repo-relative path, refusing anything that would land outside the store.
 pub fn rel_to_repo(root: &Path, path: &str) -> Result<String> {
+    rel_scope(root, path)?
+        .ok_or_else(|| anyhow::anyhow!("{path} is the repository root, not a file"))
+}
+
+/// The same path for a read that accepts a directory, where the repository root is
+/// `None` because it holds everything and filters nothing.
+pub fn rel_scope(root: &Path, path: &str) -> Result<Option<String>> {
     let abs = resolved(Path::new(path))?;
     let base = resolved(root)?;
     let rel = abs
         .strip_prefix(&base)
         .map_err(|_| anyhow::anyhow!("{path} is outside the repository"))?;
     if rel.as_os_str().is_empty() {
-        anyhow::bail!("{path} is the repository root, not a file");
+        return Ok(None);
     }
-    Ok(rel.to_string_lossy().to_string())
+    Ok(Some(rel.to_string_lossy().to_string()))
 }
 
 pub fn append_pending(root: &Path, rec: &PendingNote) -> Result<()> {
@@ -1105,6 +1124,45 @@ mod tests {
             1
         );
         assert_eq!(load_notes(root.path(), Some("src/token.rs")).len(), 2);
+    }
+
+    #[test]
+    fn a_directory_filter_holds_every_note_beneath_it() {
+        let root = tempfile::tempdir().unwrap();
+        seed_note(root.path(), "src/auth.rs", "01M0A", "at the top");
+        seed_note(root.path(), "src/db/pool.rs", "01M0B", "further down");
+        seed_note(root.path(), "src-gen/lib.rs", "01M0C", "a different tree");
+        seed_note(root.path(), "docs/api.md", "01M0D", "elsewhere");
+
+        let paths = |filter: &str| {
+            let mut found: Vec<String> = load_notes(root.path(), Some(filter))
+                .iter()
+                .map(Note::path)
+                .collect();
+            found.sort();
+            found
+        };
+        assert_eq!(paths("src"), ["src/auth.rs", "src/db/pool.rs"]);
+        assert_eq!(paths("src/db"), ["src/db/pool.rs"]);
+        assert_eq!(paths("src/auth.rs"), ["src/auth.rs"]);
+        assert!(paths("src/au").is_empty());
+    }
+
+    #[test]
+    fn the_repository_root_scopes_to_everything() {
+        let root = tempfile::tempdir().unwrap();
+        let inside = root.path().join("src");
+        std::fs::create_dir_all(&inside).unwrap();
+
+        assert_eq!(
+            rel_scope(root.path(), root.path().to_str().unwrap()).unwrap(),
+            None
+        );
+        assert_eq!(
+            rel_scope(root.path(), inside.to_str().unwrap()).unwrap(),
+            Some("src".into())
+        );
+        assert!(rel_to_repo(root.path(), root.path().to_str().unwrap()).is_err());
     }
 
     #[test]

--- a/readme.md
+++ b/readme.md
@@ -121,6 +121,7 @@ lane note restore <id>                           # restore a retired note
 lane note pin <id>                               # protect a note from eviction
 lane note unpin <id>                             # remove eviction protection
 lane why src/auth.rs                 # read what earlier lanes learned
+lane why src/                        # read every note beneath a directory
 lane merge                           # rebase, audit memory, fast-forward, remove
 lane push                            # rebase, audit, and push for a pull request
 lane prune                           # remove lanes whose branch has landed

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -700,7 +700,19 @@ is "lane why uses the compact note format" \
   - $WHY_ID · $WHY_DATE
     must stay constant-time"
 is "the whole-store view keeps paths unambiguous" \
-  "$("$LANE" why | head -n 1)" "[src/auth.rs@fn verify]"
+  "$("$LANE" why | head -n 1)" "[src/auth.rs#fn verify]"
+is "a directory reads every note beneath it" \
+  "$("$LANE" why src/)" \
+  "[src/auth.rs#fn verify]
+  - $WHY_ID · $WHY_DATE
+    must stay constant-time"
+is "the repository root reads the whole store" \
+  "$("$LANE" why . | head -n 1)" "[src/auth.rs#fn verify]"
+is "a directory json carries the path of every match" \
+  "$("$LANE" why src/ --json | python3 -c 'import json,sys; print([n["path"] for n in json.load(sys.stdin)])')" \
+  "['src/auth.rs']"
+is "a partial name matches no path" \
+  "$("$LANE" why src/au)" "no context for src/au"
 is "why json reports the exact full note row" \
   "$("$LANE" why src/auth.rs --json | python3 -c 'import json,sys; d=json.load(sys.stdin); print(int(d == [{"id":sys.argv[1],"path":"src/auth.rs","anchor":"fn verify","created":sys.argv[2],"note":"must stay constant-time"}]))' "$WHY_FULL_ID" "$WHY_CREATED")" "1"
 is "why json honors an anchor with no matches" \

--- a/www/src/data/commands.ts
+++ b/www/src/data/commands.ts
@@ -134,7 +134,7 @@ export let commands: Command[] = [
 	{
 		name: "why",
 		usage: "lane why [<path>] [-a <anchor>] [--json]",
-		summary: "prints the notes for a path in compact form. A pure read; it changes nothing.",
+		summary: "prints the notes for a path in compact form, or for every path beneath it when the path is a directory. A pure read; it changes nothing.",
 		options: [
 			{ flag: "-a, --anchor", arg: "<anchor>", about: "show only the notes on this anchor." },
 			{ flag: "--json", arg: null, about: "print full note fields as machine-readable JSON." },

--- a/www/src/pages/usage.md
+++ b/www/src/pages/usage.md
@@ -152,8 +152,23 @@ $ lane why src/auth.rs
     must stay constant-time; early return leaks token length
 ```
 
-The path is omitted from headers because the command already names it. The whole-store
-form, `lane why`, keeps `path@anchor` in each header so groups remain unambiguous.
+The path is omitted from headers because the command already names it. A directory
+reads the whole subtree beneath it, and a bare `lane why` reads the whole store; both
+keep `path#anchor` in each header so groups remain unambiguous:
+
+```bash
+$ lane why src/
+
+[src/auth.rs#fn verify]
+  - 01M0B9MBYB · 2026-08-14
+    must stay constant-time; early return leaks token length
+
+[src/db/pool.rs#@file]
+  - 01M0C1PDQR · 2026-08-15
+    the pool is created once per process; a second one exhausts the server
+```
+
+Matching is by whole path component, so `src` never claims `src-gen/lib.rs`.
 `lane why` changes nothing and carries no branch provenance. Run `lane check` to see
 whether a note's anchored code has drifted and get the id needed to resolve it.
 
@@ -352,7 +367,7 @@ The short version. See [commands](/commands) for full information.
 | `lane note unpin <id>` | remove eviction protection |
 | `lane install skill|hooks` | install the agent skill, or the commit decision capture hooks |
 | `lane uninstall skill|hooks` | remove them |
-| `lane why <file> [-a <anchor>]` | read the notes on a file; changes nothing |
+| `lane why <path> [-a <anchor>]` | read the notes on a file or a directory; changes nothing |
 | `lane check [--json]` | staleness report; exits 1 on missing anchors |
 | `lane audit [--base <ref>]` | run the memory pass alone |
 | `lane merge [--keep] [--base <ref>] [--squash] [--cd]` | rebase, audit, fast-forward, remove |


### PR DESCRIPTION
## Summary
- `lane why src/` reports every note beneath a directory; `lane why .` reports the whole store
- match on whole path components, so `src` never claims `src-gen/lib.rs` and `src/au` claims nothing
- carry `path#anchor` in headers wherever the argument does not name one file, including the whole-store view, which drops the lone `path@anchor` spelling
- correct the root help summary for `note`, which is a namespace now, not a single action
- document directory reads in built-in help, README, shipped skill, and website

## Verification
- cargo fmt --all --check
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test --workspace
- ./scripts/test.sh (227 passed, 0 failed)
- cd www && bun run build