### PR TITLE
feat(prune): prove landings

### DIFF
--- a/.lane/memory/crates/lane/src/worktree.rs/01M0XBQ9GF1MZFTHQJTM4Y88VV-patch-id-hashes-context-line.md
+++ b/.lane/memory/crates/lane/src/worktree.rs/01M0XBQ9GF1MZFTHQJTM4Y88VV-patch-id-hashes-context-line.md
@@ -1,0 +1,12 @@
+---
+id: 01M0XBQ9GF1MZFTHQJTM4Y88VV
+anchor: fn contained_in
+created: 2026-08-25T20:51:01Z
+norm: '1'
+sig: a32a45555bb8c553
+body_hash: 516f6171b5bf93b1
+raw_hash: 390741e2e5329512
+lines: 609-644
+---
+
+patch-id hashes context lines, so a PR landing between a lane's base and its own squash makes a landed lane read as open

--- a/.lane/memory/crates/lane/src/worktree.rs/01M0XCG8D92WDJPAEN4T2BASFB-a-squash-rewrites-commits-bu.md
+++ b/.lane/memory/crates/lane/src/worktree.rs/01M0XCG8D92WDJPAEN4T2BASFB-a-squash-rewrites-commits-bu.md
@@ -1,0 +1,12 @@
+---
+id: 01M0XCG8D92WDJPAEN4T2BASFB
+anchor: fn upstream_gone
+created: 2026-08-25T21:16:25Z
+norm: '1'
+sig: a8c6fddb52747d80
+body_hash: 6070bc5f394d0e9b
+raw_hash: 481c96426fdc6226
+lines: 634-642
+---
+
+a squash rewrites commits but cannot resurrect a deleted head branch, so a retired upstream sees a landing every patch-id comparison misses

--- a/.lane/memory/scripts/test.sh/01M0XCG8DP729BYRMTZWT4AS4A-git-push-delete-drops-the-lo.md
+++ b/.lane/memory/scripts/test.sh/01M0XCG8DP729BYRMTZWT4AS4A-git-push-delete-drops-the-lo.md
@@ -1,0 +1,12 @@
+---
+id: 01M0XCG8DP729BYRMTZWT4AS4A
+anchor: '@file'
+created: 2026-08-25T21:16:25Z
+norm: '1'
+sig: e3b0c44298fc1c14
+body_hash: 86c93d9342b27f84
+raw_hash: 34ccf27279dedfba
+lines: 1-1169
+---
+
+git push --delete drops the local tracking ref too, so a server-side branch delete is the only faithful way to test that ls does not fetch

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -20,9 +20,10 @@ The repository's default branch. Only ever a fallback, used when a lane has no r
 _Avoid_: main, master, mainline — the default branch is frequently none of these.
 
 **Landing record**:
-An entry in the log marking a lane's memory as final. Its presence in the base's copy of the
-log is what proves the branch merged, whichever merge strategy was used.
-_Avoid_: merge marker, landing commit — it is tree content, not a commit.
+A marker in the lane's own git directory, written when a lane is prepared, holding the lane id
+and the branch tip. Never committed. It records that a landing was prepared, not that one
+arrived; the tip is what makes work added afterwards countable.
+_Avoid_: merge marker, landing commit — it is worktree state, not history.
 
 **Open**:
 A lane whose work is not on the remote and not in its base.
@@ -32,4 +33,5 @@ A lane whose branch is on the remote at exactly its local tip. Committing again 
 to open, because the remote no longer has everything.
 
 **Landed**:
-A lane whose landing record has reached its base. Collectable by prune.
+A marked lane whose branch its remote retired, or whose work its base already contains.
+Collectable by prune once nothing has been added since the landing.

--- a/crates/lane/src/cli.rs
+++ b/crates/lane/src/cli.rs
@@ -598,9 +598,11 @@ fn ls(json: bool) -> Result<i32> {
                 .map(|n| n.to_string_lossy().to_string())
                 .unwrap_or_default();
             let upstream = try_git(&["rev-parse", "@{upstream}"], Some(&lane.path));
-            // Only marked lanes pay for the containment probe.
+            // Only marked lanes pay for a probe, and a retired upstream settles it before
+            // the expensive one runs.
             let state = if store::is_landed(&lane.path)
-                && wt::contained_in(&root, &wt::trunk_name(&root), &lane.branch)
+                && (wt::upstream_gone(&root, &lane.branch)
+                    || wt::contained_in(&root, &wt::trunk_name(&root), &lane.branch))
             {
                 "landed"
             } else if !upstream.is_empty()
@@ -643,6 +645,13 @@ fn ls(json: bool) -> Result<i32> {
 
 fn prune(dry_run: bool) -> Result<i32> {
     let root = wt::main_root()?;
+    // A retired upstream is read from a cache that only empties on a prune. Failing here
+    // costs accuracy, never the command: fall through and decide on the refs we have.
+    if !try_git(&["remote"], Some(&root)).trim().is_empty()
+        && !git::git_ok(&["fetch", "--prune", "--quiet"], Some(&root))
+    {
+        eprintln!("warning: fetch failed; deciding on cached remote refs");
+    }
     let trunk = wt::trunk_name(&root);
     let lanes = wt::list_lanes(&root);
 
@@ -1264,7 +1273,6 @@ fn prepare(
     if store::lane_id(&lane_path).is_empty() {
         eprintln!("warning: lane has no id; `lane prune` will not recognise this landing");
     }
-    store::mark_landed(&lane_path)?;
 
     if stage_memory(&lane_path) {
         git(
@@ -1273,6 +1281,10 @@ fn prepare(
         )?;
         writeln!(info, "committed memory update")?;
     }
+
+    // After the memory commit: the marker records the tip, and that commit is part of what
+    // lands. Marking earlier would date the landing one commit short of itself.
+    store::mark_landed(&lane_path)?;
 
     Ok(Preparation::Ready(Prepared {
         lane_path,

--- a/crates/lane/src/store.rs
+++ b/crates/lane/src/store.rs
@@ -60,6 +60,8 @@ pub fn landed_path(worktree: &Path) -> Option<PathBuf> {
         .map(|layout| layout.git_dir.join(LANDED))
 }
 
+/// Records the tip as well, so what arrives after a landing is countable. Call this once
+/// the memory commit exists, or the tip names a commit the landing never included.
 pub fn mark_landed(worktree: &Path) -> Result<()> {
     let Some(path) = landed_path(worktree) else {
         return Ok(());
@@ -71,12 +73,28 @@ pub fn mark_landed(worktree: &Path) -> Result<()> {
     if let Some(parent) = path.parent() {
         std::fs::create_dir_all(parent)?;
     }
-    std::fs::write(path, format!("{id} {}\n", now_iso()))?;
+    let tip = git::try_git(&["rev-parse", "HEAD"], Some(worktree));
+    let mut line = format!("{id} {}", now_iso());
+    if !tip.is_empty() {
+        line.push(' ');
+        line.push_str(&tip);
+    }
+    line.push('\n');
+    std::fs::write(path, line)?;
     Ok(())
 }
 
 pub fn is_landed(worktree: &Path) -> bool {
     landed_path(worktree).is_some_and(|path| path.is_file())
+}
+
+/// The tip at landing time. `None` for a marker written before tips were recorded, and
+/// that is never the same answer as "nothing followed the landing".
+pub fn landed_tip(worktree: &Path) -> Option<String> {
+    let path = landed_path(worktree)?;
+    let text = std::fs::read_to_string(path).ok()?;
+    let tip = text.split_whitespace().nth(2)?;
+    Some(tip.to_string())
 }
 
 /// The whole file. Its span has no declaration line, so its first line is an

--- a/crates/lane/src/worktree.rs
+++ b/crates/lane/src/worktree.rs
@@ -484,12 +484,32 @@ pub fn losses(root: &Path, path: &Path, branch: &str, trunk: &str) -> Vec<String
         }
     }
     let refname = format!("refs/heads/{branch}");
-    if git_ok(&["rev-parse", "--verify", "--quiet", &refname], Some(root))
-        && !contained_in(root, trunk, branch)
-    {
+    if !git_ok(&["rev-parse", "--verify", "--quiet", &refname], Some(root)) {
+        return out;
+    }
+
+    let after = crate::store::landed_tip(path).map(|tip| {
+        try_git(
+            &["rev-list", "--count", &format!("{tip}..{branch}")],
+            Some(root),
+        )
+        .parse::<u32>()
+        .unwrap_or(0)
+    });
+
+    // A retired upstream proves arrival and a recorded tip dates it. Together they answer
+    // without a patch comparison; missing either one, the probe is still the only witness.
+    let landed = match (upstream_gone(root, branch), after) {
+        (true, Some(_)) => true,
+        _ => contained_in(root, trunk, branch),
+    };
+
+    if !landed {
         // No count: a squash merge leaves commits whose patches landed inside one of
         // trunk's, so `rev-list` would name a number larger than what is really at risk.
         out.push(format!("commits {trunk} does not have"));
+    } else if let Some(count) = after.filter(|count| *count > 0) {
+        out.push(format!("{count} commit(s) after landing"));
     }
     out
 }
@@ -606,6 +626,21 @@ pub fn blocking_changes(root: &Path, trunk: &str, branch: &str) -> Vec<String> {
 /// ancestor. Anything else rewrites the SHAs, so `git branch -d` refuses even when the
 /// trees are identical; comparing the branch's cumulative diff against trunk by patch-id
 /// is what sees through a rebase or a squash.
+/// Git's own name for a branch its remote retired: upstream configured, ref no longer there.
+///
+/// Proof of arrival that compares no patches, which is what lets it see through a squash.
+/// Reads a cache, so it answers for the last fetch. Not `%(push:track)`, which reports
+/// `[gone]` for a branch never pushed, having answered for where a push would land.
+pub fn upstream_gone(root: &Path, branch: &str) -> bool {
+    let refname = format!("refs/heads/{branch}");
+    try_git(
+        &["for-each-ref", "--format=%(upstream:track)", &refname],
+        Some(root),
+    )
+    .trim()
+        == "[gone]"
+}
+
 pub fn contained_in(root: &Path, trunk: &str, branch: &str) -> bool {
     if git_ok(&["merge-base", "--is-ancestor", branch, trunk], Some(root)) {
         return true;

--- a/plans/037-prove-a-landing-from-the-remote.md
+++ b/plans/037-prove-a-landing-from-the-remote.md
@@ -1,0 +1,196 @@
+# Plan 037: Prove a landing from the remote, not from a patch
+
+> **Executor instructions**: Follow this plan step by step. Run every verification command and confirm the expected result before moving on. If a STOP condition occurs, stop and report.
+
+## Status
+
+- **Priority**: P1
+- **Effort**: M
+- **Risk**: MED
+- **Depends on**: none
+- **Category**: bug
+- **Revises**: plan 033's `landing` row. Landings still need no sharing; what 033 missed is that arrival is a fact about the remote, so a local marker alone cannot prove it.
+
+## Why this matters
+
+Two lanes in this repository landed and neither `ls` nor `prune` can see it:
+
+```
+skipped fast-clone: commits main does not have
+skipped fix-merge-staging: commits main does not have
+```
+
+Both trace to `wt::contained_in` (`worktree.rs:609`), which answers "did this land" by comparing patch ids. A squash merge destroys the evidence that read depends on, in two different ways.
+
+**fast-clone is a false negative.** Its collapsed probe and the diff of its own squash commit `c904e8d` differ by exactly one line:
+
+```
+<  fn registered(root: &Path, dest: &Path) -> bool {
+>  pub fn registered(root: &Path, dest: &Path) -> bool {
+```
+
+#23 made `registered` public between fast-clone's merge-base and fast-clone's own merge. That line is context, not a change fast-clone made, and `patch-id` hashes context. `150dfc00` against `e0a402b8`. Any pull request landing between a lane's base and its merge can do this to any lane.
+
+**fix-merge-staging is a question the probe cannot express.** #23 squashed its first five commits. Then `7e70718` and `66c1fc1` were committed on the same branch and shipped separately through the enter-exit lane as #25. The probe collapses a branch to one patch, so a branch that landed in two pieces can never match.
+
+Plan 033's case table says:
+
+```
+L4. Lane prepared, PR squash-merged → same as L3; contained_in sees the patch id
+```
+
+True only when nothing lands in between. There is no row for a lane that keeps committing after its own merge.
+
+## The design
+
+Git already separates these states, and stores exactly two things to do it:
+
+| `branch.<n>.remote` | `refs/remotes/origin/<n>` | git's name | meaning |
+|---|---|---|---|
+| absent | — | untracked | never pushed |
+| present | present | tracking | pushed, still open |
+| present | **absent** | **`gone`** | the remote retired the branch |
+
+`gone` reads from local refs, compares no patches, and therefore survives a squash — a squash rewrites commits but cannot resurrect a deleted head branch. GitHub's auto-delete fires on merge only; closing a pull request leaves the branch standing.
+
+So a **marked** lane whose upstream is `gone` has landed. `contained_in` stays exactly as it is for every lane that is not `gone`. This adds a fast path in front of the probe; it removes nothing.
+
+`gone` cannot answer the second question — whether anything reached the lane after it was prepared. That needs the branch tip recorded at landing time, which the marker does not hold today.
+
+## Scope
+
+In: `store.rs`, `worktree.rs`, `cli.rs`, `scripts/test.sh`, `CONTEXT.md`, `plans/README.md`.
+
+Out: `help.rs` — new behaviour does not earn a clause in a help description, and `prune` fetching is not a new command. Also out: `note.rs`, `audit.rs`, `syntax.rs`, `cow.rs`, and every clone path in `worktree.rs`.
+
+## Steps
+
+### Step 1: The marker records the tip
+
+`store::mark_landed` writes `<id> <iso>` today. It gains the branch tip as a third field, space separated and last, so a two-field marker written by an older lane still parses.
+
+Ordering is the trap. `mark_landed` runs inside `prepare` (`cli.rs:1267`) **before** `stage_memory` commits the memory update, so the tip at that moment is not the tip that gets pushed. Stamp the tip after that commit exists, not at the current call site.
+
+Add `store::landed_tip(worktree) -> Option<String>`, returning `None` for a marker with no third field. `None` means unknown, never "nothing landed after".
+
+### Step 2: `wt::upstream_gone`
+
+```
+git for-each-ref --format='%(upstream:track)' refs/heads/<branch>
+```
+
+`[gone]` means gone. Empty means either in sync or no upstream configured, and both fall through to `contained_in`.
+
+Encode this trap in a comment: `%(push:track)` also reports `[gone]` for a branch that was never pushed, because it is computed against where a push *would* land. `clone-syscalls` in this repository proves it. Use `%(upstream:track)`, which is empty unless `branch.<n>.remote` exists.
+
+### Step 3: `losses` counts what arrived after landing
+
+`worktree.rs:487` reports `commits {trunk} does not have` and says in a comment that it cannot count. With a tip it can. New order inside `losses`:
+
+- a tip is recorded → `rev-list <tip>..<branch>`; when above zero, `N commit(s) after landing`, which is exact;
+- else the upstream is `gone` → the branch puts nothing at stake;
+- else `!contained_in` → today's message, unchanged.
+
+The uncommitted-change and pending-note losses are untouched and still run first.
+
+### Step 4: `ls` and `prune` gate on gone or contained
+
+Both call sites (`cli.rs:602`, `cli.rs:654`) treat a lane as landed when it is marked **and** (`upstream_gone` **or** `contained_in`). Order the `or` so `upstream_gone` runs first: it is one `for-each-ref` against a local ref, where `contained_in` can reach `commit-tree`.
+
+The marker stays the first gate and short-circuits both probes, so an unmarked lane still costs no extra git process.
+
+### Step 5: `prune` fetches before it decides
+
+`gone` reads a cache that only empties on `git fetch --prune`. `prune` runs it first.
+
+It must be failure tolerant: offline, unauthenticated, or no remote at all, `prune` warns on stderr and continues against the cached refs. A failed fetch is never fatal — it degrades to today's answer.
+
+`ls` never fetches. It stays offline and instant, which is #7's win and the reason 033 kept the short-circuit.
+
+### Step 6: `CONTEXT.md` catches up
+
+The **Landing record** entry still describes the committed log that PR #11 deleted:
+
+> Its presence in the base's copy of the log is what proves the branch merged
+
+Rewrite it against what ships: a marker in the lane's own git directory, never committed, proved by the remote retiring the branch or by containment in the base.
+
+## CASE TABLE — handle and test every row
+
+```
+G1.  Marked, gone, tip recorded, nothing after     → ls `landed`; prune collects
+G2.  Marked, gone, tip recorded, 2 commits after   → ls `landed`; prune skips,
+                                                     "2 commit(s) after landing"
+G3.  Marked, gone, NO tip (marker from an older
+     lane)                                         → tip unknown; fall back to
+                                                     contained_in for losses. Never
+                                                     assume the current tip is the
+                                                     landing tip.
+G4.  Marked, tracking, contained_in true           → ls `landed`; prune collects
+G5.  Marked, tracking, contained_in false          → ls `open`; prune skips with
+                                                     today's message. This is an open
+                                                     pull request and must not change.
+G6.  Marked, never pushed, landed by `lane merge`  → no upstream, so gone must NOT
+                                                     fire; contained_in carries it
+G7.  UNMARKED lane whose upstream is gone          → never pruned. The marker is the
+                                                     identity gate, not the ref.
+G8.  Remote branch deleted by hand, never merged   → reads as landed. Accepted risk,
+                                                     stated in the plan. The dirty and
+                                                     pending-note guards still fire.
+G9.  Repo with no remote at all                    → no upstream config; falls to
+                                                     contained_in; no error
+G10. Fetch fails: offline, auth, dead remote       → warn, continue on cached refs,
+                                                     exit code unchanged
+G11. Repo with deleteBranchOnMerge off             → gone never fires; every lane on
+                                                     contained_in, exactly as today
+G12. Merged, but the stale ref not yet pruned      → the Step 5 fetch prunes it, then
+                                                     gone fires. Without a fetch this
+                                                     is G5.
+G13. Worktree removed by hand, branch remains      → no marker to read; no panic
+G14. Branch name reused by a NEW lane after the
+     old one went gone                             → the new lane has its own git dir
+                                                     and no marker, so it is never
+                                                     pruned. §36 covers this and must
+                                                     keep passing.
+G15. Upstream on a remote that is not `origin`     → `%(upstream:track)` is remote
+                                                     agnostic; works unchanged
+G16. Lane pushed, then pushed AGAIN with more
+     commits                                       → the tip is re-stamped on the
+                                                     second push. A stale tip would
+                                                     read the new commits as landing
+                                                     after the fact.
+G17. Marked and gone, but the worktree is dirty
+     or holds pending notes                        → prune still skips on those
+                                                     losses. Landing is not the only
+                                                     guard.
+```
+
+## Done criteria
+
+- A repro of the fast-clone shape — lane branched, another pull request lands touching an adjacent context line, lane squash-merged, head branch deleted — reports `landed` and is collected.
+- A repro of the fix-merge-staging shape — commits added after the merge — is skipped with an exact count, not with `commits main does not have`.
+- `lane prune` with the network unplugged still runs, warns once, and collects nothing it would not have collected before.
+- `rg 'push:track'` returns no hits in Rust source.
+- `cargo test`, `./scripts/test.sh`, `cargo clippy --all-targets -- -D warnings`, `cargo fmt --check` all clean.
+
+## STOP conditions
+
+- If `scripts/test.sh` §36 fails, the reused-name protection broke. Stop; do not weaken the test.
+- If `ls` gains a network call, or the git-process count for an unmarked lane rises above today's, stop. Both are 033's guarantees and #7's win.
+- If an existing test asserting `commits main does not have` needs deleting rather than rewriting, stop and report. That message must survive for G5, which is the common case of an open pull request.
+- If `upstream_gone` returns true for any lane in THIS repository that has an open pull request, stop. The signal is wrong and nothing downstream is safe.
+
+## Migration
+
+None, deliberately. Old markers carry no tip, and the only backfill available is "the current tip was the landing tip", which is false for exactly the fix-merge-staging shape and would let `prune` delete work that never landed. G3 keeps those lanes on today's behaviour.
+
+The two stuck lanes in this repository are cleared by hand once:
+
+```
+lane rm fast-clone --force
+lane rm fix-merge-staging --force
+```
+
+Both are verified safe: #24 carries fast-clone, and #25 carries the two commits fix-merge-staging added after #23.
+
+`enter-exit` is **not** one of them. It already reports `landed`, and its blocker is a real pending note on `fn move_to` that never reached main. Resolve that note; do not force it away.

--- a/plans/037-prove-a-landing-from-the-remote.md
+++ b/plans/037-prove-a-landing-from-the-remote.md
@@ -85,19 +85,20 @@ Encode this trap in a comment: `%(push:track)` also reports `[gone]` for a branc
 
 ### Step 3: `losses` counts what arrived after landing
 
-`worktree.rs:487` reports `commits {trunk} does not have` and says in a comment that it cannot count. With a tip it can. New order inside `losses`:
+`worktree.rs:487` reports `commits {trunk} does not have` and says in a comment that it cannot count. With a tip it can. `losses` asks two questions in order, where today it asks one:
 
-- a tip is recorded → `rev-list <tip>..<branch>`; when above zero, `N commit(s) after landing`, which is exact;
-- else the upstream is `gone` → the branch puts nothing at stake;
-- else `!contained_in` → today's message, unchanged.
+1. **Did it land?** A retired upstream and a recorded tip settle this together. Missing either one, `contained_in` is still the only witness.
+2. **Did anything follow?** With a tip, `rev-list <tip>..<branch>` — exact, where a collapsed patch never was.
+
+`gone` alone must not clear a lane, and this is the trap in the step. A marker with no tip cannot prove nothing followed the landing, and a lane whose pull request is merely open has not landed at all. Both fall back to the probe.
 
 The uncommitted-change and pending-note losses are untouched and still run first.
 
-### Step 4: `ls` and `prune` gate on gone or contained
+### Step 4: `ls` labels a retired upstream as landed
 
-Both call sites (`cli.rs:602`, `cli.rs:654`) treat a lane as landed when it is marked **and** (`upstream_gone` **or** `contained_in`). Order the `or` so `upstream_gone` runs first: it is one `for-each-ref` against a local ref, where `contained_in` can reach `commit-tree`.
+`ls` (`cli.rs:602`) treats a lane as landed when it is marked **and** (`upstream_gone` **or** `contained_in`), in that order: one `for-each-ref` against a local ref before a probe that can reach `commit-tree`. The marker stays the first gate and short-circuits both, so an unmarked lane still costs no extra git process.
 
-The marker stays the first gate and short-circuits both probes, so an unmarked lane still costs no extra git process.
+`prune` needs no change here. It gates on the marker and then on `losses`, which Step 3 has already taught to answer without a patch.
 
 ### Step 5: `prune` fetches before it decides
 
@@ -122,10 +123,12 @@ G1.  Marked, gone, tip recorded, nothing after     → ls `landed`; prune collec
 G2.  Marked, gone, tip recorded, 2 commits after   → ls `landed`; prune skips,
                                                      "2 commit(s) after landing"
 G3.  Marked, gone, NO tip (marker from an older
-     lane)                                         → tip unknown; fall back to
-                                                     contained_in for losses. Never
-                                                     assume the current tip is the
-                                                     landing tip.
+     lane)                                         → ls says `landed`, because gone is
+                                                     proof of arrival. prune falls back
+                                                     to contained_in, because an unknown
+                                                     tip is never the same answer as
+                                                     "nothing followed". Never assume the
+                                                     current tip is the landing tip.
 G4.  Marked, tracking, contained_in true           → ls `landed`; prune collects
 G5.  Marked, tracking, contained_in false          → ls `open`; prune skips with
                                                      today's message. This is an open
@@ -170,7 +173,7 @@ G17. Marked and gone, but the worktree is dirty
 - A repro of the fast-clone shape — lane branched, another pull request lands touching an adjacent context line, lane squash-merged, head branch deleted — reports `landed` and is collected.
 - A repro of the fix-merge-staging shape — commits added after the merge — is skipped with an exact count, not with `commits main does not have`.
 - `lane prune` with the network unplugged still runs, warns once, and collects nothing it would not have collected before.
-- `rg 'push:track'` returns no hits in Rust source.
+- `rg 'push:track'` finds it only inside the comment warning against it, never in a git invocation.
 - `cargo test`, `./scripts/test.sh`, `cargo clippy --all-targets -- -D warnings`, `cargo fmt --check` all clean.
 
 ## STOP conditions

--- a/plans/README.md
+++ b/plans/README.md
@@ -46,7 +46,7 @@ counts before starting, and update your row when done.
 | 034 | Make lane inventory and context machine-readable | P2 | M | — | DONE |
 | 035 | Make resolvable anchors discoverable and canonical | P2 | L | 034 | DONE |
 | 036 | Make the note lifecycle explicit behind one command family | P2 | L | 035 | DONE |
-| 037 | Prove a landing from the remote, not from a patch | P1 | M | — | TODO |
+| 037 | Prove a landing from the remote, not from a patch | P1 | M | — | DONE |
 | 012 | Make the grammar set a build-time choice | P3 | M | 011 | TODO |
 | 003 | Stop rewriting unchanged notes, so a merge cannot destroy one | P1 | M | — | DONE |
 | 009 | Bound the read ledger and make its counts survive a merge | P3 | M | 003 | SUPERSEDED by 013 |

--- a/plans/README.md
+++ b/plans/README.md
@@ -8,6 +8,9 @@ Plan 033 landed in `5f3742f` and was reconciled into this index on 2026-08-24.
 Plans 034-036 were written against `ae4343c` on 2026-08-24. They form one
 recommended sequence: structured reads, then anchor discovery, then the note lifecycle.
 
+Plan 037 was written against `16c1b05` on 2026-08-25, from two lanes in this repository
+that had landed and could not be collected. It revises one row of 033's case table.
+
 Each executor: read the plan fully, honour its STOP conditions, record the baseline test
 counts before starting, and update your row when done.
 
@@ -43,6 +46,7 @@ counts before starting, and update your row when done.
 | 034 | Make lane inventory and context machine-readable | P2 | M | — | DONE |
 | 035 | Make resolvable anchors discoverable and canonical | P2 | L | 034 | DONE |
 | 036 | Make the note lifecycle explicit behind one command family | P2 | L | 035 | DONE |
+| 037 | Prove a landing from the remote, not from a patch | P1 | M | — | TODO |
 | 012 | Make the grammar set a build-time choice | P3 | M | 011 | TODO |
 | 003 | Stop rewriting unchanged notes, so a merge cannot destroy one | P1 | M | — | DONE |
 | 009 | Bound the read ledger and make its counts survive a merge | P3 | M | 003 | SUPERSEDED by 013 |

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -1109,6 +1109,61 @@ LP="$TMP/repo/.lane/trees/clean-pr"
 ( cd "$LP" && "$LANE" merge > /tmp/clean-pr.out 2>&1 )
 is "merge stays silent when the pushed tip remains reachable" "$(grep -c '^warning: pushed pull request' /tmp/clean-pr.out)" "0"
 
+
+echo "== 40. a retired upstream proves a landing no patch can =="
+setup
+remote_setup
+printf 'one\ntwo\nthree\nfour\nfive\n' > src/ctx.txt
+git add -A && git commit -qm ctx
+git push -q origin main
+"$LANE" new drifted > /dev/null 2>&1
+LP="$TMP/repo/.lane/trees/drifted"
+( cd "$LP" && sedi 's/^four$/four-lane/' src/ctx.txt && git add -A && git commit -qm "lane edits four" \
+  && "$LANE" push > /dev/null 2>&1 )
+# main moves first, touching only a context line of the lane's own hunk, then takes the
+# lane's change on top of it. That is enough to give the two diffs different patch ids.
+sedi 's/^two$/two-main/' src/ctx.txt && git add -A && git commit -qm "main edits two"
+sedi 's/^four$/four-lane/' src/ctx.txt && git add -A && git commit -qm "squash drifted"
+is "the patch probe alone cannot see the landing" "$("$LANE" ls | grep -c 'drifted .*pushed')" "1"
+# The remote retires the branch on its own side, exactly as a merged pull request does.
+git --git-dir="$TMP/origin.git" branch -q -D drifted
+is "ls does not fetch, so it still reads the cached ref" "$("$LANE" ls | grep -c 'drifted .*pushed')" "1"
+git fetch -q --prune
+is "a retired upstream reads as landed" "$("$LANE" ls | grep -c 'drifted .*landed')" "1"
+is "prune collects it" "$("$LANE" prune 2>&1 | grep -c 'removed drifted')" "1"
+is "and the lane is gone" "$([ -d .lane/trees/drifted ] && echo yes || echo no)" "no"
+
+echo "== 41. work added after a landing is counted, not guessed =="
+setup
+remote_setup
+"$LANE" new kept > /dev/null 2>&1
+LP="$TMP/repo/.lane/trees/kept"
+( cd "$LP" && echo one > src/one.rs && git add -A && git commit -qm one && "$LANE" push > /dev/null 2>&1 )
+git merge -q --squash kept > /dev/null && git commit -qm "squash kept" > /dev/null
+git --git-dir="$TMP/origin.git" branch -q -D kept && git fetch -q --prune
+# The branch keeps committing after its own pull request merged.
+( cd "$LP" && echo two > src/two.rs && git add -A && git commit -qm two )
+is "prune counts what arrived after the landing" \
+   "$("$LANE" prune 2>&1 | grep -c 'kept: 1 commit(s) after landing')" "1"
+is "it does not fall back to the uncountable message" \
+   "$("$LANE" prune 2>&1 | grep -c 'kept: commits main does not have')" "0"
+is "and the lane survives" "$([ -d .lane/trees/kept ] && echo yes || echo no)" "yes"
+
+echo "== 42. an open pull request is never collected =="
+setup
+remote_setup
+"$LANE" new open-pr > /dev/null 2>&1
+( cd "$TMP/repo/.lane/trees/open-pr" && echo x > src/x.rs && git add -A && git commit -qm x \
+  && "$LANE" push > /dev/null 2>&1 )
+is "prune keeps a lane whose branch is still on the remote" \
+   "$("$LANE" prune 2>&1 | grep -c 'skipped open-pr: commits main does not have')" "1"
+is "the lane survives" "$([ -d .lane/trees/open-pr ] && echo yes || echo no)" "yes"
+git remote set-url origin "$TMP/gone.git"
+is "a failed fetch warns instead of stopping prune" \
+   "$("$LANE" prune 2>&1 | grep -c 'warning: fetch failed')" "1"
+is "and the open lane is still kept" \
+   "$("$LANE" prune 2>&1 | grep -c 'skipped open-pr')" "1"
+
 echo
 echo "passed: $pass   failed: $fail"
 [ "$fail" -eq 0 ]


### PR DESCRIPTION
Adds `plans/037-prove-a-landing-from-the-remote.md` and implements it. Revises one row of plan 033's case table.

## Why

Two lanes in this repository landed and neither `ls` nor `prune` can see it:

```
skipped fast-clone: commits main does not have
skipped fix-merge-staging: commits main does not have
```

Both trace to `wt::contained_in`, which answers "did this land" by comparing patch ids. A squash merge destroys that evidence, in two different ways.

**fast-clone is a false negative.** Its collapsed probe and the diff of its own squash commit `c904e8d` differ by exactly one line:

```
<  fn registered(root: &Path, dest: &Path) -> bool {
>  pub fn registered(root: &Path, dest: &Path) -> bool {
```

#23 made `registered` public between fast-clone's merge-base and fast-clone's own merge. That line is context, not a change fast-clone made, and `patch-id` hashes context. `150dfc00` against `e0a402b8`. Any pull request landing between a lane's base and its merge can do this to any lane.

**fix-merge-staging is a question the probe cannot express.** #23 squashed its first five commits. Then `7e70718` and `66c1fc1` were committed on the same branch and shipped separately through the enter-exit lane as #25. The probe collapses a branch to one patch, so a branch that landed in two pieces can never match.

## What #11 missed

| kind | read by | needs sharing? |
|---|---|---|
| `landing` | `prune`, `ls` — both local operations on local worktrees | no |

Still true, and still the right call — `.lane/trees/` is in `info/exclude`, so a lane only ever exists on the machine that made it. What the row hides is that *arrival* is a fact about the remote. The marker went local, and proving arrival fell to a patch comparison that a squash defeats.

## The signal

Git already separates these states, and stores exactly two things to do it:

| `branch.<n>.remote` | `refs/remotes/origin/<n>` | git's name |
|---|---|---|
| absent | — | untracked |
| present | present | tracking |
| present | **absent** | **`gone`** |

Proven, not asserted — `%(upstream:track)` across every branch here:

```
clone-syscalls|            never pushed
bench-linux|               open PR
usage-migration|           open PR
enter-exit|[gone]          merged
fast-clone|[gone]          merged
fix-merge-staging|[gone]   merged
```

Clean separation, including the two that patch ids get wrong. `gone` compares no patches, so a squash cannot hide from it: a squash rewrites commits, but it cannot resurrect a deleted head branch. GitHub's auto-delete fires on merge only, so closing a pull request leaves the branch standing.

`gone` becomes a fast path in front of `contained_in`, which stays exactly as it is for every lane that is not gone. This removes nothing.

## What `gone` cannot answer

Whether anything reached the lane after it was prepared — the fix-merge-staging half. So the marker gains the branch tip, and `losses` reports `2 commit(s) after landing` where today it emits `commits main does not have` and admits in a comment that it cannot count.

## Decisions the plan pins down

- `prune` runs `fetch --prune` before it decides; `ls` never fetches and stays offline. `gone` reads a cache that only empties on a prune, and `ls` has to stay instant.
- A failed fetch is never fatal. Offline, `prune` warns and continues against cached refs.
- No migration. Old markers carry no tip, and the only backfill available — "the current tip was the landing tip" — is false for exactly the fix-merge-staging shape and would let `prune` delete work that never landed.
- A hand-deleted remote branch reads as landed. Recorded as an accepted risk rather than papered over.

## What shipped

**The marker records the tip** (`store.rs`). `mark_landed` writes `<id> <iso> <tip>` and moves after the memory commit in `prepare`, because marking earlier dates the landing one commit short of itself. `landed_tip` returns `None` for an older two-field marker, and `None` is never read as "nothing followed".

**`wt::upstream_gone`** reads `%(upstream:track)`. Not `%(push:track)`, which reports `[gone]` for a branch never pushed, having answered for where a push *would* land — `clone-syscalls` in this repository proves it, and the comment records the trap.

**`losses` asks two questions** where it asked one: did it land, and did anything follow. A retired upstream and a recorded tip settle the first together; missing either, `contained_in` is still the only witness. The second is `rev-list <tip>..<branch>` — exact, where the old comment admitted a collapsed patch could not count.

**`prune` fetches first, `ls` never does.** A failed fetch warns and falls through to cached refs, so the command degrades instead of stopping.

## Verified against this repository

Before, and the reason this exists:

```
fast-clone           open    clean  0 pending note(s)
fix-merge-staging    open    clean  0 pending note(s)
```

After:

```
fast-clone           landed  clean  0 pending note(s)
fix-merge-staging    landed  clean  0 pending note(s)
```

`prune --dry-run` still keeps both, and that is G3 behaving as specified rather than a miss: their markers predate tips, so `losses` falls back to the probe instead of assuming the current tip was the landing tip. Clear them once by hand:

```
lane rm fast-clone --force
lane rm fix-merge-staging --force
```

`enter-exit` is not one of them. It already read `landed`, and its blocker is a real pending note on `fn move_to` that never reached main.

## One correction to the plan, made in this branch

Step 3 originally ordered `losses` as tip, then gone, then probe. That contradicted its own G3 row, and it would have collected a lane whose pull request was merely **open** — a worse bug than the one being fixed. Step 3 and Step 4 now match what shipped, and §42 is the regression guard.

## Test plan

- [x] `cargo test` — 175 pass
- [x] `./scripts/test.sh` — 254 assertions, up from 242
- [x] `cargo clippy --all-targets -- -D warnings` and `cargo fmt --check` — clean
- [x] §40 reproduces the fast-clone shape end to end: main moves a context line of the lane's own hunk, takes the change on top, and the lane reads `pushed` until the remote retires the branch
- [x] §41 counts commits added after a landing, and asserts the uncountable message is *not* reached
- [x] §42 refuses to collect a lane whose branch is still on the remote, and survives a failed fetch
- [x] §36 still passes: a reused branch name is never pruned

§40 caught a real one while being written. `git push origin --delete` drops the local tracking ref as well, so it cannot test that `ls` stays offline. The suite deletes the branch on the remote's own side instead, which is what a merged pull request does.

`help.rs` is untouched: new behaviour does not earn a clause in a help description.
