### PR TITLE
feat: merge or push a lane by name

### DIFF
--- a/.lane/memory/crates/lane/src/cli.rs/01M0X0EFXA0JM52T5Y2G1GJHX1-git-add-applies-its-pathspec.md
+++ b/.lane/memory/crates/lane/src/cli.rs/01M0X0EFXA0JM52T5Y2G1GJHX1-git-add-applies-its-pathspec.md
@@ -1,0 +1,12 @@
+---
+id: 01M0X0EFXA0JM52T5Y2G1GJHX1
+anchor: fn stage_memory
+created: 2026-08-25T16:39:54Z
+norm: '1'
+sig: f4a6af165833b850
+body_hash: a178fc7114192d0c
+raw_hash: cb25f4524e95ef20
+lines: 1282-1287
+---
+
+git add applies its pathspecs atomically, so one that matches nothing discards the staging of the others; the paths lane syncs are each optional and must be added separately

--- a/.lane/memory/crates/lane/src/cli.rs/01M0X0EFZP3SFCF9NEMMC4B5S8-a-directory-git-has-no-workt.md
+++ b/.lane/memory/crates/lane/src/cli.rs/01M0X0EFZP3SFCF9NEMMC4B5S8-a-directory-git-has-no-workt.md
@@ -1,0 +1,12 @@
+---
+id: 01M0X0EFZP3SFCF9NEMMC4B5S8
+anchor: fn registered_lane
+created: 2026-08-25T17:38:20Z
+norm: '1'
+sig: 7cb4fd1a509e9e8d
+body_hash: a800b66b307d454d
+raw_hash: 5072a9e4d8d4221e
+lines: 705-711
+---
+
+a directory git has no worktree for resolves to the primary worktree, so landing it would rebase and fast-forward trunk onto itself

--- a/.lane/memory/crates/lane/src/git.rs/01M0X0EFZ2MW1ABZ42G3PWS29J-git-reports-some-refusals-on.md
+++ b/.lane/memory/crates/lane/src/git.rs/01M0X0EFZ2MW1ABZ42G3PWS29J-git-reports-some-refusals-on.md
@@ -1,0 +1,12 @@
+---
+id: 01M0X0EFZ2MW1ABZ42G3PWS29J
+anchor: fn diagnosis
+created: 2026-08-25T16:39:59Z
+norm: '1'
+sig: 99a669d308eb95d0
+body_hash: cd87cca791ab7a4a
+raw_hash: 26454ab02d6089c7
+lines: 26-33
+---
+
+git reports some refusals on stdout with an empty stderr, so an error built from stderr alone renders as a bare "failed:" with nothing after it

--- a/.lane/memory/crates/lane/src/git.rs/01M0X0EFZDFDT64VEK6AHSTAZK-these-reads-answer-for-one-w.md
+++ b/.lane/memory/crates/lane/src/git.rs/01M0X0EFZDFDT64VEK6AHSTAZK-these-reads-answer-for-one-w.md
@@ -1,0 +1,12 @@
+---
+id: 01M0X0EFZDFDT64VEK6AHSTAZK
+anchor: fn touched_paths
+created: 2026-08-25T17:38:13Z
+norm: '1'
+sig: 07ed51afe0290e2b
+body_hash: 09205e57cda4582b
+raw_hash: e9cf9be0cda6f082
+lines: 142-151
+---
+
+these reads answer for one worktree, and the process directory stops being that worktree as soon as a command can name a lane it is not standing in

--- a/crates/lane/src/args.rs
+++ b/crates/lane/src/args.rs
@@ -114,6 +114,7 @@ pub struct AuditArgs {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct MergeArgs {
+    pub name: Option<String>,
     pub base: Option<String>,
     pub keep: bool,
     pub cd: bool,
@@ -123,6 +124,7 @@ pub struct MergeArgs {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct PushArgs {
+    pub name: Option<String>,
     pub base: Option<String>,
     pub budget: Budget,
 }
@@ -500,8 +502,9 @@ fn parse_merge(raw: Vec<OsString>) -> Result<Parsed> {
     let cd = pargs.contains("--cd");
     let squash = pargs.contains("--squash");
     let budget = budget(&mut pargs)?;
-    none(positionals(pargs, after, Help::Merge)?, Help::Merge)?;
+    let name = at_most_one(positionals(pargs, after, Help::Merge)?, Help::Merge)?;
     Ok(Parsed::Merge(MergeArgs {
+        name,
         base,
         keep,
         cd,
@@ -518,8 +521,8 @@ fn parse_push(raw: Vec<OsString>) -> Result<Parsed> {
     }
     let base = pargs.opt_value_from_str("--base")?;
     let budget = budget(&mut pargs)?;
-    none(positionals(pargs, after, Help::Push)?, Help::Push)?;
-    Ok(Parsed::Push(PushArgs { base, budget }))
+    let name = at_most_one(positionals(pargs, after, Help::Push)?, Help::Push)?;
+    Ok(Parsed::Push(PushArgs { name, base, budget }))
 }
 
 fn parse_prune(raw: Vec<OsString>) -> Result<Parsed> {

--- a/crates/lane/src/audit.rs
+++ b/crates/lane/src/audit.rs
@@ -63,7 +63,7 @@ pub fn run(root: &Path, opts: &Options) -> Result<Outcome> {
     let touched: HashSet<String> = if opts.base.is_empty() {
         HashSet::new()
     } else {
-        git::touched_paths(&opts.base)
+        git::touched_paths(root, &opts.base)
     };
 
     let mut notes = store::load_notes(root, None);
@@ -72,7 +72,7 @@ pub fn run(root: &Path, opts: &Options) -> Result<Outcome> {
     // one loses it. Costs a git call only when something is actually missing.
     let mut moved = Vec::new();
     if store::has_missing_sources(root, &notes) {
-        for (old, new) in git::renames(&opts.base) {
+        for (old, new) in git::renames(root, &opts.base) {
             let count = store::move_notes(root, &old, &new)?;
             if count > 0 {
                 moved.push((old, new, count));

--- a/crates/lane/src/cli.rs
+++ b/crates/lane/src/cli.rs
@@ -76,13 +76,14 @@ pub fn run() -> Result<i32> {
         Parsed::Check { json } => check(json),
         Parsed::Audit(args) => audit_cmd(&args.base, &args.budget, args.json),
         Parsed::Merge(args) => merge(
+            args.name.as_deref(),
             args.base.as_deref(),
             args.keep,
             args.cd,
             args.squash,
             &args.budget,
         ),
-        Parsed::Push(args) => push(args.base.as_deref(), &args.budget),
+        Parsed::Push(args) => push(args.name.as_deref(), args.base.as_deref(), &args.budget),
         Parsed::Prune { dry_run } => prune(dry_run),
         Parsed::Rm(args) => rm(&args.name, args.force),
         Parsed::Shellenv => shellenv(),
@@ -699,11 +700,26 @@ fn prune(dry_run: bool) -> Result<i32> {
     Ok(i32::from(skipped > 0))
 }
 
-fn path(name: &str) -> Result<i32> {
-    let dest = wt::lanes_dir(&wt::main_root()?).join(name);
+/// A named lane git still holds; an unregistered directory would resolve to the primary
+/// worktree and land trunk onto itself.
+fn registered_lane(root: &Path, name: &str) -> Result<PathBuf> {
+    let dest = lane_named(root, name)?;
+    if !wt::registered(root, &dest) {
+        bail!("{name} is not a lane; git has no worktree there");
+    }
+    Ok(dest)
+}
+
+fn lane_named(root: &Path, name: &str) -> Result<PathBuf> {
+    let dest = wt::lanes_dir(root).join(name);
     if !dest.exists() {
         bail!("no lane named {name}");
     }
+    Ok(dest)
+}
+
+fn path(name: &str) -> Result<i32> {
+    let dest = lane_named(&wt::main_root()?, name)?;
     println!("{}", dest.display());
     Ok(0)
 }
@@ -1193,18 +1209,22 @@ enum Preparation {
 }
 
 fn prepare(
+    name: Option<&str>,
     base: Option<&str>,
     budget: &Budget,
     check_blocking: bool,
     info: &mut dyn Write,
 ) -> Result<Preparation> {
-    let lane_path = git::repo_root()?;
     let root = wt::main_root()?;
+    let lane_path = match name {
+        Some(name) => registered_lane(&root, name)?,
+        None => git::repo_root()?,
+    };
     if lane_path == root {
-        eprintln!("error: not inside a lane");
+        eprintln!("error: not inside a lane; name one");
         return Ok(Preparation::Exit(2));
     }
-    let branch = git::current_branch();
+    let branch = git::current_branch(&lane_path);
     let base = base
         .map(str::to_string)
         .unwrap_or_else(|| wt::lane_base(&root, &branch));
@@ -1266,13 +1286,21 @@ fn stage_memory(lane_path: &Path) -> bool {
     !git::git_ok(&["diff", "--cached", "--quiet"], Some(lane_path))
 }
 
-fn merge(base: Option<&str>, keep: bool, cd: bool, squash: bool, budget: &Budget) -> Result<i32> {
+fn merge(
+    name: Option<&str>,
+    base: Option<&str>,
+    keep: bool,
+    cd: bool,
+    squash: bool,
+    budget: &Budget,
+) -> Result<i32> {
     let info: &mut dyn Write = if cd {
         &mut std::io::stderr()
     } else {
         &mut std::io::stdout()
     };
-    let prepared = match prepare(base, budget, true, info)? {
+    let origin = std::env::current_dir().ok();
+    let prepared = match prepare(name, base, budget, true, info)? {
         Preparation::Ready(prepared) => prepared,
         Preparation::Exit(code) => return Ok(code),
     };
@@ -1284,6 +1312,11 @@ fn merge(base: Option<&str>, keep: bool, cd: bool, squash: bool, budget: &Budget
         _lock,
     } = prepared;
     let upstream = upstream_branch(&lane_path, &branch);
+    let departing = origin
+        .as_deref()
+        .and_then(|origin| origin.canonicalize().ok())
+        .zip(lane_path.canonicalize().ok())
+        .is_some_and(|(origin, lane)| origin.starts_with(lane));
 
     if squash {
         git(&["merge", "--squash", &branch], Some(&root))?;
@@ -1321,7 +1354,10 @@ fn merge(base: Option<&str>, keep: bool, cd: bool, squash: bool, budget: &Budget
         writeln!(info, "removed lane {branch}")?;
     }
     if cd {
-        println!("{}", root.display());
+        println!(
+            "{}",
+            origin.filter(|_| !departing).unwrap_or(root).display()
+        );
     }
     Ok(0)
 }
@@ -1383,8 +1419,8 @@ fn pull_request_number(lane_path: &Path, remote: &str, tip: &str) -> Option<Stri
     })
 }
 
-fn push(base: Option<&str>, budget: &Budget) -> Result<i32> {
-    let prepared = match prepare(base, budget, false, &mut std::io::stdout())? {
+fn push(name: Option<&str>, base: Option<&str>, budget: &Budget) -> Result<i32> {
+    let prepared = match prepare(name, base, budget, false, &mut std::io::stdout())? {
         Preparation::Ready(prepared) => prepared,
         Preparation::Exit(code) => return Ok(code),
     };
@@ -1763,6 +1799,28 @@ mod tests {
         assert_eq!(
             git(&["diff", "--cached", "--name-only"], Some(root)).unwrap(),
             ".lane/memory/main.rs/01M0A-note.md\nAGENTS.md"
+        );
+    }
+
+    #[test]
+    fn a_directory_git_does_not_know_is_not_a_lane() {
+        let temp = repository();
+        let root = temp.path();
+
+        assert!(
+            registered_lane(root, "ghost")
+                .unwrap_err()
+                .to_string()
+                .contains("no lane named ghost")
+        );
+
+        std::fs::create_dir_all(wt::lanes_dir(root).join("ghost")).unwrap();
+
+        assert!(
+            registered_lane(root, "ghost")
+                .unwrap_err()
+                .to_string()
+                .contains("git has no worktree there")
         );
     }
 }

--- a/crates/lane/src/cli.rs
+++ b/crates/lane/src/cli.rs
@@ -1241,12 +1241,7 @@ fn prepare(
     }
     store::mark_landed(&lane_path)?;
 
-    let changed = try_git(
-        &["status", "--porcelain", "--", LANE_DIR, "AGENTS.md"],
-        Some(&lane_path),
-    );
-    if !changed.trim().is_empty() {
-        try_git(&["add", LANE_DIR, "AGENTS.md"], Some(&lane_path));
+    if stage_memory(&lane_path) {
         git(
             &["commit", "-q", "-m", &format!("lane: sync {branch} memory")],
             Some(&lane_path),
@@ -1261,6 +1256,14 @@ fn prepare(
         base,
         _lock: lock,
     }))
+}
+
+/// Stage lane's own paths one at a time: a pathspec matching nothing fails the whole add.
+fn stage_memory(lane_path: &Path) -> bool {
+    for path in [LANE_DIR, "AGENTS.md"] {
+        try_git(&["add", "--", path], Some(lane_path));
+    }
+    !git::git_ok(&["diff", "--cached", "--quiet"], Some(lane_path))
 }
 
 fn merge(base: Option<&str>, keep: bool, cd: bool, squash: bool, budget: &Budget) -> Result<i32> {
@@ -1700,5 +1703,66 @@ mod tests {
         assert!(drifted["span"].as_str().unwrap().contains("\"new\""));
         assert_eq!(fresh["note"], "fresh note");
         assert!(fresh.get("span").is_none());
+    }
+
+    fn repository() -> tempfile::TempDir {
+        let temp = tempfile::tempdir().unwrap();
+        let root = temp.path();
+        for args in [
+            &["init", "-qb", "main"][..],
+            &["config", "user.email", "t@t.t"],
+            &["config", "user.name", "t"],
+        ] {
+            git(args, Some(root)).unwrap();
+        }
+        std::fs::write(root.join("main.rs"), "fn main() {}\n").unwrap();
+        git(&["add", "-A"], Some(root)).unwrap();
+        git(&["commit", "-qm", "base"], Some(root)).unwrap();
+        temp
+    }
+
+    fn write_note(root: &Path) {
+        let dir = root.join(LANE_DIR).join("memory/main.rs");
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(dir.join("01M0A-note.md"), "note\n").unwrap();
+    }
+
+    #[test]
+    fn memory_stages_where_the_repository_has_no_agents_file() {
+        let temp = repository();
+        let root = temp.path();
+        write_note(root);
+
+        assert!(stage_memory(root));
+        assert_eq!(
+            git(&["diff", "--cached", "--name-only"], Some(root)).unwrap(),
+            ".lane/memory/main.rs/01M0A-note.md"
+        );
+    }
+
+    #[test]
+    fn an_ignored_store_stages_nothing_to_commit() {
+        let temp = repository();
+        let root = temp.path();
+        std::fs::write(root.join(".gitignore"), ".lane/\n").unwrap();
+        git(&["add", "-A"], Some(root)).unwrap();
+        git(&["commit", "-qm", "ignore the store"], Some(root)).unwrap();
+        write_note(root);
+
+        assert!(!stage_memory(root));
+    }
+
+    #[test]
+    fn an_agents_file_stages_alongside_the_store() {
+        let temp = repository();
+        let root = temp.path();
+        write_note(root);
+        std::fs::write(root.join("AGENTS.md"), "# AGENTS\n").unwrap();
+
+        assert!(stage_memory(root));
+        assert_eq!(
+            git(&["diff", "--cached", "--name-only"], Some(root)).unwrap(),
+            ".lane/memory/main.rs/01M0A-note.md\nAGENTS.md"
+        );
     }
 }

--- a/crates/lane/src/git.rs
+++ b/crates/lane/src/git.rs
@@ -133,25 +133,28 @@ pub fn repo_root() -> Result<PathBuf> {
     Ok(layout(&std::env::current_dir()?)?.repo_root)
 }
 
-pub fn current_branch() -> String {
-    let b = try_git(&["rev-parse", "--abbrev-ref", "HEAD"], None);
+pub fn current_branch(cwd: &Path) -> String {
+    let b = try_git(&["rev-parse", "--abbrev-ref", "HEAD"], Some(cwd));
     if b.is_empty() { "unknown".into() } else { b }
 }
 
 /// Paths this branch changed relative to base; biases note retention.
-pub fn touched_paths(base: &str) -> std::collections::HashSet<String> {
-    try_git(&["diff", "--name-only", &format!("{base}...HEAD")], None)
-        .lines()
-        .filter(|l| !l.is_empty())
-        .map(str::to_string)
-        .collect()
+pub fn touched_paths(root: &Path, base: &str) -> std::collections::HashSet<String> {
+    try_git(
+        &["diff", "--name-only", &format!("{base}...HEAD")],
+        Some(root),
+    )
+    .lines()
+    .filter(|l| !l.is_empty())
+    .map(str::to_string)
+    .collect()
 }
 
 /// Renames reachable from HEAD, oldest first so a chain of them applies in order.
 ///
 /// A lane knows its base and can diff against it. On trunk there is no base — the rename
 /// is already in history — so fall back to a bounded walk of recent commits.
-pub fn renames(base: &str) -> Vec<(String, String)> {
+pub fn renames(root: &Path, base: &str) -> Vec<(String, String)> {
     let (out, newest_first) = if base.is_empty() {
         (
             try_git(
@@ -163,7 +166,7 @@ pub fn renames(base: &str) -> Vec<(String, String)> {
                     "--format=",
                     "--max-count=200",
                 ],
-                None,
+                Some(root),
             ),
             true,
         )
@@ -176,7 +179,7 @@ pub fn renames(base: &str) -> Vec<(String, String)> {
                     "--find-renames",
                     &format!("{base}...HEAD"),
                 ],
-                None,
+                Some(root),
             ),
             false,
         )
@@ -295,17 +298,22 @@ mod tests {
         );
     }
 
-    #[test]
-    fn a_failure_reported_on_stdout_alone_is_still_named() {
+    fn repository() -> TempDir {
         let temp = TempDir::new().unwrap();
-        let root = temp.path();
         for args in [
             &["init", "-qb", "main"][..],
             &["config", "user.email", "t@t.t"],
             &["config", "user.name", "t"],
         ] {
-            git(args, Some(root)).unwrap();
+            git(args, Some(temp.path())).unwrap();
         }
+        temp
+    }
+
+    #[test]
+    fn a_failure_reported_on_stdout_alone_is_still_named() {
+        let temp = repository();
+        let root = temp.path();
         std::fs::write(root.join("untracked.txt"), "x").unwrap();
 
         let error = git(&["commit", "-q", "-m", "empty"], Some(root))
@@ -313,6 +321,29 @@ mod tests {
             .to_string();
 
         assert!(error.contains("nothing added to commit"), "{error}");
+    }
+
+    #[test]
+    fn history_is_read_where_it_is_named_not_where_the_process_stands() {
+        let temp = repository();
+        let root = temp.path();
+        std::fs::create_dir(root.join("src")).unwrap();
+        std::fs::write(root.join("src/auth.rs"), "fn verify() {}\n").unwrap();
+        git(&["add", "-A"], Some(root)).unwrap();
+        git(&["commit", "-qm", "base"], Some(root)).unwrap();
+        git(&["checkout", "-qb", "lane"], Some(root)).unwrap();
+        git(&["mv", "src/auth.rs", "src/token.rs"], Some(root)).unwrap();
+        git(&["commit", "-qm", "rename"], Some(root)).unwrap();
+
+        assert_eq!(current_branch(root), "lane");
+        assert_eq!(
+            touched_paths(root, "main"),
+            std::collections::HashSet::from(["src/token.rs".to_string()])
+        );
+        assert_eq!(
+            renames(root, "main"),
+            vec![("src/auth.rs".to_string(), "src/token.rs".to_string())]
+        );
     }
 
     #[test]

--- a/crates/lane/src/git.rs
+++ b/crates/lane/src/git.rs
@@ -13,17 +13,23 @@ fn spawn(args: &[&str], cwd: Option<&Path>) -> Result<std::process::Output> {
     Ok(cmd.output()?)
 }
 
-/// Run git, failing with its stderr.
+/// Run git, failing with its diagnosis.
 pub fn git(args: &[&str], cwd: Option<&Path>) -> Result<String> {
     let out = spawn(args, cwd)?;
     if !out.status.success() {
-        bail!(
-            "git {} failed: {}",
-            args.join(" "),
-            String::from_utf8_lossy(&out.stderr).trim()
-        );
+        bail!("git {} failed: {}", args.join(" "), diagnosis(&out));
     }
     Ok(String::from_utf8_lossy(&out.stdout).trim().to_string())
+}
+
+/// Some refusals are reported on stdout alone; `git commit` with an empty index is one.
+fn diagnosis(out: &std::process::Output) -> String {
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    [stderr.trim(), stdout.trim()]
+        .into_iter()
+        .find(|text| !text.is_empty())
+        .map_or_else(|| out.status.to_string(), str::to_string)
 }
 
 /// Run git, treating failure as empty output.
@@ -287,6 +293,26 @@ mod tests {
             layout.main_root,
             std::fs::canonicalize(alternate_common.parent().unwrap()).unwrap()
         );
+    }
+
+    #[test]
+    fn a_failure_reported_on_stdout_alone_is_still_named() {
+        let temp = TempDir::new().unwrap();
+        let root = temp.path();
+        for args in [
+            &["init", "-qb", "main"][..],
+            &["config", "user.email", "t@t.t"],
+            &["config", "user.name", "t"],
+        ] {
+            git(args, Some(root)).unwrap();
+        }
+        std::fs::write(root.join("untracked.txt"), "x").unwrap();
+
+        let error = git(&["commit", "-q", "-m", "empty"], Some(root))
+            .unwrap_err()
+            .to_string();
+
+        assert!(error.contains("nothing added to commit"), "{error}");
     }
 
     #[test]

--- a/crates/lane/src/help.rs
+++ b/crates/lane/src/help.rs
@@ -92,8 +92,8 @@ impl Help {
             Help::Why => "lane why [OPTIONS] [PATH]",
             Help::Check => "lane check [--json]",
             Help::Audit => "lane audit [OPTIONS]",
-            Help::Merge => "lane merge [OPTIONS]",
-            Help::Push => "lane push [OPTIONS]",
+            Help::Merge => "lane merge [OPTIONS] [NAME]",
+            Help::Push => "lane push [OPTIONS] [NAME]",
             Help::Prune => "lane prune [--dry-run]",
             Help::Rm => "lane rm [--force] <NAME>",
             Help::Shellenv => "lane shellenv",
@@ -459,7 +459,7 @@ const MERGE: &str = "
     the worktree. Landings are locked, so two at once serialize.
 
   Usage
-    $ lane merge [options]
+    $ lane merge [name] [options]
 
   Options
     --base <ref>        Rebase onto <ref> instead of the recorded base
@@ -481,7 +481,7 @@ const PUSH: &str = "
     pull request. The remote is the branch's upstream or origin.
 
   Usage
-    $ lane push [options]
+    $ lane push [name] [options]
 
   Options
     --base <ref>        Rebase onto <ref> instead of the recorded base

--- a/crates/lane/src/worktree.rs
+++ b/crates/lane/src/worktree.rs
@@ -414,7 +414,7 @@ pub fn create(name: &str, base: Option<&str>, dirty: bool) -> Result<Created> {
 }
 
 /// True while git still has a worktree registered at this path, prunable ones included.
-fn registered(root: &Path, dest: &Path) -> bool {
+pub fn registered(root: &Path, dest: &Path) -> bool {
     let target = dest.canonicalize().ok();
     list_lanes(root).iter().any(|lane| {
         lane.path == dest || (target.is_some() && lane.path.canonicalize().ok() == target)

--- a/crates/lane/tests/args.rs
+++ b/crates/lane/tests/args.rs
@@ -145,6 +145,7 @@ fn the_shell_function_s_own_invocation_still_parses() {
     assert_eq!(
         ok(&["merge", "--cd"]),
         Parsed::Merge(MergeArgs {
+            name: None,
             base: None,
             keep: false,
             cd: true,
@@ -567,6 +568,7 @@ fn merge_and_rm_read_the_rest_of_their_flags() {
     assert_eq!(
         ok(&["merge", "--base", "release", "--keep", "--squash"]),
         Parsed::Merge(MergeArgs {
+            name: None,
             base: Some("release".into()),
             keep: true,
             cd: false,
@@ -691,6 +693,7 @@ fn push_takes_a_base_and_budget() {
     assert_eq!(
         ok(&["push", "--base", "release", "--max-notes", "3"]),
         Parsed::Push(PushArgs {
+            name: None,
             base: Some("release".into()),
             budget: Budget {
                 max_notes: 3,
@@ -708,4 +711,21 @@ fn prune_takes_only_its_dry_run() {
     assert!(err(&["prune", "extra"]).contains("unexpected argument 'extra' found"));
     assert!(err(&["prune", "--dry"]).contains("unexpected argument '--dry' found"));
     assert!(err(&["sweep"]).contains("unrecognized subcommand 'sweep'"));
+}
+
+#[test]
+fn merge_and_push_name_a_lane_or_take_the_current_one() {
+    let Parsed::Merge(merge) = ok(&["merge", "fix-login", "--squash"]) else {
+        panic!("expected merge");
+    };
+    assert_eq!(merge.name.as_deref(), Some("fix-login"));
+    assert!(merge.squash);
+
+    let Parsed::Push(push) = ok(&["push", "fix-login"]) else {
+        panic!("expected push");
+    };
+    assert_eq!(push.name.as_deref(), Some("fix-login"));
+
+    assert!(err(&["merge", "one", "two"]).contains("unexpected argument 'two' found"));
+    assert!(err(&["push", "one", "two"]).contains("unexpected argument 'two' found"));
 }

--- a/www/src/data/commands.ts
+++ b/www/src/data/commands.ts
@@ -164,7 +164,7 @@ export let commands: Command[] = [
 	},
 	{
 		name: "merge",
-		usage: "lane merge [--base <ref>] [--keep] [--squash]",
+		usage: "lane merge [<name>] [--base <ref>] [--keep] [--squash]",
 		summary: "rebases the lane onto its base, audits memory, commits it, fast-forwards the base, and removes the lane.",
 		options: [
 			{ flag: "--base", arg: "<ref>", about: "ref to rebase onto and advance; defaults to the lane's recorded base." },
@@ -178,7 +178,7 @@ export let commands: Command[] = [
 	},
 	{
 		name: "push",
-		usage: "lane push [--base <ref>]",
+		usage: "lane push [<name>] [--base <ref>]",
 		summary: "rebases the lane onto its base, audits and commits memory, then pushes it for a pull request.",
 		options: [
 			{ flag: "--base", arg: "<ref>", about: "ref to rebase onto; defaults to the lane's recorded base." },

--- a/www/src/pages/usage.md
+++ b/www/src/pages/usage.md
@@ -370,8 +370,8 @@ The short version. See [commands](/commands) for full information.
 | `lane why <path> [-a <anchor>]` | read the notes on a file or a directory; changes nothing |
 | `lane check [--json]` | staleness report; exits 1 on missing anchors |
 | `lane audit [--base <ref>]` | run the memory pass alone |
-| `lane merge [--keep] [--base <ref>] [--squash] [--cd]` | rebase, audit, fast-forward, remove |
-| `lane push [--base <ref>]` | rebase, audit, commit memory, and push for a pull request |
+| `lane merge [<name>] [--keep] [--base <ref>] [--squash] [--cd]` | rebase, audit, fast-forward, remove |
+| `lane push [<name>] [--base <ref>]` | rebase, audit, commit memory, and push for a pull request |
 | `lane prune [--dry-run]` | remove lanes whose branch has landed in trunk |
 | `lane rm <name> [--force]` | discard a lane; it stops and names uncommitted work, pending notes, or commits trunk does not have, `--force` drops them |
 | `lane shellenv` | shell integration |


### PR DESCRIPTION
## The bug

`lane merge` staged `.lane/` and `AGENTS.md` in one `git add`, then committed. A repository that keeps no `AGENTS.md` made that add fatal, and git discards the whole staging when one pathspec matches nothing — so the commit ran against an empty index and every merge stopped. Reported five times out of five in a repo without an `AGENTS.md`. Nothing reached the base: the lane aborted before its fast-forward.

The error named no cause, because `git commit` writes that refusal to stdout and lane built its message from stderr alone:

```
error: git commit -q -m lane: sync <branch> memory failed:
```

Each path now stages on its own, and the commit runs only where the index actually moved. A git failure falls back to stdout, then to the exit status.

## Merging a lane you are not standing in

`lane merge` and `lane push` read the lane from the working directory, so they answered `not inside a lane` anywhere else, the repository root included. Both now take an optional name and keep the current lane as the default:

```
$ lane merge [<name>]
$ lane push [<name>]
```

Two things that forced:

- **cwd-bound git reads.** `current_branch`, `touched_paths`, and `renames` read whatever directory the process stood in, which was right only because every caller had chdir'd there — `audit::run` took a `root` it then ignored for these three. Merging a named lane from the root would have diffed trunk against its own base: no touched paths, no renames, so a note on a renamed file would be dropped instead of moved. They now take the worktree they answer for.
- **Unregistered directories.** A leftover `.lane/trees/<name>/` that git has no worktree for resolves up to the primary worktree, where landing would rebase and fast-forward trunk onto itself. It is refused by name.

`--cd` moves the shell only when the lane it stood in is the one that went away.

## Verified

- The reported shape end to end: no `AGENTS.md`, merged by name from the root.
- No name from the root, an unknown name, an unregistered directory, `--cd` from inside another lane, `--cd` on your own lane, rename-following by name, and `lane push <name>` against a bare remote.
- 170 tests, clippy clean across the workspace.

Docs carry the usage grammar only: `help.rs`, `www/src/data/commands.ts`, and the `usage.md` table.