### PR TITLE
fix(prune): name the real gap

### DIFF
--- a/.lane/memory/crates/lane/src/worktree.rs/01M0XDMR0DMQ6ZJWFDC0473F2C-a-lane-whose-upstream-is-gon.md
+++ b/.lane/memory/crates/lane/src/worktree.rs/01M0XDMR0DMQ6ZJWFDC0473F2C-a-lane-whose-upstream-is-gon.md
@@ -1,0 +1,12 @@
+---
+id: 01M0XDMR0DMQ6ZJWFDC0473F2C
+anchor: fn losses
+created: 2026-08-25T21:36:22Z
+norm: '1'
+sig: 22381cb7e3c03d76
+body_hash: c9b9b5b075fd3799
+raw_hash: cf627fb8f2fc51f0
+lines: 470-522
+---
+
+a lane whose upstream is gone but whose marker predates tips did land, so reporting that trunk lacks its commits states the opposite of the truth

--- a/crates/lane/src/worktree.rs
+++ b/crates/lane/src/worktree.rs
@@ -499,15 +499,22 @@ pub fn losses(root: &Path, path: &Path, branch: &str, trunk: &str) -> Vec<String
 
     // A retired upstream proves arrival and a recorded tip dates it. Together they answer
     // without a patch comparison; missing either one, the probe is still the only witness.
-    let landed = match (upstream_gone(root, branch), after) {
+    let gone = upstream_gone(root, branch);
+    let landed = match (gone, after) {
         (true, Some(_)) => true,
         _ => contained_in(root, trunk, branch),
     };
 
     if !landed {
-        // No count: a squash merge leaves commits whose patches landed inside one of
-        // trunk's, so `rev-list` would name a number larger than what is really at risk.
-        out.push(format!("commits {trunk} does not have"));
+        if gone {
+            // It arrived, and no tip dates it, so what sits on top is unknown rather than
+            // absent. Saying trunk lacks the work would be false.
+            out.push("landed, later commits unknown".into());
+        } else {
+            // No count: a squash merge leaves commits whose patches landed inside one of
+            // trunk's, so `rev-list` would name a number larger than what is really at risk.
+            out.push(format!("commits {trunk} does not have"));
+        }
     } else if let Some(count) = after.filter(|count| *count > 0) {
         out.push(format!("{count} commit(s) after landing"));
     }

--- a/plans/037-prove-a-landing-from-the-remote.md
+++ b/plans/037-prove-a-landing-from-the-remote.md
@@ -124,11 +124,14 @@ G2.  Marked, gone, tip recorded, 2 commits after   → ls `landed`; prune skips,
                                                      "2 commit(s) after landing"
 G3.  Marked, gone, NO tip (marker from an older
      lane)                                         → ls says `landed`, because gone is
-                                                     proof of arrival. prune falls back
-                                                     to contained_in, because an unknown
-                                                     tip is never the same answer as
-                                                     "nothing followed". Never assume the
-                                                     current tip is the landing tip.
+                                                     proof of arrival. prune keeps it and
+                                                     says "landed, later commits unknown".
+                                                     An unknown tip is never the same
+                                                     answer as "nothing followed", and the
+                                                     trunk message would be false here —
+                                                     the base does have the work. Never
+                                                     assume the current tip is the landing
+                                                     tip.
 G4.  Marked, tracking, contained_in true           → ls `landed`; prune collects
 G5.  Marked, tracking, contained_in false          → ls `open`; prune skips with
                                                      today's message. This is an open

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -1164,6 +1164,26 @@ is "a failed fetch warns instead of stopping prune" \
 is "and the open lane is still kept" \
    "$("$LANE" prune 2>&1 | grep -c 'skipped open-pr')" "1"
 
+
+echo "== 43. a landing with no recorded tip says so =="
+setup
+remote_setup
+"$LANE" new legacy > /dev/null 2>&1
+LP="$TMP/repo/.lane/trees/legacy"
+( cd "$LP" && echo one > src/one.rs && git add -A && git commit -qm one && "$LANE" push > /dev/null 2>&1 )
+MARK="$TMP/repo/.git/worktrees/legacy/lane/landed"
+is "a landing records the tip alongside the id and stamp" "$(wc -w < "$MARK" | tr -d ' ')" "3"
+# Roll the marker back to the two-field shape a lane written before tips would carry.
+cut -d' ' -f1,2 "$MARK" > "$MARK.old" && mv "$MARK.old" "$MARK"
+git --git-dir="$TMP/origin.git" branch -q -D legacy && git fetch -q --prune
+is "ls still reads the retired upstream as landed" "$("$LANE" ls | grep -c 'legacy .*landed')" "1"
+is "prune names the gap instead of the trunk" \
+   "$("$LANE" prune 2>&1 | grep -c 'skipped legacy: landed, later commits unknown')" "1"
+is "and never claims main lacks work it has" \
+   "$("$LANE" prune 2>&1 | grep -c 'legacy: commits main does not have')" "0"
+is "the lane survives" "$([ -d .lane/trees/legacy ] && echo yes || echo no)" "yes"
+is "force is the way out" "$("$LANE" rm legacy --force 2>&1 | grep -c 'removed lane legacy')" "1"
+
 echo
 echo "passed: $pass   failed: $fail"
 [ "$fail" -eq 0 ]


### PR DESCRIPTION
`prune` told you the opposite of the truth. Follow-up to #28, which left this behind.

## The bug

```
$ lane ls
fast-clone           landed  clean  0 pending note(s)

$ lane prune
skipped fast-clone: commits main does not have
```

Main *does* have them, via #24. Two commands contradicting each other on one screen, and the one that blocks is the one lying.

The logic was right, the words were not. A lane whose upstream is `[gone]` but whose marker predates tips has landed — `gone` proves that. What is unknown is whether anything was committed on top of it afterwards. `losses` had no message for "landed, but I cannot date what followed", so it borrowed the one that means "this never landed".

## The fix

```
skipped fast-clone: landed, later commits unknown
```

Same conservatism — the lane is still kept, `lane rm <name> --force` is still the way out. It now reads in the same slot as every other loss, and says what is actually at stake:

```
1 pending note(s)
3 uncommitted change(s)
2 commit(s) after landing        # tip recorded, counted exactly
landed, later commits unknown    # no tip, so nothing dates what came after
```

An earlier draft said "landed before tips were recorded". That asks the reader to care that lane's marker format changed, which is lane's problem and not theirs.

## Where the plan was thin

037's G3 row specified the *behaviour* — fall back to the probe, never assume the current tip was the landing tip — and said nothing about what the user is told. So the fallback inherited the fallback's message. G3 now spells out the output, since that was the actual gap.

## Verified on this repository

```
skipped enter-exit: 1 pending note(s)
skipped fast-clone: landed, later commits unknown
skipped fix-merge-staging: landed, later commits unknown
```

`enter-exit` is untouched: its blocker is a real pending note on `fn move_to`, not a marker.

## Test plan

- [x] `cargo test` — 175 pass
- [x] `./scripts/test.sh` — 260 assertions, up from 254
- [x] `cargo clippy --all-targets -- -D warnings` and `cargo fmt --check` — clean
- [x] New §43 rolls a marker back to its two-field shape, retires the branch on the remote's own side, and asserts `ls` still reads `landed`, `prune` names the gap, the trunk message is **not** reached, the lane survives, and `--force` removes it
- [x] §42 still passes: an open pull request keeps the trunk message, which is where it is true
