### PR TITLE
feat: add lane enter and exit

### DIFF
--- a/.lane/memory/crates/lane/src/cli.rs/01M0X5TMX34CWXNTEE0V33W550-printing-a-destination-is-th.md
+++ b/.lane/memory/crates/lane/src/cli.rs/01M0X5TMX34CWXNTEE0V33W550-printing-a-destination-is-th.md
@@ -1,0 +1,12 @@
+---
+id: 01M0X5TMX34CWXNTEE0V33W550
+anchor: fn enter
+created: 2026-08-25T19:19:30Z
+norm: '1'
+sig: c39b29934be23698
+body_hash: 142669742ace73e4
+raw_hash: 9d4ab9477fe39dd6
+lines: 713-716
+---
+
+printing a destination is the whole contract of these two verbs, which is what lets the flag disappear rather than move

--- a/.lane/memory/crates/lane/src/worktree.rs/01M0X5TMW7C5RP76GAM7J28S18-git-path-answers-relative-to.md
+++ b/.lane/memory/crates/lane/src/worktree.rs/01M0X5TMW7C5RP76GAM7J28S18-git-path-answers-relative-to.md
@@ -1,0 +1,12 @@
+---
+id: 01M0X5TMW7C5RP76GAM7J28S18
+anchor: fn prepare_lanes_dir
+created: 2026-08-25T19:19:30Z
+norm: '1'
+sig: 282a57e07385efe8
+body_hash: d0445587f0aeb1ce
+raw_hash: 20a74b5009b39f56
+lines: 140-150
+---
+
+--git-path answers relative to the repository it is asked about, and lane runs commands from directories that are not it

--- a/crates/lane/src/args.rs
+++ b/crates/lane/src/args.rs
@@ -20,8 +20,10 @@ const MAX_CHARS: usize = 1200;
 const COMMANDS: &[&str] = &[
     "init",
     "new",
+    "enter",
+    "switch",
+    "exit",
     "ls",
-    "path",
     "anchors",
     "note",
     "install",
@@ -68,7 +70,6 @@ pub struct NewArgs {
     pub name: String,
     pub base: Option<String>,
     pub dirty: bool,
-    pub cd: bool,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -117,7 +118,6 @@ pub struct MergeArgs {
     pub name: Option<String>,
     pub base: Option<String>,
     pub keep: bool,
-    pub cd: bool,
     pub squash: bool,
     pub budget: Budget,
 }
@@ -142,7 +142,8 @@ pub enum Parsed {
     Init,
     New(NewArgs),
     Ls { json: bool },
-    Path { name: String },
+    Enter { name: String },
+    Exit,
     Anchors { path: String, json: bool },
     Note(NoteCommand),
     Install(Installable),
@@ -174,9 +175,10 @@ pub fn parse(raw: Vec<OsString>) -> Result<Parsed> {
         Some("init") => bare(rest(raw), Help::Init, Parsed::Init),
         Some("new") => parse_new(rest(raw)),
         Some("ls") => parse_ls(rest(raw)),
-        Some("path") => parse_one(rest(raw), Help::Path, "<NAME>", |name| Parsed::Path {
-            name,
+        Some("enter" | "switch") => parse_one(rest(raw), Help::Enter, "<NAME>", |name| {
+            Parsed::Enter { name }
         }),
+        Some("exit") => bare(rest(raw), Help::Exit, Parsed::Exit),
         Some("anchors") => parse_anchors(rest(raw)),
         Some("note") => parse_note(rest(raw)),
         Some("install") => parse_installable(rest(raw), Help::Install, Parsed::Install),
@@ -310,14 +312,8 @@ fn parse_new(raw: Vec<OsString>) -> Result<Parsed> {
     }
     let base = pargs.opt_value_from_str("--base")?;
     let dirty = pargs.contains("--dirty");
-    let cd = pargs.contains("--cd");
     let name = one(positionals(pargs, after, Help::New)?, "<NAME>", Help::New)?;
-    Ok(Parsed::New(NewArgs {
-        name,
-        base,
-        dirty,
-        cd,
-    }))
+    Ok(Parsed::New(NewArgs { name, base, dirty }))
 }
 
 fn parse_ls(raw: Vec<OsString>) -> Result<Parsed> {
@@ -499,7 +495,6 @@ fn parse_merge(raw: Vec<OsString>) -> Result<Parsed> {
     }
     let base = pargs.opt_value_from_str("--base")?;
     let keep = pargs.contains("--keep");
-    let cd = pargs.contains("--cd");
     let squash = pargs.contains("--squash");
     let budget = budget(&mut pargs)?;
     let name = at_most_one(positionals(pargs, after, Help::Merge)?, Help::Merge)?;
@@ -507,7 +502,6 @@ fn parse_merge(raw: Vec<OsString>) -> Result<Parsed> {
         name,
         base,
         keep,
-        cd,
         squash,
         budget,
     }))

--- a/crates/lane/src/cli.rs
+++ b/crates/lane/src/cli.rs
@@ -708,16 +708,25 @@ fn lane_named(root: &Path, name: &str) -> Result<PathBuf> {
     Ok(dest)
 }
 
-/// Both print a destination and nothing else: the shell function turns that into a cd,
-/// and `cd "$(lane enter x)"` is the same thing typed by hand.
-fn enter(name: &str) -> Result<i32> {
-    println!("{}", lane_named(&wt::main_root()?, name)?.display());
+/// Move the shell, or say why it did not.
+///
+/// A terminal on stdout means nothing captured the destination, so no shell function ran.
+fn move_to(dest: &Path) -> Result<i32> {
+    println!("{}", dest.display());
+    if std::io::stdout().is_terminal() {
+        eprintln!(
+            "note: no shell integration; add `eval \"$(lane shellenv)\"` to cd automatically"
+        );
+    }
     Ok(0)
 }
 
+fn enter(name: &str) -> Result<i32> {
+    move_to(&lane_named(&wt::main_root()?, name)?)
+}
+
 fn exit() -> Result<i32> {
-    println!("{}", wt::main_root()?.display());
-    Ok(0)
+    move_to(&wt::main_root()?)
 }
 
 #[derive(serde::Serialize)]

--- a/crates/lane/src/cli.rs
+++ b/crates/lane/src/cli.rs
@@ -16,7 +16,7 @@ use std::io::{IsTerminal, Write};
 use std::ops::Range;
 use std::path::{Path, PathBuf};
 
-/// Takes the stream it will be written to; under --cd that is stderr, not stdout.
+/// Takes the stream it will be written to; for `new` that is stderr, not stdout.
 fn bold(text: &str, tty: bool) -> String {
     if tty {
         format!("\x1b[1m{text}\x1b[0m")
@@ -46,9 +46,10 @@ pub fn run() -> Result<i32> {
             Ok(0)
         }
         Parsed::Init => init(),
-        Parsed::New(args) => new(&args.name, args.base.as_deref(), args.dirty, args.cd),
+        Parsed::New(args) => new(&args.name, args.base.as_deref(), args.dirty),
         Parsed::Ls { json } => ls(json),
-        Parsed::Path { name } => path(&name),
+        Parsed::Enter { name } => enter(&name),
+        Parsed::Exit => exit(),
         Parsed::Anchors { path, json } => anchors(&path, json),
         Parsed::Note(command) => match command {
             NoteCommand::Add(args) => note_add(args),
@@ -79,7 +80,6 @@ pub fn run() -> Result<i32> {
             args.name.as_deref(),
             args.base.as_deref(),
             args.keep,
-            args.cd,
             args.squash,
             &args.budget,
         ),
@@ -551,27 +551,17 @@ fn init() -> Result<i32> {
     Ok(0)
 }
 
-fn new(name: &str, base: Option<&str>, dirty: bool, cd: bool) -> Result<i32> {
+fn new(name: &str, base: Option<&str>, dirty: bool) -> Result<i32> {
     let created = wt::create(name, base, dirty)?;
-    // With --cd, stdout is reserved for the path so the shell can capture it without a pipe.
-    let tty = if cd {
-        std::io::stderr().is_terminal()
-    } else {
-        std::io::stdout().is_terminal()
-    };
-    let info: &mut dyn std::io::Write = if cd {
-        &mut std::io::stderr()
-    } else {
-        &mut std::io::stdout()
-    };
+    // Progress goes to stderr so stdout carries the path alone, as `enter` does. Bold only
+    // for a terminal: a captured path must not carry escapes.
+    let info = &mut std::io::stderr();
     for note in &created.notes {
         writeln!(info, "  {note}")?;
     }
     writeln!(info, "  {}", created.stats)?;
-    writeln!(info, "{}", bold(&created.path.to_string_lossy(), tty))?;
-    if cd {
-        println!("{}", created.path.display());
-    }
+    let tty = std::io::stdout().is_terminal();
+    println!("{}", bold(&created.path.to_string_lossy(), tty));
     Ok(0)
 }
 
@@ -718,9 +708,15 @@ fn lane_named(root: &Path, name: &str) -> Result<PathBuf> {
     Ok(dest)
 }
 
-fn path(name: &str) -> Result<i32> {
-    let dest = lane_named(&wt::main_root()?, name)?;
-    println!("{}", dest.display());
+/// Both print a destination and nothing else: the shell function turns that into a cd,
+/// and `cd "$(lane enter x)"` is the same thing typed by hand.
+fn enter(name: &str) -> Result<i32> {
+    println!("{}", lane_named(&wt::main_root()?, name)?.display());
+    Ok(0)
+}
+
+fn exit() -> Result<i32> {
+    println!("{}", wt::main_root()?.display());
     Ok(0)
 }
 
@@ -1290,16 +1286,10 @@ fn merge(
     name: Option<&str>,
     base: Option<&str>,
     keep: bool,
-    cd: bool,
     squash: bool,
     budget: &Budget,
 ) -> Result<i32> {
-    let info: &mut dyn Write = if cd {
-        &mut std::io::stderr()
-    } else {
-        &mut std::io::stdout()
-    };
-    let origin = std::env::current_dir().ok();
+    let info: &mut dyn Write = &mut std::io::stdout();
     let prepared = match prepare(name, base, budget, true, info)? {
         Preparation::Ready(prepared) => prepared,
         Preparation::Exit(code) => return Ok(code),
@@ -1312,11 +1302,6 @@ fn merge(
         _lock,
     } = prepared;
     let upstream = upstream_branch(&lane_path, &branch);
-    let departing = origin
-        .as_deref()
-        .and_then(|origin| origin.canonicalize().ok())
-        .zip(lane_path.canonicalize().ok())
-        .is_some_and(|(origin, lane)| origin.starts_with(lane));
 
     if squash {
         git(&["merge", "--squash", &branch], Some(&root))?;
@@ -1352,12 +1337,6 @@ fn merge(
             .unwrap_or_default();
         wt::remove(&name)?;
         writeln!(info, "removed lane {branch}")?;
-    }
-    if cd {
-        println!(
-            "{}",
-            origin.filter(|_| !departing).unwrap_or(root).display()
-        );
     }
     Ok(0)
 }
@@ -1462,10 +1441,13 @@ fn rm(name: &str, force: bool) -> Result<i32> {
 fn shellenv() -> Result<i32> {
     println!(
         r#"lane() {{
+  local p
   case "$1" in
-    new)   shift; local p; p=$(command lane new --cd "$@")   || return; cd "$p" ;;
-    cd)    shift; local p; p=$(command lane path "$1")       || return; cd "$p" ;;
-    merge) shift; local p; p=$(command lane merge --cd "$@") || return; cd "$p" ;;
+    new|enter|switch|exit) p=$(command lane "$@") || return; cd "$p" ;;
+    # Read the destination first: merge deletes the worktree, and nothing runs from a
+    # directory that no longer exists. Stay put unless it was ours that went away.
+    merge) p=$(command lane exit) || return; command lane "$@" || return
+           cd "$PWD" 2>/dev/null || cd "$p" ;;
     *)     command lane "$@" ;;
   esac
 }}"#

--- a/crates/lane/src/help.rs
+++ b/crates/lane/src/help.rs
@@ -14,7 +14,8 @@ pub enum Help {
     Init,
     New,
     Ls,
-    Path,
+    Enter,
+    Exit,
     Anchors,
     Note,
     NoteAdd,
@@ -45,7 +46,8 @@ impl Help {
             Help::Init => INIT,
             Help::New => NEW,
             Help::Ls => LS,
-            Help::Path => PATH,
+            Help::Enter => ENTER,
+            Help::Exit => EXIT,
             Help::Anchors => ANCHORS,
             Help::Note => NOTE,
             Help::NoteAdd => NOTE_ADD,
@@ -76,7 +78,8 @@ impl Help {
             Help::Init => "lane init",
             Help::New => "lane new [OPTIONS] <NAME>",
             Help::Ls => "lane ls [--json]",
-            Help::Path => "lane path <NAME>",
+            Help::Enter => "lane enter <NAME>",
+            Help::Exit => "lane exit",
             Help::Anchors => "lane anchors [--json] <PATH>",
             Help::Note => "lane note <COMMAND>",
             Help::NoteAdd => "lane note add [OPTIONS] <PATH> [TEXT]",
@@ -119,7 +122,8 @@ impl Help {
             Help::Init => "lane init",
             Help::New => "lane new",
             Help::Ls => "lane ls",
-            Help::Path => "lane path",
+            Help::Enter => "lane enter",
+            Help::Exit => "lane exit",
             Help::Anchors => "lane anchors",
             Help::Note => "lane note",
             Help::NoteAdd => "lane note add",
@@ -155,8 +159,9 @@ const ROOT: &str = "
   Commands
     init         Scaffold memory + merge rules, probe reflink
     new          Create a CoW lane
+    enter        Change directory into a lane
+    exit         Change directory back to the main worktree
     ls           List lanes
-    path         Print a lane's path
     anchors      List addressable anchors in a file
     note         Manage memory notes
     install      Install lane's agent integrations
@@ -204,7 +209,6 @@ const NEW: &str = "
   Options
     --base <rev>    Branch from <rev> instead of the default base
     --dirty         Carry uncommitted work into the lane
-    --cd            Print the path last, for the shell function
     -h, --help      Display this message
 
   Examples
@@ -226,12 +230,27 @@ const LS: &str = "
     -h, --help    Display this message
 ";
 
-const PATH: &str = "
+const ENTER: &str = "
   Description
-    Print one lane's worktree path.
+    Change directory into a lane. Also spelled `switch`.
 
   Usage
-    $ lane path <name>
+    $ lane enter <name>
+
+  Options
+    -h, --help    Display this message
+
+  Examples
+    $ lane enter fix-login
+    $ lane switch fix-login
+";
+
+const EXIT: &str = "
+  Description
+    Change directory back to the main worktree.
+
+  Usage
+    $ lane exit
 
   Options
     -h, --help    Display this message
@@ -465,7 +484,6 @@ const MERGE: &str = "
     --base <ref>        Rebase onto <ref> instead of the recorded base
     --squash            Squash the lane's commits into one landing commit
     --keep              Leave the worktree in place after landing
-    --cd                Print the path last, for the shell function
     --max-notes <n>     Notes kept per anchor (default: 5)
     --max-chars <n>     Characters kept per anchor (default: 1200)
     -h, --help          Display this message
@@ -524,8 +542,8 @@ const RM: &str = "
 
 const SHELLENV: &str = "
   Description
-    Print the shell function that leaves you in the right directory after
-    `lane new` and `lane merge`, and adds `lane cd <name>`.
+    Print the shell function that makes `lane enter`, `lane exit`, `lane new`
+    and `lane merge` leave the shell in the right directory.
 
   Usage
     $ eval \"$(lane shellenv)\"

--- a/crates/lane/src/help.rs
+++ b/crates/lane/src/help.rs
@@ -232,7 +232,7 @@ const LS: &str = "
 
 const ENTER: &str = "
   Description
-    Change directory into a lane. Also spelled `switch`.
+    Change directory into a lane. Or `switch` alias.
 
   Usage
     $ lane enter <name>

--- a/crates/lane/src/worktree.rs
+++ b/crates/lane/src/worktree.rs
@@ -144,8 +144,9 @@ fn prepare_lanes_dir(root: &Path) -> Result<()> {
     if !ignore.exists() {
         std::fs::write(ignore, "*\n")?;
     }
+    // --git-path answers relative to the repository, not to wherever the process stands.
     let exclude = git(&["rev-parse", "--git-path", "info/exclude"], Some(root))?;
-    append_line(Path::new(&exclude), &format!("{TREES_PATH}/"))
+    append_line(&root.join(exclude), &format!("{TREES_PATH}/"))
 }
 
 fn excluded(root: &Path) -> HashSet<String> {
@@ -735,6 +736,21 @@ mod tests {
             std::thread::sleep(std::time::Duration::from_millis(50));
         }
         panic!("sweep left the trash behind");
+    }
+
+    #[test]
+    fn the_exclude_file_is_found_from_outside_the_repository() -> Result<()> {
+        let root = tempfile::tempdir()?;
+        let r = root.path();
+        git(&["init", "-qb", "main"], Some(r))?;
+
+        // The test process stands in the crate directory, never in `r`: the same relation a
+        // lane has to the repository it was made from.
+        prepare_lanes_dir(r)?;
+
+        let exclude = std::fs::read_to_string(r.join(".git/info/exclude"))?;
+        assert!(exclude.contains(TREES_PATH), "{exclude}");
+        Ok(())
     }
 
     #[test]

--- a/crates/lane/tests/args.rs
+++ b/crates/lane/tests/args.rs
@@ -42,7 +42,9 @@ fn every_command_answers_its_own_help_flag() {
         ("init", Help::Init),
         ("new", Help::New),
         ("ls", Help::Ls),
-        ("path", Help::Path),
+        ("enter", Help::Enter),
+        ("switch", Help::Enter),
+        ("exit", Help::Exit),
         ("anchors", Help::Anchors),
         ("note", Help::Note),
         ("install", Help::Install),
@@ -104,14 +106,13 @@ fn new_reads_its_flags_before_or_after_the_name() {
         name: "fix-login".into(),
         base: Some("main".into()),
         dirty: true,
-        cd: true,
     });
     assert_eq!(
-        ok(&["new", "fix-login", "--base", "main", "--dirty", "--cd"]),
+        ok(&["new", "fix-login", "--base", "main", "--dirty"]),
         expected
     );
     assert_eq!(
-        ok(&["new", "--cd", "--base", "main", "--dirty", "fix-login"]),
+        ok(&["new", "--base", "main", "--dirty", "fix-login"]),
         expected
     );
 }
@@ -124,31 +125,41 @@ fn new_defaults_the_flags_it_was_not_given() {
             name: "spike".into(),
             base: None,
             dirty: false,
-            cd: false,
         })
     );
 }
 
 #[test]
 fn the_shell_function_s_own_invocation_still_parses() {
-    // `lane shellenv` writes `command lane new --cd "$@"`, so the flag
-    // arrives before the name and must not swallow it.
+    // `lane shellenv` writes `command lane "$@"` for each of the four verbs it wraps,
+    // so every one of them must parse with nothing added.
     assert_eq!(
-        ok(&["new", "--cd", "fix-login"]),
+        ok(&["new", "fix-login"]),
         Parsed::New(NewArgs {
             name: "fix-login".into(),
             base: None,
             dirty: false,
-            cd: true,
         })
     );
     assert_eq!(
-        ok(&["merge", "--cd"]),
+        ok(&["enter", "fix-login"]),
+        Parsed::Enter {
+            name: "fix-login".into()
+        }
+    );
+    assert_eq!(
+        ok(&["switch", "fix-login"]),
+        Parsed::Enter {
+            name: "fix-login".into()
+        }
+    );
+    assert_eq!(ok(&["exit"]), Parsed::Exit);
+    assert_eq!(
+        ok(&["merge"]),
         Parsed::Merge(MergeArgs {
             name: None,
             base: None,
             keep: false,
-            cd: true,
             squash: false,
             budget: Budget::default(),
         })
@@ -571,7 +582,6 @@ fn merge_and_rm_read_the_rest_of_their_flags() {
             name: None,
             base: Some("release".into()),
             keep: true,
-            cd: false,
             squash: true,
             budget: Budget::default(),
         })
@@ -585,11 +595,12 @@ fn merge_and_rm_read_the_rest_of_their_flags() {
     );
     assert_eq!(ok(&["check", "--json"]), Parsed::Check { json: true });
     assert_eq!(
-        ok(&["path", "spike"]),
-        Parsed::Path {
+        ok(&["enter", "spike"]),
+        Parsed::Enter {
             name: "spike".into()
         }
     );
+    assert_eq!(ok(&["exit"]), Parsed::Exit);
 }
 
 #[test]
@@ -643,7 +654,7 @@ fn every_command_the_root_screen_lists_parses() {
         .take_while(|line| !line.trim().is_empty())
         .filter_map(|line| line.split_whitespace().next())
         .collect();
-    assert_eq!(listed.len(), 16, "{listed:?}");
+    assert_eq!(listed.len(), 17, "{listed:?}");
     for name in listed {
         assert!(matches!(ok(&[name, "--help"]), Parsed::Help(_)), "{name}");
     }
@@ -656,7 +667,8 @@ fn every_screen_quotes_a_usage_line_it_agrees_with() {
         Help::Init,
         Help::New,
         Help::Ls,
-        Help::Path,
+        Help::Enter,
+        Help::Exit,
         Help::Anchors,
         Help::Note,
         Help::NoteAdd,

--- a/readme.md
+++ b/readme.md
@@ -46,7 +46,7 @@ Lane requires Rust 1.85 or newer.
 
 ## Set up a repository
 
-Enable the shell wrapper once in `.zshrc` or `.bashrc`; it leaves the shell in the new lane after `lane new` and returns it to the main worktree after `lane merge`:
+Enable the shell wrapper once in `.zshrc` or `.bashrc`; it is what lets `lane new`, `lane enter`, `lane exit` and `lane merge` move the shell:
 
 ```bash
 eval "$(lane shellenv)"

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -428,9 +428,27 @@ setup
 PATH="$(dirname "$LANE"):$PATH"
 eval "$(command lane shellenv)"
 
-is "new --cd puts only the path on stdout" \
-   "$(command lane new probe --cd 2>/dev/null | wc -l | tr -d ' ')" "1"
+is "new puts only the path on stdout" \
+   "$(command lane new probe 2>/dev/null | wc -l | tr -d ' ')" "1"
+is "enter puts only the path on stdout" \
+   "$(command lane enter probe 2>/dev/null | wc -l | tr -d ' ')" "1"
+is "switch is the same command as enter" \
+   "$(command lane switch probe 2>/dev/null)" "$(command lane enter probe 2>/dev/null)"
+is "exit prints the main worktree" \
+   "$(command lane exit 2>/dev/null)" "$(cd "$TMP/repo" && pwd -P)"
 command lane rm probe --force > /dev/null 2>&1
+
+cd "$TMP/repo"
+lane new hop > /dev/null 2>&1
+cd "$TMP/repo"
+lane enter hop
+is "enter moves the shell into the lane" \
+   "$PWD" "$(cd "$TMP/repo/.lane/trees/hop" && pwd -P)"
+lane exit
+is "exit moves the shell back to the main worktree" "$PWD" "$(cd "$TMP/repo" && pwd -P)"
+lane enter nosuchlane > /dev/null 2>&1
+is "a failed enter leaves the shell where it was" "$PWD" "$(cd "$TMP/repo" && pwd -P)"
+lane rm hop --force > /dev/null 2>&1
 
 cd "$TMP/repo"
 lane new dup > /dev/null 2>&1

--- a/www/src/data/commands.ts
+++ b/www/src/data/commands.ts
@@ -36,12 +36,11 @@ export let commands: Command[] = [
 	},
 	{
 		name: "new",
-		usage: "lane new <name> [--base <ref>] [--dirty] [--cd]",
+		usage: "lane new <name> [--base <ref>] [--dirty]",
 		summary: "creates a branch and a copy-on-write worktree under .lane/trees/, cloning everything git ignores by reference.",
 		options: [
 			{ flag: "--base", arg: "<ref>", about: "ref the lane branches from; defaults to the repo's trunk." },
 			{ flag: "--dirty", arg: null, about: "carry uncommitted work into the lane." },
-			{ flag: "--cd", arg: null, about: "print the path last on stdout, for the shell function." },
 		],
 		example: "$ lane new fix-login\n  reflink: yes (reflink available)\n  1284 files cloned (612.4 MiB shared, 0 copied)\n/w/proj/.lane/trees/fix-login",
 	},
@@ -55,11 +54,18 @@ export let commands: Command[] = [
 		example: '$ lane ls --json\n[{"name":"agent-a","path":"/w/proj/.lane/trees/agent-a","branch":"agent-a","state":"open","dirty":false,"pending_notes":3}]',
 	},
 	{
-		name: "path",
-		usage: "lane path <name>",
-		summary: "prints the absolute path of a lane's worktree.",
+		name: "enter",
+		usage: "lane enter <name>",
+		summary: "changes directory into a lane; also spelled `switch`.",
 		options: [],
-		example: "$ lane path fix-login\n/w/proj/.lane/trees/fix-login",
+		example: "$ lane enter fix-login\n/w/proj/.lane/trees/fix-login",
+	},
+	{
+		name: "exit",
+		usage: "lane exit",
+		summary: "changes directory back to the main worktree.",
+		options: [],
+		example: "$ lane exit\n/w/proj",
 	},
 	{
 		name: "anchors",
@@ -170,7 +176,6 @@ export let commands: Command[] = [
 			{ flag: "--base", arg: "<ref>", about: "ref to rebase onto and advance; defaults to the lane's recorded base." },
 			{ flag: "--keep", arg: null, about: "keep the lane worktree and branch after landing." },
 			{ flag: "--squash", arg: null, about: "squash the lane's commits into one landing commit." },
-			{ flag: "--cd", arg: null, about: "print the main root path last on stdout, for the shell function." },
 			{ flag: "--max-notes", arg: "<n>", about: "keep at most this many notes per path and anchor; default 5." },
 			{ flag: "--max-chars", arg: "<n>", about: "keep at most this many characters per path and anchor; default 1200." },
 		],
@@ -238,7 +243,7 @@ export let commands: Command[] = [
 		usage: "lane shellenv",
 		summary: "prints the shell function that makes new, cd and merge leave you in the right directory.",
 		options: [],
-		example: "$ eval \"$(lane shellenv)\"\n$ lane shellenv\nlane() {\n  case \"$1\" in\n    new)   shift; p=$(command lane new --cd \"$@\") ...\n    cd)    shift; p=$(command lane path \"$@\") ...\n    merge) shift; p=$(command lane merge --cd \"$@\") ...\n    *)     command lane \"$@\" ;;\n  esac\n}",
+		example: "$ eval \"$(lane shellenv)\"\n$ lane shellenv\nlane() {\n  local p\n  case \"$1\" in\n    new|enter|switch|exit) p=$(command lane \"$@\") || return; cd \"$p\" ;;\n    merge) p=$(command lane exit) || return; command lane \"$@\" || return\n           cd \"$PWD\" 2>/dev/null || cd \"$p\" ;;\n    *)     command lane \"$@\" ;;\n  esac\n}",
 	},
 	{
 		name: "capture",

--- a/www/src/data/commands.ts
+++ b/www/src/data/commands.ts
@@ -56,7 +56,7 @@ export let commands: Command[] = [
 	{
 		name: "enter",
 		usage: "lane enter <name>",
-		summary: "changes directory into a lane; also spelled `switch`.",
+		summary: "changes directory into a lane. Or `switch` alias.",
 		options: [],
 		example: "$ lane enter fix-login\n/w/proj/.lane/trees/fix-login",
 	},

--- a/www/src/pages/usage.md
+++ b/www/src/pages/usage.md
@@ -26,7 +26,7 @@ $ lane merge                # rebase, distill memory, fast-forward, delete
 
 ```bash
 $ cargo install --path crates/lane
-$ eval "$(lane shellenv)"   # add to .zshrc: makes `lane new` cd into the lane
+$ eval "$(lane shellenv)"   # add to .zshrc: makes `lane new` and `lane enter` cd
 $ cd yourproject && lane init
 $ git add .lane .gitattributes AGENTS.md
 $ git commit -m "lane: context memory"
@@ -355,7 +355,8 @@ The short version. See [commands](/commands) for full information.
 | `lane init` | scaffold, probe reflink |
 | `lane new <name> [--dirty] [--base <ref>]` | create a lane |
 | `lane ls` | lanes, whether they landed, dirt, pending notes |
-| `lane path <name>` | print a lane's path |
+| `lane enter <name>` | change directory into a lane; also spelled `switch` |
+| `lane exit` | change directory back to the main worktree |
 | `lane anchors <file> [--json]` | list canonical anchors and line ranges |
 | `lane note add <file> [-a <anchor>] [<text>]` | record a finding; omit text for interaction |
 | `lane note edit <id>` | interactively confirm, replace, retire, pin, or unpin a live note |
@@ -370,7 +371,7 @@ The short version. See [commands](/commands) for full information.
 | `lane why <path> [-a <anchor>]` | read the notes on a file or a directory; changes nothing |
 | `lane check [--json]` | staleness report; exits 1 on missing anchors |
 | `lane audit [--base <ref>]` | run the memory pass alone |
-| `lane merge [<name>] [--keep] [--base <ref>] [--squash] [--cd]` | rebase, audit, fast-forward, remove |
+| `lane merge [<name>] [--keep] [--base <ref>] [--squash]` | rebase, audit, fast-forward, remove |
 | `lane push [<name>] [--base <ref>]` | rebase, audit, commit memory, and push for a pull request |
 | `lane prune [--dry-run]` | remove lanes whose branch has landed in trunk |
 | `lane rm <name> [--force]` | discard a lane; it stops and names uncommitted work, pending notes, or commits trunk does not have, `--force` drops them |

--- a/www/src/pages/usage.md
+++ b/www/src/pages/usage.md
@@ -355,7 +355,7 @@ The short version. See [commands](/commands) for full information.
 | `lane init` | scaffold, probe reflink |
 | `lane new <name> [--dirty] [--base <ref>]` | create a lane |
 | `lane ls` | lanes, whether they landed, dirt, pending notes |
-| `lane enter <name>` | change directory into a lane; also spelled `switch` |
+| `lane enter <name>` | change directory into a lane. Or `switch` alias |
 | `lane exit` | change directory back to the main worktree |
 | `lane anchors <file> [--json]` | list canonical anchors and line ranges |
 | `lane note add <file> [-a <anchor>] [<text>]` | record a finding; omit text for interaction |


### PR DESCRIPTION
`lane enter <name>` moves you into a lane. `lane exit` moves you back. `switch` is a second spelling of `enter`.

That was previously a flag on two commands that do other things: `lane new` and `lane merge` took `--cd`, which rewired their output streams so the shell function could read a path off stdout, and `lane cd` existed only inside that function — spelled `lane path` when typed by hand. `--cd` and `lane path` are both gone. `lane new` keeps printing its path, with progress moved to stderr.

## The wrapper

```sh
lane() {
  local p
  case "$1" in
    new|enter|switch|exit) p=$(command lane "$@") || return; cd "$p" ;;
    merge) p=$(command lane exit) || return; command lane "$@" || return
           cd "$PWD" 2>/dev/null || cd "$p" ;;
    *)     command lane "$@" ;;
  esac
}
```

`merge` reads its destination *before* merging, because the merge deletes the worktree and nothing runs from a directory that no longer exists — `git rev-parse` and `lane` itself both fail there with `ENOENT`. Afterwards it stays put unless the lane that went away was the one you were standing in, which `cd "$PWD"` answers without lane needing to know.

Without the wrapper installed, `enter` and `exit` cannot move anything, and printing a path silently reads as the command doing nothing. A terminal on stdout means nothing captured the destination, so no shell function ran; that case now names the reason:

```
$ lane exit
/w/proj
note: no shell integration; add `eval "$(lane shellenv)"` to cd automatically
```

The note goes to stderr, so a capture never sees it.

## A bug found on the way

`lane new` failed from inside a lane with a bare `Not a directory (os error 20)`. `git rev-parse --git-path info/exclude` answers relative to the repository, and lane opened that answer relative to the process — inside a lane `.git` is a file, so `.git/info/exclude` is not a directory to open through. It reproduces on `main` and it is exactly what `enter` invites you to do, so it is fixed here with a test that stands outside the repository the way a lane does.

## Verified

`scripts/test.sh` section 19 covers the shell integration: `new`, `enter` and `exit` each put one path on stdout and nothing else, `switch` answers identically to `enter`, and through the wrapper both move the shell and leave it where it was when the lane does not exist. 242 assertions, 0 failing.

Also end to end in a real zsh: `new` from inside another lane, `merge <name>` from a different lane staying put, and `merge` of your own lane landing at the root from a deleted cwd. The terminal hint verified through a pty.

175 cargo tests, clippy clean across the workspace.