### PR TITLE
ci: add a linux clone benchmark

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -13,6 +13,9 @@ on:
       files:
         description: ignored files in the synthetic repository
         default: "20000"
+      order:
+        description: which binary runs first, to separate a code difference from a position one
+        default: "base head"
       runs:
         description: timed runs per measurement, best of
         default: "3"
@@ -92,30 +95,34 @@ jobs:
         env:
           FILES: ${{ inputs.files || '20000' }}
           RUNS: ${{ inputs.runs || '3' }}
+          ORDER: ${{ inputs.order || 'base head' }}
         run: |
           set -uo pipefail
-          for which in base head; do
+          for which in $ORDER; do
             bin="$RUNNER_TEMP/lane-$which"
             [ -x "$bin" ] || continue
             echo "== $which =="
             ./scripts/bench.sh "$bin" "$BENCH_DIR/$which" "$FILES" "$RUNS" \
               | tee "$RUNNER_TEMP/$which.txt"
-            # Leave the filesystem as the next binary found it. The first run measured
-            # `lane rm` at 0.02s and the second at 0.88s from the same code, because the
-            # first repository was still on the disk and still being unlinked.
-            rm -rf "${BENCH_DIR:?}/$which"
-            sync
-            sleep 5
+            # Leave the filesystem as the next binary found it, but keep the last repo:
+            # the syscall profile runs in it.
+            if [ "$which" != "${ORDER##* }" ]; then
+              rm -rf "${BENCH_DIR:?}/$which"
+              sync
+              sleep 5
+            fi
           done
 
       # Where the time goes, rather than how much of it there is. On Darwin the answer was
       # one clonefile per file; this is the same question asked of FICLONE.
       - name: Profile the syscalls
+        env:
+          ORDER: ${{ inputs.order || 'base head' }}
         run: |
           set -euo pipefail
           sudo apt-get install -y -qq strace
-          bin="$RUNNER_TEMP/lane-head"; which=head
-          [ -x "$bin" ] || { bin="$RUNNER_TEMP/lane-base"; which=base; }
+          which="${ORDER##* }"
+          bin="$RUNNER_TEMP/lane-$which"
           cd "$BENCH_DIR/$which/repo"
           strace -f -c -o "$RUNNER_TEMP/strace.txt" "$bin" new profiled >/dev/null 2>&1
           "$bin" rm profiled --force >/dev/null 2>&1

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -35,7 +35,11 @@ jobs:
       fail-fast: false
       matrix:
         fs: [ext4, btrfs, xfs]
+        # Uniform stubs measure syscall count alone; a built target/ puts real archives
+        # among them, which is where sharing extents rather than copying them shows.
+        workload: [synthetic, cargo]
     runs-on: ubuntu-latest
+    name: ${{ matrix.fs }} / ${{ matrix.workload }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -96,13 +100,14 @@ jobs:
           FILES: ${{ inputs.files || '20000' }}
           RUNS: ${{ inputs.runs || '3' }}
           ORDER: ${{ inputs.order || 'base head' }}
+          WORKLOAD: ${{ matrix.workload }}
         run: |
           set -uo pipefail
           for which in $ORDER; do
             bin="$RUNNER_TEMP/lane-$which"
             [ -x "$bin" ] || continue
             echo "== $which =="
-            ./scripts/bench.sh "$bin" "$BENCH_DIR/$which" "$FILES" "$RUNS" \
+            ./scripts/bench.sh "$bin" "$BENCH_DIR/$which" "$FILES" "$RUNS" "$WORKLOAD" \
               | tee "$RUNNER_TEMP/$which.txt"
             # Leave the filesystem as the next binary found it, but keep the last repo:
             # the syscall profile runs in it.
@@ -134,11 +139,11 @@ jobs:
           BASELINE: ${{ inputs.baseline || 'main' }}
         run: |
           {
-            echo "## ${{ matrix.fs }}"
+            echo "## ${{ matrix.fs }} / ${{ matrix.workload }}"
             echo
             echo "| key | baseline (${BASELINE:-none}) | this ref |"
             echo '| --- | --- | --- |'
-            for key in kernel filesystem ignored_files reflink lane_new lane_rm; do
+            for key in kernel filesystem mode ignored_files ignored_bytes reflink lane_new lane_rm; do
               b=$(awk -F= -v k="$key" '$1==k{print $2}' "$RUNNER_TEMP/base.txt" 2>/dev/null)
               h=$(awk -F= -v k="$key" '$1==k{print $2}' "$RUNNER_TEMP/head.txt" 2>/dev/null)
               echo "| $key | ${b:-—} | ${h:-—} |"

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -3,8 +3,6 @@ name: bench
 # Manual only. Loop-mounting a filesystem and writing 20k files is too slow to gate a
 # pull request, and the numbers are only worth reading when someone is asking for them.
 on:
-  push:
-    branches: [bench-linux]
   workflow_dispatch:
     inputs:
       baseline:

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -100,6 +100,12 @@ jobs:
             echo "== $which =="
             ./scripts/bench.sh "$bin" "$BENCH_DIR/$which" "$FILES" "$RUNS" \
               | tee "$RUNNER_TEMP/$which.txt"
+            # Leave the filesystem as the next binary found it. The first run measured
+            # `lane rm` at 0.02s and the second at 0.88s from the same code, because the
+            # first repository was still on the disk and still being unlinked.
+            rm -rf "${BENCH_DIR:?}/$which"
+            sync
+            sleep 5
           done
 
       # Where the time goes, rather than how much of it there is. On Darwin the answer was

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -95,7 +95,7 @@ jobs:
         env:
           FILES: ${{ inputs.files || '20000' }}
           RUNS: ${{ inputs.runs || '3' }}
-          ORDER: ${{ inputs.order || 'head base' }}
+          ORDER: ${{ inputs.order || 'base head' }}
         run: |
           set -uo pipefail
           for which in $ORDER; do
@@ -117,7 +117,7 @@ jobs:
       # one clonefile per file; this is the same question asked of FICLONE.
       - name: Profile the syscalls
         env:
-          ORDER: ${{ inputs.order || 'head base' }}
+          ORDER: ${{ inputs.order || 'base head' }}
         run: |
           set -euo pipefail
           sudo apt-get install -y -qq strace

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -3,6 +3,8 @@ name: bench
 # Manual only. Loop-mounting a filesystem and writing 20k files is too slow to gate a
 # pull request, and the numbers are only worth reading when someone is asking for them.
 on:
+  push:
+    branches: [bench-linux]
   workflow_dispatch:
     inputs:
       baseline:
@@ -74,7 +76,7 @@ jobs:
       # string somebody typed.
       - name: Build the binaries
         env:
-          BASELINE: ${{ inputs.baseline }}
+          BASELINE: ${{ inputs.baseline || 'main' }}
         run: |
           set -euo pipefail
           cargo build --release --quiet
@@ -88,8 +90,8 @@ jobs:
 
       - name: Measure
         env:
-          FILES: ${{ inputs.files }}
-          RUNS: ${{ inputs.runs }}
+          FILES: ${{ inputs.files || '20000' }}
+          RUNS: ${{ inputs.runs || '3' }}
         run: |
           set -uo pipefail
           for which in base head; do
@@ -116,7 +118,7 @@ jobs:
       - name: Summarize
         if: always()
         env:
-          BASELINE: ${{ inputs.baseline }}
+          BASELINE: ${{ inputs.baseline || 'main' }}
         run: |
           {
             echo "## ${{ matrix.fs }}"

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -1,0 +1,138 @@
+name: bench
+
+# Manual only. Loop-mounting a filesystem and writing 20k files is too slow to gate a
+# pull request, and the numbers are only worth reading when someone is asking for them.
+on:
+  workflow_dispatch:
+    inputs:
+      baseline:
+        description: ref to measure against, or empty to measure this ref alone
+        default: main
+      files:
+        description: ignored files in the synthetic repository
+        default: "20000"
+      runs:
+        description: timed runs per measurement, best of
+        default: "3"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  measure:
+    # ext4 has no reflink, so it is the fallback copy and not a clone at all. btrfs and XFS
+    # are the two implementations FICLONE actually runs on, and they are separate answers.
+    strategy:
+      fail-fast: false
+      matrix:
+        fs: [ext4, btrfs, xfs]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+
+      # Restore only: a benchmark must not spend the repository's 10 GB cache budget.
+      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
+        with:
+          shared-key: ubuntu-latest
+          save-if: "false"
+
+      - name: Report the machine
+        run: |
+          uname -a
+          nproc
+          df -PTh "$RUNNER_TEMP" | tail -1
+
+      - name: Mount ${{ matrix.fs }}
+        run: |
+          set -euo pipefail
+          if [ "${{ matrix.fs }}" = ext4 ]; then
+            # The runner's own disk. No image, no mount, no reflink.
+            echo "BENCH_DIR=$RUNNER_TEMP/bench" >> "$GITHUB_ENV"
+            mkdir -p "$RUNNER_TEMP/bench"
+            exit 0
+          fi
+          sudo apt-get update -qq
+          sudo apt-get install -y -qq btrfs-progs xfsprogs
+          truncate -s 8G "$RUNNER_TEMP/fs.img"
+          case "${{ matrix.fs }}" in
+            btrfs) mkfs.btrfs -q "$RUNNER_TEMP/fs.img" ;;
+            # reflink is default on new XFS, but say it: an older mkfs silently omits it.
+            xfs)   mkfs.xfs -q -m reflink=1 "$RUNNER_TEMP/fs.img" ;;
+          esac
+          sudo mkdir -p /mnt/bench
+          sudo mount -o loop "$RUNNER_TEMP/fs.img" /mnt/bench
+          sudo chown "$(id -u):$(id -g)" /mnt/bench
+          echo "BENCH_DIR=/mnt/bench" >> "$GITHUB_ENV"
+
+      # Inputs reach the shell as environment, never as interpolated text: a ref is a
+      # string somebody typed.
+      - name: Build the binaries
+        env:
+          BASELINE: ${{ inputs.baseline }}
+        run: |
+          set -euo pipefail
+          cargo build --release --quiet
+          cp target/release/lane "$RUNNER_TEMP/lane-head"
+          if [ -n "$BASELINE" ]; then
+            git fetch -q origin "$BASELINE"
+            git worktree add --detach "$RUNNER_TEMP/baseline" FETCH_HEAD
+            cargo build --release --quiet --manifest-path "$RUNNER_TEMP/baseline/Cargo.toml"
+            cp "$RUNNER_TEMP/baseline/target/release/lane" "$RUNNER_TEMP/lane-base"
+          fi
+
+      - name: Measure
+        env:
+          FILES: ${{ inputs.files }}
+          RUNS: ${{ inputs.runs }}
+        run: |
+          set -uo pipefail
+          for which in base head; do
+            bin="$RUNNER_TEMP/lane-$which"
+            [ -x "$bin" ] || continue
+            echo "== $which =="
+            ./scripts/bench.sh "$bin" "$BENCH_DIR/$which" "$FILES" "$RUNS" \
+              | tee "$RUNNER_TEMP/$which.txt"
+          done
+
+      # Where the time goes, rather than how much of it there is. On Darwin the answer was
+      # one clonefile per file; this is the same question asked of FICLONE.
+      - name: Profile the syscalls
+        run: |
+          set -euo pipefail
+          sudo apt-get install -y -qq strace
+          bin="$RUNNER_TEMP/lane-head"; which=head
+          [ -x "$bin" ] || { bin="$RUNNER_TEMP/lane-base"; which=base; }
+          cd "$BENCH_DIR/$which/repo"
+          strace -f -c -o "$RUNNER_TEMP/strace.txt" "$bin" new profiled >/dev/null 2>&1
+          "$bin" rm profiled --force >/dev/null 2>&1
+          cat "$RUNNER_TEMP/strace.txt"
+
+      - name: Summarize
+        if: always()
+        env:
+          BASELINE: ${{ inputs.baseline }}
+        run: |
+          {
+            echo "## ${{ matrix.fs }}"
+            echo
+            echo "| key | baseline (${BASELINE:-none}) | this ref |"
+            echo '| --- | --- | --- |'
+            for key in kernel filesystem ignored_files reflink lane_new lane_rm; do
+              b=$(awk -F= -v k="$key" '$1==k{print $2}' "$RUNNER_TEMP/base.txt" 2>/dev/null)
+              h=$(awk -F= -v k="$key" '$1==k{print $2}' "$RUNNER_TEMP/head.txt" 2>/dev/null)
+              echo "| $key | ${b:-—} | ${h:-—} |"
+            done
+            echo
+            echo '<details><summary>syscalls</summary>'
+            echo
+            echo '```'
+            cat "$RUNNER_TEMP/strace.txt" 2>/dev/null | head -25
+            echo '```'
+            echo '</details>'
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -95,7 +95,7 @@ jobs:
         env:
           FILES: ${{ inputs.files || '20000' }}
           RUNS: ${{ inputs.runs || '3' }}
-          ORDER: ${{ inputs.order || 'base head' }}
+          ORDER: ${{ inputs.order || 'head base' }}
         run: |
           set -uo pipefail
           for which in $ORDER; do
@@ -117,7 +117,7 @@ jobs:
       # one clonefile per file; this is the same question asked of FICLONE.
       - name: Profile the syscalls
         env:
-          ORDER: ${{ inputs.order || 'base head' }}
+          ORDER: ${{ inputs.order || 'head base' }}
         run: |
           set -euo pipefail
           sudo apt-get install -y -qq strace

--- a/scripts/bench.sh
+++ b/scripts/bench.sh
@@ -82,11 +82,18 @@ settle "$REPO"
 
 # Both timings come from one loop: a lane must be removed before the next can be made, and
 # timing `new` against a name that already exists measures the refusal instead.
+# A command that fails returns fast, and a fast number is what this script is looking for.
+# Check the status or a broken lane reads as a quick one.
+run() {
+  local out; out=$("$@" 2>&1)
+  [ $? -eq 0 ] || { echo "FAILED: $* -> $out" >&2; exit 1; }
+}
+
 new_best=""; rm_best=""
 for _ in $(seq 1 "$RUNS"); do
-  t=$( { time "$LANE" new bench >/dev/null 2>&1; } 2>&1 )
+  t=$( { time run "$LANE" new bench; } 2>&1 )
   new_best=$(lower "${new_best:-$t}" "$t")
-  t=$( { time "$LANE" rm bench --force >/dev/null 2>&1; } 2>&1 )
+  t=$( { time run "$LANE" rm bench --force; } 2>&1 )
   rm_best=$(lower "${rm_best:-$t}" "$t")
   settle "$REPO"
 done

--- a/scripts/bench.sh
+++ b/scripts/bench.sh
@@ -1,286 +1,95 @@
 #!/usr/bin/env bash
-# Benchmark harness. Builds one deterministic repo and times every command against it,
-# so a number means the same thing on Monday as it did on Friday.
+# Times `lane new` and `lane rm` against a synthetic repository.
 #
-# The fixture is generated, never the lane repo itself: the live repo's note count and
-# file sizes drift with every commit, which is exactly what a baseline must not do.
+# The cost lane pays is one syscall per ignored file, so the file COUNT is the variable
+# that matters and the byte total is not. Run it on the filesystem you care about: ext4
+# has no reflink at all, and the fallback copy it forces is a different measurement.
 #
-#   scripts/bench.sh                          time the current build
-#   scripts/bench.sh --out before.json        record a baseline
-#   scripts/bench.sh --compare before.json    time again and print the deltas
-#   scripts/bench.sh --bin path/to/lane       time a binary built elsewhere
-#   scripts/bench.sh --fixture DIR            build the fixture there and stop, for profiling
-#   scripts/bench.sh --against old-lane       A/B both binaries in one run, immune to drift
+#   scripts/bench.sh <lane-binary> <workdir> [files] [runs]
 set -uo pipefail
 
-ROOT="$(cd "$(dirname "$0")/.." && pwd)"
-RUNS=${RUNS:-100}
-WARMUP=${WARMUP:-15}
-BIN=""
-OUT=""
-BASELINE=""
-FILTER=""
-FIXTURE_ONLY=""
-AGAINST=""
+LANE="${1:?usage: bench.sh <lane-binary> <workdir> [files] [runs]}"
+WORK="${2:?usage: bench.sh <lane-binary> <workdir> [files] [runs]}"
+FILES="${3:-20000}"
+RUNS="${4:-3}"
+command -v "$LANE" >/dev/null 2>&1 || [ -x "$LANE" ] || { echo "no binary at $LANE" >&2; exit 1; }
+LANE="$(cd "$(dirname "$LANE")" && pwd)/$(basename "$LANE")"
 
-while [ $# -gt 0 ]; do
-  case "$1" in
-    --bin)     BIN="$2"; shift 2 ;;
-    --out)     OUT="$2"; shift 2 ;;
-    --compare) BASELINE="$2"; shift 2 ;;
-    --runs)    RUNS="$2"; shift 2 ;;
-    --only)    FILTER="$2"; shift 2 ;;
-    --fixture) FIXTURE_ONLY="$2"; shift 2 ;;
-    --against) AGAINST="$2"; shift 2 ;;
-    -h|--help) sed -n '2,12p' "$0" | sed 's/^# \?//'; exit 0 ;;
-    *) echo "unknown flag: $1" >&2; exit 2 ;;
-  esac
+# %R alone, so the builtin reports wall seconds and nothing else. BSD date has no %N and
+# GNU time is not installed everywhere; this is the one timer both shells always have.
+TIMEFORMAT='%R'
+
+# Noise on a shared runner only ever adds, so the minimum is the honest reading — the same
+# argument the extent-sharing test makes.
+lower() { awk -v a="$1" -v b="$2" 'BEGIN{print (b < a) ? b : a}'; }
+
+# `lane rm` returns before the unlinking does; waiting keeps it out of the next reading.
+settle() {
+  local i
+  for i in $(seq 1 120); do
+    [ -z "$(ls -A "$1/.lane/trees/.trash" 2>/dev/null)" ] && return 0
+    sleep 1
+  done
+}
+
+# Two ignored trees, the shape a real checkout has: a build directory of many small files,
+# and a dependency directory holding symlinks among them.
+build_tree() {
+  local root="$1" count="$2" i dir
+  for i in $(seq 1 "$count"); do
+    dir="$root/$((i / 100))"
+    [ -d "$dir" ] || mkdir -p "$dir"
+    printf 'artifact %d\n' "$i" > "$dir/unit-$i.o"
+  done
+}
+
+REPO="$WORK/repo"
+rm -rf "$REPO"; mkdir -p "$REPO"; cd "$REPO" || exit 1
+
+git init -qb main .
+git config user.email bench@example.com
+git config user.name bench
+mkdir -p src
+for i in $(seq 1 20); do printf 'pub fn f%d() {}\n' "$i" > "src/m$i.rs"; done
+printf 'target/\nnode_modules/\n' > .gitignore
+git add -A && git commit -qm base
+
+build_tree target $((FILES * 2 / 3))
+build_tree node_modules $((FILES - FILES * 2 / 3))
+ln -sf ../src/m1.rs node_modules/relative-link
+ln -sf "$REPO/src/m2.rs" node_modules/absolute-link
+
+"$LANE" init >/dev/null 2>&1
+git add -A >/dev/null 2>&1 && git commit -qm lane >/dev/null 2>&1
+
+echo "kernel=$(uname -sr | tr ' ' '-')"
+# -T is GNU; on BSD read the type out of mount instead.
+fs=$(df -PT . 2>/dev/null | awk 'NR==2{print $2}')
+[ -n "$fs" ] || fs=$(mount | awk -v m="$(df -P . | awk 'NR==2{print $NF}')" '$3==m{print $4}' | tr -d '(,' | head -1)
+echo "filesystem=${fs:-unknown}"
+echo "ignored_files=$(find target node_modules -type f | wc -l | tr -d ' ')"
+
+"$LANE" new probe > /tmp/bench-probe.out 2>&1
+echo "reflink=$(awk '/reflink:/{print $2; exit}' /tmp/bench-probe.out)"
+echo "clone_stats=$(awk '/cloned/{$1=$1; print; exit}' /tmp/bench-probe.out)"
+"$LANE" rm probe --force >/dev/null 2>&1
+settle "$REPO"
+
+# One untimed pair first: the first read of a cold tree is measuring the page cache.
+"$LANE" new warm >/dev/null 2>&1
+"$LANE" rm warm --force >/dev/null 2>&1
+settle "$REPO"
+
+# Both timings come from one loop: a lane must be removed before the next can be made, and
+# timing `new` against a name that already exists measures the refusal instead.
+new_best=""; rm_best=""
+for _ in $(seq 1 "$RUNS"); do
+  t=$( { time "$LANE" new bench >/dev/null 2>&1; } 2>&1 )
+  new_best=$(lower "${new_best:-$t}" "$t")
+  t=$( { time "$LANE" rm bench --force >/dev/null 2>&1; } 2>&1 )
+  rm_best=$(lower "${rm_best:-$t}" "$t")
+  settle "$REPO"
 done
 
-command -v hyperfine >/dev/null || { echo "bench needs hyperfine: brew install hyperfine" >&2; exit 1; }
-command -v jq >/dev/null || { echo "bench needs jq" >&2; exit 1; }
-
-if [ -z "$BIN" ]; then
-  cargo build --release --quiet --manifest-path "$ROOT/crates/lane/Cargo.toml" || exit 1
-  TARGET=$(cargo metadata --no-deps --format-version 1 --manifest-path "$ROOT/crates/lane/Cargo.toml" \
-    | jq -r .target_directory)
-  BIN="$TARGET/release/lane"
-fi
-[ -x "$BIN" ] || { echo "no binary at $BIN" >&2; exit 1; }
-BIN="$(cd "$(dirname "$BIN")" && pwd)/$(basename "$BIN")"
-
-if [ -n "$FIXTURE_ONLY" ]; then
-  TMP="$FIXTURE_ONLY"; mkdir -p "$TMP"; rm -rf "${TMP:?}/repo"
-else
-  TMP=$(mktemp -d); trap 'rm -rf "$TMP"' EXIT
-fi
-
-# ---------------------------------------------------------------------------
-# Fixture: 18 files across 5 grammars, ~180 KB, 30 notes, 3 lanes. Sized to sit
-# near this repo's own shape so a win here is a win in practice.
-# ---------------------------------------------------------------------------
-build_fixture() {
-  REPO="$TMP/repo"
-  mkdir -p "$REPO/src" "$REPO/scripts" "$REPO/docs"
-  cd "$REPO" || exit 1
-  git init -qb main . && git config user.email b@b.b && git config user.name b
-
-  python3 - "$REPO" <<'PY'
-import sys, pathlib
-root = pathlib.Path(sys.argv[1])
-
-def rust(n, decls):
-    out = ["//! generated fixture module\n"]
-    for i in range(decls):
-        out.append(f"""
-pub struct Item{i} {{
-    pub id: usize,
-    pub name: String,
-}}
-
-pub fn handle_{i}(item: &Item{i}) -> usize {{
-    let mut total = item.id;
-    for step in 0..8 {{
-        total = total.wrapping_add(step * item.name.len());
-    }}
-    total
-}}
-""")
-    return "".join(out)
-
-def bash(decls):
-    out = ["#!/usr/bin/env bash\nset -euo pipefail\n"]
-    for i in range(decls):
-        out.append(f"""
-run_step_{i}() {{
-  local input="$1"
-  if [ -z "$input" ]; then return 1; fi
-  printf '%s\\n' "$input"
-}}
-""")
-    return "".join(out)
-
-def markdown(sections):
-    out = ["# Fixture\n"]
-    for i in range(sections):
-        out.append(f"\n## Section {i}\n\nProse for section {i}. " * 3 + "\n")
-    return "".join(out)
-
-def typescript(decls):
-    out = ["export type Id = string;\n"]
-    for i in range(decls):
-        out.append(f"""
-export function transform{i}(input: Id): Id {{
-  const parts = input.split('-');
-  return parts.map((p) => p.trim()).join('/');
-}}
-""")
-    return "".join(out)
-
-# Eight rust files, deliberately uneven: one big file carries most anchors, which is
-# the shape that exposes per-note work repeated over one tree.
-for i, decls in enumerate([220, 130, 90, 65, 50, 40, 30, 20]):
-    (root / "src" / f"mod_{i}.rs").write_text(rust(i, decls))
-for i, decls in enumerate([170, 70, 35]):
-    (root / "scripts" / f"task_{i}.sh").write_text(bash(decls))
-for i in range(3):
-    (root / "docs" / f"page_{i}.md").write_text(markdown(60))
-for i, decls in enumerate([110, 55]):
-    (root / "src" / f"client_{i}.ts").write_text(typescript(decls))
-(root / "Cargo.toml").write_text('[package]\nname = "fixture"\nversion = "0.1.0"\n')
-(root / "README.md").write_text(markdown(4))
-PY
-
-  git add -A && git commit -qm init >/dev/null
-  "$BIN" init >/dev/null 2>&1
-  git add -A && git commit -qm "lane init" >/dev/null
-
-  # 30 notes, weighted onto mod_0.rs so one tree carries many anchors.
-  for i in 0 1 2 3 4 5 6 7 8 9 10 11; do
-    "$BIN" note -p src/mod_0.rs -a "fn handle_$i" "fixture note about handle_$i" >/dev/null 2>&1
-  done
-  for i in 0 1 2 3 4 5; do
-    "$BIN" note -p src/mod_1.rs -a "struct Item$i" "fixture note about Item$i" >/dev/null 2>&1
-  done
-  for i in 1 2 3 4 5 6 7; do
-    "$BIN" note -p "src/mod_$i.rs" -a "fn handle_0" "entry point for module $i" >/dev/null 2>&1
-  done
-  for i in 0 1 2; do
-    "$BIN" note -p "scripts/task_$i.sh" -a "run_step_0" "first step of task $i" >/dev/null 2>&1
-  done
-  "$BIN" note -p src/client_0.ts -a "function transform0" "id shape is dash separated" >/dev/null 2>&1
-  "$BIN" note -p docs/page_0.md -a "@file" "page zero is the entry doc" >/dev/null 2>&1
-  "$BIN" audit >/dev/null 2>&1
-  git add -A && git commit -qm "notes" >/dev/null
-
-  # Three lanes, so `ls` and `prune` have something to walk.
-  for name in alpha beta gamma; do "$BIN" new "$name" >/dev/null 2>&1; done
-
-  NOTES=$(find .lane/memory -name '*.md' 2>/dev/null | wc -l | tr -d ' ')
-  BYTES=$(find src scripts docs -type f -exec cat {} + | wc -c | tr -d ' ')
-  echo "fixture: $NOTES notes, $BYTES bytes of source, 3 lanes" >&2
-}
-
-build_fixture
-cd "$REPO" || exit 1
-
-if [ -n "$FIXTURE_ONLY" ]; then
-  echo "fixture kept at $REPO" >&2
-  exit 0
-fi
-
-# name|args. Read-only unless marked; `new` gets a prepare step to stay honest.
-CASES=$(cat <<'CASES'
-version|--version
-ls|ls
-check|check
-check-json|check --json
-why-hot|why src/mod_0.rs
-why-cold|why src/mod_7.rs
-audit|audit
-prune|prune --dry-run
-shellenv|shellenv
-CASES
-)
-
-# `new` mutates, so each run starts from a lane that is not there yet. Under -N there is
-# no shell to chain the reset, so it lives in a file.
-cat > "$TMP/reset-lane" <<RESET
-#!/usr/bin/env bash
-rm -rf "$REPO/.lane/trees/benchlane"
-git -C "$REPO" worktree prune
-git -C "$REPO" branch -D benchlane >/dev/null 2>&1
-exit 0
-RESET
-chmod +x "$TMP/reset-lane"
-
-RESULTS="$TMP/results.json"
-echo '{}' > "$RESULTS"
-
-# A quiet machine is not a given. --against times both binaries inside ONE hyperfine
-# invocation per case, so load that drifts between runs hits both sides equally; the
-# earlier --compare reads a file recorded minutes ago and cannot do that.
-run_ab() {
-  local name="$1" args="$2" prepare="${3:-}"
-  [ -n "$FILTER" ] && [[ "$name" != *"$FILTER"* ]] && return 0
-  local json="$TMP/ab-$name.json"
-  local hf=(-N --warmup "$WARMUP" --runs "$RUNS" --style none --export-json "$json")
-  [ -n "$prepare" ] && hf+=(--prepare "$prepare")
-  if ! hyperfine "${hf[@]}" "$AGAINST $args" "$BIN $args" >/dev/null 2>&1; then
-    echo "  !! $name failed to run" >&2
-    return 0
-  fi
-  local before after delta
-  before=$(jq -r '.results[0].mean * 1000' "$json")
-  after=$(jq -r '.results[1].mean * 1000' "$json")
-  delta=$(python3 -c "print(f'{(($after-$before)/$before*100):+.1f}%')")
-  printf '  %-12s %9.1f %9.1f %9s\n' "$name" "$before" "$after" "$delta" >&2
-}
-
-run_case() {
-  local name="$1" cmd="$2" prepare="${3:-}"
-  [ -n "$FILTER" ] && [[ "$name" != *"$FILTER"* ]] && return 0
-  local json="$TMP/$name.json"
-  local args=(-N --warmup "$WARMUP" --runs "$RUNS" --style none --export-json "$json")
-  [ -n "$prepare" ] && args+=(--prepare "$prepare")
-  if ! hyperfine "${args[@]}" "$cmd" >/dev/null 2>&1; then
-    echo "  !! $name failed to run" >&2
-    return 0
-  fi
-  local mean stddev user
-  mean=$(jq -r '.results[0].mean * 1000' "$json")
-  stddev=$(jq -r '.results[0].stddev * 1000' "$json")
-  user=$(jq -r '.results[0].user * 1000' "$json")
-  jq --arg n "$name" --argjson m "$mean" --argjson s "$stddev" --argjson u "$user" \
-    '.[$n] = {mean: $m, stddev: $s, user: $u}' "$RESULTS" > "$RESULTS.tmp" && mv "$RESULTS.tmp" "$RESULTS"
-  printf '  %-12s %8.1f ms  ± %5.1f   user %6.1f ms\n' "$name" "$mean" "$stddev" "$user" >&2
-}
-
-echo "" >&2
-echo "binary: $BIN ($(stat -f%z "$BIN" 2>/dev/null || stat -c%s "$BIN") bytes)" >&2
-echo "runs:   $RUNS (warmup $WARMUP)" >&2
-echo "" >&2
-
-if [ -n "$AGAINST" ]; then
-  printf '  %-12s %9s %9s %9s\n' "case" "before" "after" "delta" >&2
-  printf '  %-12s %9s %9s %9s\n' "----" "------" "-----" "-----" >&2
-  while IFS='|' read -r name args; do
-    [ -z "$name" ] && continue
-    run_ab "$name" "$args"
-  done <<< "$CASES"
-  run_ab "new" "new benchlane" "$TMP/reset-lane"
-  echo "" >&2
-  exit 0
-fi
-
-while IFS='|' read -r name args; do
-  [ -z "$name" ] && continue
-  run_case "$name" "$BIN $args"
-done <<< "$CASES"
-
-run_case "new" "$BIN new benchlane" "$TMP/reset-lane"
-
-echo "" >&2
-
-if [ -n "$OUT" ]; then
-  cp "$RESULTS" "$OUT"
-  echo "wrote $OUT" >&2
-fi
-
-if [ -n "$BASELINE" ]; then
-  echo "" >&2
-  printf '  %-12s %10s %10s %9s\n' "case" "before" "after" "delta" >&2
-  printf '  %-12s %10s %10s %9s\n' "----" "------" "-----" "-----" >&2
-  jq -r --slurpfile base "$BASELINE" '
-    . as $after
-    | $base[0] as $before
-    | ($before | keys_unsorted) as $names
-    | $names[]
-    | select($after[.] != null)
-    | [., $before[.].mean, $after[.].mean] | @tsv
-  ' "$RESULTS" | while IFS=$'\t' read -r name b a; do
-    delta=$(python3 -c "print(f'{(($a-$b)/$b*100):+.1f}%')" 2>/dev/null || echo "n/a")
-    printf '  %-12s %9.1f %9.1f %9s\n' "$name" "$b" "$a" "$delta" >&2
-  done
-  echo "" >&2
-fi
+echo "lane_new=$new_best"
+echo "lane_rm=$rm_best"

--- a/scripts/bench.sh
+++ b/scripts/bench.sh
@@ -5,13 +5,18 @@
 # that matters and the byte total is not. Run it on the filesystem you care about: ext4
 # has no reflink at all, and the fallback copy it forces is a different measurement.
 #
-#   scripts/bench.sh <lane-binary> <workdir> [files] [runs]
+#   scripts/bench.sh <lane-binary> <workdir> [files] [runs] [synthetic|cargo]
+#
+# `cargo` builds this workspace inside the repository under test, so the ignored tree is a
+# real target/ — a few large archives among many small ones — rather than uniform stubs.
 set -uo pipefail
 
 LANE="${1:?usage: bench.sh <lane-binary> <workdir> [files] [runs]}"
 WORK="${2:?usage: bench.sh <lane-binary> <workdir> [files] [runs]}"
 FILES="${3:-20000}"
 RUNS="${4:-3}"
+MODE="${5:-synthetic}"
+SOURCE="$(cd "$(dirname "$0")/.." && pwd)"
 command -v "$LANE" >/dev/null 2>&1 || [ -x "$LANE" ] || { echo "no binary at $LANE" >&2; exit 1; }
 LANE="$(cd "$(dirname "$LANE")" && pwd)/$(basename "$LANE")"
 
@@ -46,18 +51,29 @@ build_tree() {
 REPO="$WORK/repo"
 rm -rf "$REPO"; mkdir -p "$REPO"; cd "$REPO" || exit 1
 
-git init -qb main .
-git config user.email bench@example.com
-git config user.name bench
-mkdir -p src
-for i in $(seq 1 20); do printf 'pub fn f%d() {}\n' "$i" > "src/m$i.rs"; done
-printf 'target/\nnode_modules/\n' > .gitignore
-git add -A && git commit -qm base
+if [ "$MODE" = cargo ]; then
+  # Tracked files only, then build: target/ has to be made here, on the filesystem under
+  # test, or it is not the thing being measured.
+  git -C "$SOURCE" archive HEAD | tar -x -C "$REPO"
+  git init -qb main .
+  git config user.email bench@example.com
+  git config user.name bench
+  git add -A && git commit -qm base
+  cargo build --release --all-targets --quiet 2>/dev/null || cargo build --release --all-targets 2>&1 | tail -5
+else
+  git init -qb main .
+  git config user.email bench@example.com
+  git config user.name bench
+  mkdir -p src
+  for i in $(seq 1 20); do printf 'pub fn f%d() {}\n' "$i" > "src/m$i.rs"; done
+  printf 'target/\nnode_modules/\n' > .gitignore
+  git add -A && git commit -qm base
 
-build_tree target $((FILES * 2 / 3))
-build_tree node_modules $((FILES - FILES * 2 / 3))
-ln -sf ../src/m1.rs node_modules/relative-link
-ln -sf "$REPO/src/m2.rs" node_modules/absolute-link
+  build_tree target $((FILES * 2 / 3))
+  build_tree node_modules $((FILES - FILES * 2 / 3))
+  ln -sf ../src/m1.rs node_modules/relative-link
+  ln -sf "$REPO/src/m2.rs" node_modules/absolute-link
+fi
 
 "$LANE" init >/dev/null 2>&1
 git add -A >/dev/null 2>&1 && git commit -qm lane >/dev/null 2>&1
@@ -67,7 +83,9 @@ echo "kernel=$(uname -sr | tr ' ' '-')"
 fs=$(df -PT . 2>/dev/null | awk 'NR==2{print $2}')
 [ -n "$fs" ] || fs=$(mount | awk -v m="$(df -P . | awk 'NR==2{print $NF}')" '$3==m{print $4}' | tr -d '(,' | head -1)
 echo "filesystem=${fs:-unknown}"
-echo "ignored_files=$(find target node_modules -type f | wc -l | tr -d ' ')"
+echo "mode=$MODE"
+echo "ignored_files=$(find target node_modules -type f 2>/dev/null | wc -l | tr -d ' ')"
+echo "ignored_bytes=$(du -sk target node_modules 2>/dev/null | awk '{s+=$1} END{printf "%.0fMiB", s/1024}')"
 
 "$LANE" new probe > /tmp/bench-probe.out 2>&1
 echo "reflink=$(awk '/reflink:/{print $2; exit}' /tmp/bench-probe.out)"


### PR DESCRIPTION
lane's clone path is measured only on the machine it is developed on. The Darwin directory clone in #24 was chosen against numbers; the Linux per-file path had none, and the existing gates cannot supply them — ubuntu runners are ext4, which has no reflink, so CI exercises the fallback and never touches `FICLONE`.

`scripts/bench.sh` builds a repository and reports the best of several `lane new` and `lane rm` runs. The workflow runs it on three filesystems — the runner's ext4 for the no-reflink path, and loop-mounted btrfs and XFS for the two implementations `FICLONE` runs on — against two workloads, and builds a baseline ref alongside the current one so a comparison is never across machines. Manual dispatch only.

## What it already found

**Per-file syscalls are the cost; bytes are nearly free.** 392 MiB in 1,378 files clones in 0.12s, while 79 MiB in 20,000 files takes 0.85s. Five times the bytes, seven times faster, because there are fourteen times fewer files.

| fs | workload | files | bytes | `lane new` | `lane rm` |
| --- | --- | --- | --- | --- | --- |
| ext4 | synthetic | 20,000 | 79 MiB | 0.018 | 0.011 |
| btrfs | synthetic | 20,000 | 78 MiB | 0.850 | 0.017 |
| xfs | synthetic | 20,000 | 79 MiB | 1.607 | 0.020 |
| ext4 | cargo | 1,378 | 392 MiB | 0.036 | 0.023 |
| btrfs | cargo | 1,378 | 392 MiB | 0.126 | 0.033 |
| xfs | cargo | 1,378 | 392 MiB | 0.117 | 0.021 |

ext4 is fast because it does nothing: with no reflink the materialization is `Plain` and the ignored tree is not carried at all.

**`FICLONE` is 17% of the work.** The syscall profile of `lane new` over 20,000 ignored files on btrfs:

```
% time     seconds  usecs/call     calls    errors syscall
 30.69    1.090976          13     80020     20003 statx
 25.84    0.918478          22     40871        90 openat
 17.23    0.612628          30     20027         2 ioctl      <- FICLONE
 13.27    0.471789          11     40819           close
  7.57    0.269183          13     20215     20003 mkdir
```

Four `statx` and two `openat` per file, and 20,003 *failing* `mkdir` calls, because `clone_tree_rooted` calls `create_dir_all(parent)` for every file when the walk has already created the directory. That is roughly nine syscalls per file where four would do, and it is a better first move on Linux than threading the walk.

**#24 validated on Linux.** The park-and-sweep removal was written and measured on APFS only. Measured here against the commit before it: `lane rm` went from 0.711s to 0.024s on btrfs and 0.832s to 0.012s on XFS.

## Reading it honestly

Two harness bugs surfaced by running it rather than trusting it. `lane new` was timed repeatedly against a name that already existed, so runs after the first measured the refusal; both timings now come from one loop that removes the lane between them, and a non-zero exit aborts the script rather than being recorded as a fast result.

The `order` input exists because of the second one: `lane rm` differed 35x between two builds and I assumed the disk was to blame. Swapping the order showed it followed the binary, not the position — the branch was simply behind main, so it was measuring #24's absence. With the branch rebased, the two columns agree to within 3% on every filesystem, which is what a calibrated harness should say about identical code.