### PR TITLE
perf(linux): cut three syscalls per cloned file

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -3,8 +3,6 @@ name: bench
 # Manual only. Loop-mounting a filesystem and writing 20k files is too slow to gate a
 # pull request, and the numbers are only worth reading when someone is asking for them.
 on:
-  push:
-    branches: [clone-syscalls]
   workflow_dispatch:
     inputs:
       baseline:

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -3,6 +3,8 @@ name: bench
 # Manual only. Loop-mounting a filesystem and writing 20k files is too slow to gate a
 # pull request, and the numbers are only worth reading when someone is asking for them.
 on:
+  push:
+    branches: [clone-syscalls]
   workflow_dispatch:
     inputs:
       baseline:

--- a/crates/lane/src/cow.rs
+++ b/crates/lane/src/cow.rs
@@ -12,6 +12,8 @@ use std::path::{Path, PathBuf};
 pub enum CloneError {
     /// The filesystem cannot share extents; the caller should fall back.
     Unsupported(String),
+    /// The destination is already there. Cheaper to be told than to ask first.
+    Exists,
     Io(std::io::Error),
 }
 
@@ -19,6 +21,7 @@ impl fmt::Display for CloneError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             CloneError::Unsupported(why) => write!(f, "{why}"),
+            CloneError::Exists => write!(f, "destination exists"),
             CloneError::Io(e) => write!(f, "{e}"),
         }
     }
@@ -37,6 +40,9 @@ const UNSUPPORTED: &[i32] = &[];
 
 /// Separate "fall back to a byte copy" from real failures like ENOSPC.
 fn classify(err: std::io::Error) -> CloneError {
+    if err.kind() == std::io::ErrorKind::AlreadyExists {
+        return CloneError::Exists;
+    }
     match err.raw_os_error() {
         Some(e) if UNSUPPORTED.contains(&e) => CloneError::Unsupported(err.to_string()),
         _ => CloneError::Io(err),
@@ -70,7 +76,7 @@ fn root_spellings(root: &Path) -> std::io::Result<Vec<PathBuf>> {
 
 /// Clone one regular file by reference.
 #[cfg(target_os = "macos")]
-pub fn clone_file(src: &Path, dst: &Path) -> Result<(), CloneError> {
+pub fn clone_file(src: &Path, dst: &Path) -> Result<u64, CloneError> {
     use std::ffi::CString;
     use std::os::unix::ffi::OsStrExt;
 
@@ -81,30 +87,27 @@ pub fn clone_file(src: &Path, dst: &Path) -> Result<(), CloneError> {
     // CLONE_NOFOLLOW: clone the symlink itself, never its target.
     let rc = unsafe { libc::clonefile(c_src.as_ptr(), c_dst.as_ptr(), 1) };
     if rc == 0 {
-        return Ok(());
+        return Ok(fs::symlink_metadata(dst).map(|m| m.len()).unwrap_or(0));
     }
     Err(classify(std::io::Error::last_os_error()))
 }
 
 #[cfg(target_os = "linux")]
-pub fn clone_file(src: &Path, dst: &Path) -> Result<(), CloneError> {
+pub fn clone_file(src: &Path, dst: &Path) -> Result<u64, CloneError> {
     use std::os::unix::fs::{OpenOptionsExt, PermissionsExt};
 
     let source = fs::File::open(src).map_err(CloneError::Io)?;
-    let mode = source
-        .metadata()
-        .map_err(CloneError::Io)?
-        .permissions()
-        .mode();
+    let info = source.metadata().map_err(CloneError::Io)?;
+    let (mode, size) = (info.permissions().mode(), info.len());
     let target = fs::OpenOptions::new()
         .write(true)
         .create_new(true)
         .mode(mode)
         .open(dst)
-        .map_err(CloneError::Io)?;
+        .map_err(classify)?;
 
     match rustix::fs::ioctl_ficlone(&target, &source) {
-        Ok(()) => Ok(()),
+        Ok(()) => Ok(size),
         Err(e) => {
             drop(target);
             let _ = fs::remove_file(dst);
@@ -121,7 +124,7 @@ pub fn clone_file(src: &Path, dst: &Path) -> Result<(), CloneError> {
 /// a file alone, which is why the per-file walk exists at all.
 #[cfg(target_os = "macos")]
 fn clone_dir(src: &Path, dst: &Path) -> Result<(), CloneError> {
-    clone_file(src, dst)
+    clone_file(src, dst).map(|_| ())
 }
 
 #[cfg(not(target_os = "macos"))]
@@ -132,7 +135,7 @@ fn clone_dir(_src: &Path, _dst: &Path) -> Result<(), CloneError> {
 }
 
 #[cfg(not(any(target_os = "macos", target_os = "linux")))]
-pub fn clone_file(_src: &Path, _dst: &Path) -> Result<(), CloneError> {
+pub fn clone_file(_src: &Path, _dst: &Path) -> Result<u64, CloneError> {
     Err(CloneError::Unsupported(
         "no clone primitive on this platform".into(),
     ))
@@ -153,7 +156,7 @@ pub fn probe(path: &Path) -> (bool, String) {
         return (false, e.to_string());
     }
     match clone_file(&a, &b) {
-        Ok(()) => (true, "reflink available".into()),
+        Ok(_) => (true, "reflink available".into()),
         Err(e) => (false, e.to_string()),
     }
 }
@@ -211,7 +214,7 @@ pub fn clone_dir_tree(
     }
     match clone_dir(src, dst) {
         Ok(()) => {}
-        Err(CloneError::Unsupported(_)) => return walk(),
+        Err(CloneError::Unsupported(_) | CloneError::Exists) => return walk(),
         Err(CloneError::Io(e)) => return Err(e),
     }
 
@@ -355,33 +358,32 @@ pub fn clone_tree_rooted(
             fs::create_dir_all(&target)?;
             continue;
         }
-        if fs::symlink_metadata(&target).is_ok() {
-            continue;
-        }
-        if let Some(parent) = target.parent() {
-            fs::create_dir_all(parent)?;
-        }
+        // No `create_dir_all` and no existence check per file: the walk yields a directory
+        // before its contents, so the parent is already made, and the create below reports
+        // an existing destination for free. Both cost a syscall each, per file.
         if entry.file_type().is_symlink() {
             let dest = fs::read_link(entry.path())?;
             let dest = retarget(&dest, &src_roots, dst_root).unwrap_or(dest);
-            std::os::unix::fs::symlink(dest, &target)?;
-            stats.links += 1;
+            match std::os::unix::fs::symlink(dest, &target) {
+                Ok(()) => stats.links += 1,
+                Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => {}
+                Err(e) => return Err(e),
+            }
             continue;
         }
         if !entry.file_type().is_file() {
             continue;
         }
 
-        let size = entry.metadata().map(|m| m.len()).unwrap_or(0);
         match clone_file(entry.path(), &target) {
-            Ok(()) => {
+            Ok(size) => {
                 stats.cloned += 1;
                 stats.bytes_shared += size;
             }
+            Err(CloneError::Exists) => continue,
             Err(CloneError::Unsupported(_)) => {
-                fs::copy(entry.path(), &target)?;
+                stats.bytes_copied += fs::copy(entry.path(), &target)?;
                 stats.copied += 1;
-                stats.bytes_copied += size;
             }
             Err(CloneError::Io(e)) => return Err(e),
         }

--- a/crates/lane/tests/cow.rs
+++ b/crates/lane/tests/cow.rs
@@ -227,7 +227,7 @@ fn cloning_onto_an_existing_path_is_not_reported_as_unsupported() {
             let (supported, _) = cow::probe(dir.path());
             assert!(!supported, "unsupported here is only valid without reflink");
         }
-        Err(CloneError::Io(_)) | Ok(()) => {}
+        Err(CloneError::Io(_) | CloneError::Exists) | Ok(_) => {}
     }
 }
 

--- a/scripts/bench.sh
+++ b/scripts/bench.sh
@@ -60,6 +60,11 @@ if [ "$MODE" = cargo ]; then
   git config user.name bench
   git add -A && git commit -qm base
   cargo build --release --all-targets --quiet 2>/dev/null || cargo build --release --all-targets 2>&1 | tail -5
+  # The other half of a real checkout, and the opposite shape: many tiny files and the
+  # symlinks that go with them, where target/ is a few large archives.
+  if [ -f www/package.json ] && command -v npm >/dev/null 2>&1; then
+    (cd www && npm install --silent --no-audit --no-fund >/dev/null 2>&1) || echo "npm install failed" >&2
+  fi
 else
   git init -qb main .
   git config user.email bench@example.com
@@ -84,8 +89,8 @@ fs=$(df -PT . 2>/dev/null | awk 'NR==2{print $2}')
 [ -n "$fs" ] || fs=$(mount | awk -v m="$(df -P . | awk 'NR==2{print $NF}')" '$3==m{print $4}' | tr -d '(,' | head -1)
 echo "filesystem=${fs:-unknown}"
 echo "mode=$MODE"
-echo "ignored_files=$(find target node_modules -type f 2>/dev/null | wc -l | tr -d ' ')"
-echo "ignored_bytes=$(du -sk target node_modules 2>/dev/null | awk '{s+=$1} END{printf "%.0fMiB", s/1024}')"
+echo "ignored_files=$(find target node_modules www/node_modules -type f 2>/dev/null | wc -l | tr -d ' ')"
+echo "ignored_bytes=$(du -sk target node_modules www/node_modules 2>/dev/null | awk '{s+=$1} END{printf "%.0fMiB", s/1024}')"
 
 "$LANE" new probe > /tmp/bench-probe.out 2>&1
 echo "reflink=$(awk '/reflink:/{print $2; exit}' /tmp/bench-probe.out)"


### PR DESCRIPTION
Stacked on #26, which is the harness that found this. Merge that first and GitHub will retarget this to `main`.

`lane new` on Linux made roughly nine syscalls per cloned file where four would do. Profiling it over 20,000 ignored files on btrfs, `FICLONE` was 17% of the time and the bookkeeping around it was 77%.

Three of those calls were asking questions that were already answered:

- `create_dir_all(parent)` ran once per file, but the walk is pre-order — it yields a directory before its contents and has already created it. Every one of those calls was a `mkdir` that failed with `EEXIST`.
- `symlink_metadata(target)` asked whether the destination existed. The create that follows reports exactly that, for free.
- `entry.metadata()` read a size the Linux clone already holds, having opened the source to read its mode.

`clone_file` now returns the bytes it cloned and names an existing destination instead of failing on it, so the walk asks for none of the three.

## Measured

Same job, same filesystem, baseline built alongside — `main` against this branch.

| fs | workload | files | bytes | `lane new` before | after | |
| --- | --- | --- | --- | --- | --- | --- |
| btrfs | synthetic | 20,000 | 78 MiB | 1.176 | **0.975** | −17% |
| xfs | synthetic | 20,000 | 79 MiB | 0.851 | **0.574** | −33% |
| btrfs | cargo | 15,750 | 873 MiB | 0.831 | **0.678** | −18% |
| xfs | cargo | 15,750 | 869 MiB | 1.391 | **1.204** | −13% |
| ext4 | either | — | — | unchanged | unchanged | no reflink, nothing is cloned |

The syscall table, before and after, over the same 20,000 files:

```
 30.69    1.090976          13     80020     20003 statx      ->   9.49  0.273866  20020      3 statx
  7.57    0.269183          13     20215     20003 mkdir      ->   0.30  0.008590    215      3 mkdir
 25.84    0.918478          22     40871        90 openat     ->  40.32  1.164039  40872     90 openat
 17.23    0.612628          30     20027         2 ioctl      ->  24.54  0.708550  20027      2 ioctl
```

202k syscalls to 122k. `openat`, `close` and `ioctl` are unchanged, which is the point: those are the work, and what went away was the asking.

## Also here

The benchmark's `cargo` workload now runs `npm install` in `www/` as well as building the crate, so the ignored tree is both shapes a real checkout has — a few large archives in `target/` and many tiny files with symlinks in `node_modules/`. That took the workload from 1,378 files / 392 MiB to 15,750 files / 873 MiB, against the 26,245 files / 2.5 GiB this repository actually carries.

macOS is unaffected in the common case: it takes the directory clone from #24 and never reaches this walk. The fallback it does share is covered by the existing `cow` tests, and `clone_file` returning bytes costs it the one `stat` the caller used to make.

175 cargo tests, 242 shell assertions, clippy clean.