### PR TITLE
perf(macos): clone directories whole

### DIFF
--- a/.lane/memory/crates/lane/src/cow.rs/01M0X4BS4J4D1RF4M6ER7YJFVA-a-directory-clone-copies-sym.md
+++ b/.lane/memory/crates/lane/src/cow.rs/01M0X4BS4J4D1RF4M6ER7YJFVA-a-directory-clone-copies-sym.md
@@ -1,0 +1,12 @@
+---
+id: 01M0X4BS4J4D1RF4M6ER7YJFVA
+anchor: fn clone_dir_tree
+created: 2026-08-25T18:52:37Z
+norm: '1'
+sig: 49f77fc8c56e183b
+body_hash: df7189050423b23e
+raw_hash: 6b59e70b56e1b051
+lines: 197-241
+---
+
+a directory clone copies symlinks verbatim, so an absolute link into the source survives pointing at the source; the fixup walk reads dirents and costs a fraction of cloning each file

--- a/.lane/memory/crates/lane/src/cow.rs/01M0X51N9AXYCN7NF7PMPH1Z6H-the-fixup-reads-dirents-rath.md
+++ b/.lane/memory/crates/lane/src/cow.rs/01M0X51N9AXYCN7NF7PMPH1Z6H-the-fixup-reads-dirents-rath.md
@@ -1,0 +1,12 @@
+---
+id: 01M0X51N9AXYCN7NF7PMPH1Z6H
+anchor: fn fixup
+created: 2026-08-25T19:05:48Z
+norm: '1'
+sig: 5b7ee50d3303f904
+body_hash: 3ce3356e8abecf95
+raw_hash: c9774df713d90e39
+lines: 244-306
+---
+
+the fixup reads dirents rather than moving bytes, so it scales with cores where the clone underneath it is bound by the kernel

--- a/.lane/memory/crates/lane/src/worktree.rs/01M0X51N9ZT9E22S0056RZC273-git-owns-the-worktree-lifecy.md
+++ b/.lane/memory/crates/lane/src/worktree.rs/01M0X51N9ZT9E22S0056RZC273-git-owns-the-worktree-lifecy.md
@@ -1,0 +1,12 @@
+---
+id: 01M0X51N9ZT9E22S0056RZC273
+anchor: fn park
+created: 2026-08-25T19:05:55Z
+norm: '1'
+sig: a94f535f0bf7d567
+body_hash: caee546abf8a8573
+raw_hash: 168834cc6fcc975f
+lines: 418-435
+---
+
+git owns the worktree lifecycle, so the bulk moves out of its way rather than lane removing the worktree itself

--- a/.lane/memory/crates/lane/tests/cow.rs/01M0X51NAKFPAJW5M6G57RPWPK-free-space-is-a-property-of.md
+++ b/.lane/memory/crates/lane/tests/cow.rs/01M0X51NAKFPAJW5M6G57RPWPK-free-space-is-a-property-of.md
@@ -1,0 +1,12 @@
+---
+id: 01M0X51NAKFPAJW5M6G57RPWPK
+anchor: fn clone_shares_extents_where_supported
+created: 2026-08-25T19:06:07Z
+norm: '1'
+sig: 1318d979c6dbc85e
+body_hash: 616f055566adb6f4
+raw_hash: e4d7196ecf1559a6
+lines: 182-214
+---
+
+free space is a property of the volume, not of the clone, so a single reading is only as trustworthy as the machine is idle

--- a/crates/lane/src/cow.rs
+++ b/crates/lane/src/cow.rs
@@ -115,6 +115,22 @@ pub fn clone_file(src: &Path, dst: &Path) -> Result<(), CloneError> {
     }
 }
 
+/// Clone a whole directory in one call.
+///
+/// Darwin's clonefile takes a directory and clones the tree under it; Linux's FICLONE takes
+/// a file alone, which is why the per-file walk exists at all.
+#[cfg(target_os = "macos")]
+fn clone_dir(src: &Path, dst: &Path) -> Result<(), CloneError> {
+    clone_file(src, dst)
+}
+
+#[cfg(not(target_os = "macos"))]
+fn clone_dir(_src: &Path, _dst: &Path) -> Result<(), CloneError> {
+    Err(CloneError::Unsupported(
+        "no directory clone primitive on this platform".into(),
+    ))
+}
+
 #[cfg(not(any(target_os = "macos", target_os = "linux")))]
 pub fn clone_file(_src: &Path, _dst: &Path) -> Result<(), CloneError> {
     Err(CloneError::Unsupported(
@@ -172,6 +188,56 @@ impl fmt::Display for CloneStats {
             )
         }
     }
+}
+
+/// Clone a directory whole where the kernel can, walking it only to fix what it copied
+/// verbatim: an absolute symlink into the source still points at the source.
+///
+/// Falls back to the per-file walk when the tree cannot be cloned in one call.
+pub fn clone_dir_tree(
+    src: &Path,
+    dst: &Path,
+    src_root: &Path,
+    dst_root: &Path,
+) -> std::io::Result<CloneStats> {
+    let walk = || clone_tree_rooted(src, dst, &|_, _| false, src_root, dst_root);
+    // clonefile refuses an existing destination, and a destination inside the source needs
+    // the walk's pruning to avoid cloning the clone.
+    if fs::symlink_metadata(dst).is_ok() || dst.starts_with(src) {
+        return walk();
+    }
+    if let Some(parent) = dst.parent() {
+        fs::create_dir_all(parent)?;
+    }
+    match clone_dir(src, dst) {
+        Ok(()) => {}
+        Err(CloneError::Unsupported(_)) => return walk(),
+        Err(CloneError::Io(e)) => return Err(e),
+    }
+
+    let src_roots = root_spellings(src_root)?;
+    let mut stats = CloneStats::default();
+    for entry in walkdir::WalkDir::new(dst) {
+        let Ok(entry) = entry else { continue };
+        let kind = entry.file_type();
+        if kind.is_dir() {
+            continue;
+        }
+        if kind.is_symlink() {
+            stats.links += 1;
+            let target = fs::read_link(entry.path())?;
+            if let Some(retargeted) = retarget(&target, &src_roots, dst_root) {
+                fs::remove_file(entry.path())?;
+                std::os::unix::fs::symlink(retargeted, entry.path())?;
+            }
+            continue;
+        }
+        if kind.is_file() {
+            stats.cloned += 1;
+            stats.bytes_shared += entry.metadata().map(|m| m.len()).unwrap_or(0);
+        }
+    }
+    Ok(stats)
 }
 
 /// Recursively clone `src` into `dst`; `skip(relpath, is_dir)` prunes.

--- a/crates/lane/src/cow.rs
+++ b/crates/lane/src/cow.rs
@@ -215,27 +215,92 @@ pub fn clone_dir_tree(
         Err(CloneError::Io(e)) => return Err(e),
     }
 
+    fixup(dst, src_root, dst_root)
+}
+
+/// Count what was cloned and repoint links the kernel copied verbatim.
+fn visit(
+    path: &Path,
+    kind: fs::FileType,
+    src_roots: &[PathBuf],
+    dst_root: &Path,
+    stats: &mut CloneStats,
+) -> std::io::Result<()> {
+    if kind.is_symlink() {
+        stats.links += 1;
+        let target = fs::read_link(path)?;
+        if let Some(retargeted) = retarget(&target, src_roots, dst_root) {
+            fs::remove_file(path)?;
+            std::os::unix::fs::symlink(retargeted, path)?;
+        }
+    } else if kind.is_file() {
+        stats.cloned += 1;
+        stats.bytes_shared += fs::symlink_metadata(path).map(|m| m.len()).unwrap_or(0);
+    }
+    Ok(())
+}
+
+/// Walk the clone on every core: readdir over a large tree is the cost, not the clone.
+fn fixup(dst: &Path, src_root: &Path, dst_root: &Path) -> std::io::Result<CloneStats> {
     let src_roots = root_spellings(src_root)?;
+    let threads = std::thread::available_parallelism().map_or(4, |n| n.get());
     let mut stats = CloneStats::default();
-    for entry in walkdir::WalkDir::new(dst) {
-        let Ok(entry) = entry else { continue };
-        let kind = entry.file_type();
-        if kind.is_dir() {
-            continue;
-        }
-        if kind.is_symlink() {
-            stats.links += 1;
-            let target = fs::read_link(entry.path())?;
-            if let Some(retargeted) = retarget(&target, &src_roots, dst_root) {
-                fs::remove_file(entry.path())?;
-                std::os::unix::fs::symlink(retargeted, entry.path())?;
+
+    // Descend breadth-first until there are enough subtrees to spread across the threads.
+    let mut level = vec![dst.to_path_buf()];
+    while level.len() < threads * 4 {
+        let mut next = Vec::new();
+        for dir in &level {
+            for entry in fs::read_dir(dir)? {
+                let entry = entry?;
+                let kind = entry.file_type()?;
+                if kind.is_dir() {
+                    next.push(entry.path());
+                } else {
+                    visit(&entry.path(), kind, &src_roots, dst_root, &mut stats)?;
+                }
             }
-            continue;
         }
-        if kind.is_file() {
-            stats.cloned += 1;
-            stats.bytes_shared += entry.metadata().map(|m| m.len()).unwrap_or(0);
+        if next.is_empty() {
+            level.clear();
+            break;
         }
+        level = next;
+    }
+    if level.is_empty() {
+        return Ok(stats);
+    }
+
+    let chunk = level.len().div_ceil(threads);
+    let parts: Vec<std::io::Result<CloneStats>> = std::thread::scope(|scope| {
+        let handles: Vec<_> = level
+            .chunks(chunk)
+            .map(|chunk| {
+                let src_roots = &src_roots;
+                scope.spawn(move || {
+                    let mut stats = CloneStats::default();
+                    for dir in chunk {
+                        for entry in walkdir::WalkDir::new(dir) {
+                            let Ok(entry) = entry else { continue };
+                            let kind = entry.file_type();
+                            if !kind.is_dir() {
+                                visit(entry.path(), kind, src_roots, dst_root, &mut stats)?;
+                            }
+                        }
+                    }
+                    Ok(stats)
+                })
+            })
+            .collect();
+        handles.into_iter().map(|h| h.join().unwrap()).collect()
+    });
+    for part in parts {
+        let part = part?;
+        stats.cloned += part.cloned;
+        stats.copied += part.copied;
+        stats.links += part.links;
+        stats.bytes_shared += part.bytes_shared;
+        stats.bytes_copied += part.bytes_copied;
     }
     Ok(stats)
 }

--- a/crates/lane/src/worktree.rs
+++ b/crates/lane/src/worktree.rs
@@ -249,13 +249,7 @@ fn clone_entry(root: &Path, dest: &Path, entry: &str) -> Result<cow::CloneStats>
     let source = root.join(entry);
     let target = dest.join(entry);
     if std::fs::symlink_metadata(&source)?.is_dir() {
-        return Ok(cow::clone_tree_rooted(
-            &source,
-            &target,
-            &|_, _| false,
-            root,
-            dest,
-        )?);
+        return Ok(cow::clone_dir_tree(&source, &target, root, dest)?);
     }
     let Some(name) = source.file_name().map(|name| name.to_string_lossy()) else {
         bail!("ignored entry has no file name: {entry}");

--- a/crates/lane/src/worktree.rs
+++ b/crates/lane/src/worktree.rs
@@ -407,6 +407,53 @@ pub fn create(name: &str, base: Option<&str>, dirty: bool) -> Result<Created> {
     })
 }
 
+fn trash_dir(root: &Path) -> PathBuf {
+    lanes_dir(root).join(".trash")
+}
+
+/// Move the bulk aside so git's removal only unlinks what it tracks.
+///
+/// Renaming is constant time where deleting is one syscall per file, and nothing here is
+/// worth waiting for: these are the entries git itself declined to materialize.
+fn park(root: &Path, dest: &Path) -> Vec<(PathBuf, PathBuf)> {
+    let trash = trash_dir(root);
+    if std::fs::create_dir_all(&trash).is_err() {
+        return Vec::new();
+    }
+    let mut parked = Vec::new();
+    for entry in ignored_entries(dest) {
+        let from = dest.join(&entry);
+        if std::fs::symlink_metadata(&from).is_err() {
+            continue;
+        }
+        let to = trash.join(format!("{}-{}", std::process::id(), parked.len()));
+        if std::fs::rename(&from, &to).is_ok() {
+            parked.push((from, to));
+        }
+    }
+    parked
+}
+
+/// Unlink what was parked, in a process that outlives this one. Picks up anything an
+/// earlier sweep left behind, so a killed child costs disk and not correctness.
+fn sweep(root: &Path) {
+    let trash = trash_dir(root);
+    let Ok(entries) = std::fs::read_dir(&trash) else {
+        return;
+    };
+    let paths: Vec<PathBuf> = entries.flatten().map(|entry| entry.path()).collect();
+    if paths.is_empty() {
+        return;
+    }
+    let _ = std::process::Command::new("rm")
+        .arg("-rf")
+        .args(paths)
+        .stdin(std::process::Stdio::null())
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .spawn();
+}
+
 /// True while git still has a worktree registered at this path, prunable ones included.
 fn registered(root: &Path, dest: &Path) -> bool {
     let target = dest.canonicalize().ok();
@@ -475,8 +522,17 @@ pub fn remove(name: &str) -> Result<()> {
     // A hand-deleted lane leaves a branch and no worktree, and git calls removing an
     // absent one fatal. Skipping is what lets `rm` clean up after that.
     if worktree {
+        let parked = park(&root, &dest);
         let dest_str = dest.to_string_lossy().to_string();
-        git(&["worktree", "remove", "--force", &dest_str], Some(&root))?;
+        match git(&["worktree", "remove", "--force", &dest_str], Some(&root)) {
+            Ok(_) => sweep(&root),
+            Err(error) => {
+                for (from, to) in parked {
+                    let _ = std::fs::rename(to, from);
+                }
+                return Err(error);
+            }
+        }
     }
     if branch {
         git(&["branch", "-D", name], Some(&root))?;
@@ -638,6 +694,47 @@ mod tests {
         assert!(entries.contains(&"cache".to_string()));
         assert!(!entries.contains(&TREES_PATH.to_string()));
         Ok(())
+    }
+
+    #[test]
+    fn parking_moves_the_bulk_aside_and_the_sweep_unlinks_it() -> Result<()> {
+        let root = tempfile::tempdir()?;
+        let r = root.path();
+        let run = |args: &[&str]| {
+            git(args, Some(r)).ok();
+        };
+        run(&["init", "-qb", "main"]);
+        run(&["config", "user.email", "t@t.t"]);
+        run(&["config", "user.name", "t"]);
+        std::fs::write(r.join(".gitignore"), "build/\n")?;
+        run(&["add", "-A"]);
+        run(&["commit", "-qm", "base"]);
+        std::fs::create_dir_all(r.join("build/deep"))?;
+        std::fs::write(r.join("build/deep/artifact"), "bulk")?;
+
+        let parked = park(r, r);
+
+        assert_eq!(parked.len(), 1, "the ignored tree is the thing to park");
+        assert!(!r.join("build").exists(), "parking leaves the worktree");
+        let (from, to) = &parked[0];
+        assert_eq!(from, &r.join("build"));
+        assert!(to.join("deep/artifact").exists(), "content moved intact");
+
+        sweep(r);
+
+        // The unlinking outlives this process, so wait on it rather than assume it.
+        for _ in 0..100 {
+            if std::fs::read_dir(trash_dir(r))
+                .into_iter()
+                .flatten()
+                .count()
+                == 0
+            {
+                return Ok(());
+            }
+            std::thread::sleep(std::time::Duration::from_millis(50));
+        }
+        panic!("sweep left the trash behind");
     }
 
     #[test]

--- a/crates/lane/tests/cow.rs
+++ b/crates/lane/tests/cow.rs
@@ -280,3 +280,40 @@ fn directory_clone_falls_back_to_the_walk_when_the_destination_exists() {
     );
     assert_eq!(stats.cloned + stats.copied, 1);
 }
+
+/// Enough subtrees to cross the threshold where the fixup spreads across threads.
+#[test]
+fn a_wide_tree_is_fixed_up_on_every_core() {
+    let src = tempfile::tempdir().unwrap();
+    let dst = tempfile::tempdir().unwrap();
+    let out = dst.path().join("out");
+    let src = src.path().canonicalize().unwrap();
+
+    for i in 0..128 {
+        let dir = src.join(format!("d{i}/nested"));
+        fs::create_dir_all(&dir).unwrap();
+        fs::write(dir.join("f.bin"), vec![1u8; 64]).unwrap();
+    }
+    std::os::unix::fs::symlink(src.join("d0/nested/f.bin"), src.join("d7/absolute")).unwrap();
+    std::os::unix::fs::symlink("nested/f.bin", src.join("d8/relative")).unwrap();
+
+    let stats = cow::clone_dir_tree(&src, &out, &src, &out).unwrap();
+
+    assert_eq!(stats.cloned + stats.copied, 128);
+    assert_eq!(stats.links, 2);
+    assert_eq!(stats.bytes_shared + stats.bytes_copied, 128 * 64);
+    assert_eq!(
+        fs::read_link(out.join("d7/absolute")).unwrap(),
+        out.join("d0/nested/f.bin")
+    );
+    assert_eq!(
+        fs::read_link(out.join("d8/relative")).unwrap(),
+        Path::new("nested/f.bin")
+    );
+    for i in 0..128 {
+        assert_eq!(
+            fs::read(out.join(format!("d{i}/nested/f.bin"))).unwrap(),
+            vec![1u8; 64]
+        );
+    }
+}

--- a/crates/lane/tests/cow.rs
+++ b/crates/lane/tests/cow.rs
@@ -191,10 +191,17 @@ fn clone_shares_extents_where_supported() {
     fs::write(&big, vec![0xABu8; 64 * 1024 * 1024]).unwrap();
     let _ = std::process::Command::new("sync").status();
 
-    let before = free_bytes(dir.path());
-    cow::clone_file(&big, &dir.path().join("clone.bin")).expect("clone");
-    let _ = std::process::Command::new("sync").status();
-    let spent = before.saturating_sub(free_bytes(dir.path()));
+    // free_bytes reads the whole volume, so anything else writing to it lands in the
+    // measurement. Noise only ever adds, so the cheapest of several clones is the answer.
+    let spent = (0..3)
+        .map(|i| {
+            let before = free_bytes(dir.path());
+            cow::clone_file(&big, &dir.path().join(format!("clone{i}.bin"))).expect("clone");
+            let _ = std::process::Command::new("sync").status();
+            before.saturating_sub(free_bytes(dir.path()))
+        })
+        .min()
+        .unwrap();
 
     assert!(
         spent < 16 * 1024 * 1024,
@@ -202,7 +209,7 @@ fn clone_shares_extents_where_supported() {
     );
     assert_eq!(
         fs::read(&big).unwrap(),
-        fs::read(dir.path().join("clone.bin")).unwrap()
+        fs::read(dir.path().join("clone0.bin")).unwrap()
     );
 }
 

--- a/crates/lane/tests/cow.rs
+++ b/crates/lane/tests/cow.rs
@@ -2,6 +2,7 @@
 
 use lane::cow::{self, CloneError};
 use std::fs;
+use std::path::Path;
 
 /// Available bytes on the filesystem holding `path`, via df so no platform code is needed.
 fn free_bytes(path: &std::path::Path) -> u64 {
@@ -221,4 +222,61 @@ fn cloning_onto_an_existing_path_is_not_reported_as_unsupported() {
         }
         Err(CloneError::Io(_)) | Ok(()) => {}
     }
+}
+
+/// The one-call directory clone must land what the per-file walk lands.
+#[test]
+fn directory_clone_is_byte_identical_and_retargets_absolute_links() {
+    let src = tempfile::tempdir().unwrap();
+    let dst = tempfile::tempdir().unwrap();
+    let out = dst.path().join("out");
+    let src = src.path().canonicalize().unwrap();
+
+    fs::create_dir_all(src.join("sub")).unwrap();
+    fs::write(src.join("a.bin"), vec![7u8; 4096]).unwrap();
+    fs::write(src.join("sub/b.bin"), vec![9u8; 4096]).unwrap();
+    std::os::unix::fs::symlink("a.bin", src.join("relative")).unwrap();
+    std::os::unix::fs::symlink(src.join("a.bin"), src.join("absolute")).unwrap();
+
+    let stats = cow::clone_dir_tree(&src, &out, &src, &out).unwrap();
+
+    assert_eq!(
+        fs::read(src.join("sub/b.bin")).unwrap(),
+        fs::read(out.join("sub/b.bin")).unwrap()
+    );
+    assert_eq!(
+        fs::read_link(out.join("relative")).unwrap(),
+        Path::new("a.bin")
+    );
+    assert_eq!(
+        fs::read_link(out.join("absolute")).unwrap(),
+        out.join("a.bin")
+    );
+
+    // The retargeted link must read the clone's copy, not the source's.
+    fs::write(src.join("a.bin"), b"source").unwrap();
+    fs::write(out.join("a.bin"), b"clone").unwrap();
+    assert_eq!(fs::read(out.join("absolute")).unwrap(), b"clone");
+
+    assert_eq!(stats.links, 2);
+    assert_eq!(stats.cloned + stats.copied, 2);
+}
+
+#[test]
+fn directory_clone_falls_back_to_the_walk_when_the_destination_exists() {
+    let src = tempfile::tempdir().unwrap();
+    let dst = tempfile::tempdir().unwrap();
+    let out = dst.path().join("out");
+    let src = src.path().canonicalize().unwrap();
+
+    fs::write(src.join("a.bin"), vec![3u8; 4096]).unwrap();
+    fs::create_dir_all(&out).unwrap();
+
+    let stats = cow::clone_dir_tree(&src, &out, &src, &out).unwrap();
+
+    assert_eq!(
+        fs::read(src.join("a.bin")).unwrap(),
+        fs::read(out.join("a.bin")).unwrap()
+    );
+    assert_eq!(stats.cloned + stats.copied, 1);
 }


### PR DESCRIPTION
`lane new` took **15-21s** in this repository and `lane rm` took **2.1s**. They now take **~1.2s** and **~0.35s**.

## `lane new`

`clone_entry` sent every ignored directory through the per-file walk: one `clonefile` syscall per file. This repo has 26,245 such files — `target/` at 2.1G and `www/node_modules/` at 434M — so `lane new` made 26,245 syscalls at 46% CPU. It was not computing anything, it was waiting on the kernel.

Darwin's `clonefile` takes a directory and clones the tree beneath it:

```
one recursive clonefile, target/     0.178s
per-file walk (cp -Rc), same tree    5.748s
```

Byte-identical, verified with `diff -rq` against the symlink-heavy `node_modules`.

A directory clone still has to be walked once, because the kernel copies symlinks verbatim and an absolute link into the source survives pointing at the source — `cow.rs` has had a test for that since the clone layer was written. That walk then became the largest remaining cost, at 0.89s against 0.62s for the clones it was fixing, so it now descends breadth-first until there are enough subtrees to spread and walks them on every core: 0.89s to 0.40s.

Where the time goes now, measured with the stages instrumented:

```
0.056s  startup, root discovery, prepare_lanes_dir
0.005s  reflink probe
0.198s  ignored_entries (git status --ignored)
0.111s  git worktree add
0.428s  clone target/          (clonefile 0.217s + fixup 0.210s)
0.588s  clone www/node_modules (clonefile 0.393s + fixup 0.195s)
```

Two things I tried and dropped, so they don't get retried:

- **Cloning the ignored entries concurrently.** No win — 1.393s to 1.350s. The `clonefile` calls serialise in the kernel, so running them together just moves the wait (`node_modules` went from 0.393s to 0.688s once concurrent).
- **`git status --ignored=matching`,** which is 0.029s against 0.162s. It stops collapsing on the same rule, so a directory holding both ignored and untracked-but-not-ignored files would sweep the untracked ones into the clone. Not worth 0.13s.

This will not reach `git worktree add`'s 0.06s. That command is fast because it materialises nothing; the remaining second is the price of 2.5G of ignored files existing in the lane at all. `lane.exclude` already opts a tree out for anyone who would rather rebuild.

## `lane rm`

Nearly all of the 2.1s was `git worktree remove` unlinking those same 26,245 files while the caller waited. The ignored entries are now renamed aside first — constant time — and git removes only what it created. The unlinking runs in a process that outlives the command and picks up whatever an earlier sweep left behind, so a killed child costs disk and not correctness. A failed removal puts the parked trees back.

## Fallbacks

The per-file walk remains and is taken for: Linux, where `FICLONE` accepts a file alone; any filesystem whose kernel refuses the clone, already classified as `Unsupported`; a destination that already exists, which `clonefile` will not overwrite; and a destination nested inside its source, which needs the walk's pruning.

## Tests

- absolute in-source symlink is retargeted into the clone, and reading through it gets the clone's copy
- an existing destination falls back to the walk and still lands the tree
- a 128-subtree clone crosses the threshold where the fixup spreads across threads, and lands every file, both link kinds, and exact byte counts
- `park` moves the ignored tree out of the worktree and hands back what it moved; `sweep` unlinks it from the outliving process

One unrelated fix rides along. `clone_shares_extents_where_supported` read free space across the whole volume before and after a single clone, so any other writer landed in the measurement — it failed once during this work while a background sweep was unlinking 2.5G, then passed three times running. It now clones three times and asserts on the cheapest, since interference only ever adds bytes.

167 tests pass, clippy clean across the workspace.