### PR TITLE
fix(skill): link the entry

### DIFF
--- a/.claude/skills
+++ b/.claude/skills
@@ -1,1 +1,0 @@
-../.agents/skills

--- a/.claude/skills/lane
+++ b/.claude/skills/lane
@@ -1,0 +1,1 @@
+../../.agents/skills/lane

--- a/.lane/memory/crates/lane/src/cli.rs/01M0XV7Y4RKGFK4JSD2MW1PT9G-every-skill-that-loads-on-th.md
+++ b/.lane/memory/crates/lane/src/cli.rs/01M0XV7Y4RKGFK4JSD2MW1PT9G-every-skill-that-loads-on-th.md
@@ -1,0 +1,12 @@
+---
+id: 01M0XV7Y4RKGFK4JSD2MW1PT9G
+anchor: fn link_alias
+created: 2026-08-26T01:33:58Z
+norm: '1'
+sig: 1e0a2527d34fcb3f
+body_hash: f25ca2a1dc32c01d
+raw_hash: 9b353aea363d31a9
+lines: 514-525
+---
+
+every skill that loads on this machine is a symlinked entry inside a real .claude/skills, and none symlinks the directory itself, because a loader lists entries but only opts in to descending through a link

--- a/crates/lane/src/cli.rs
+++ b/crates/lane/src/cli.rs
@@ -229,10 +229,9 @@ fn write_protocol(agents: &Path) -> Result<i32> {
 }
 
 const SKILL: &str = include_str!("../assets/skill.md");
-const SKILL_HOME: &str = ".agents/skills";
 const SKILL_PATH: &str = ".agents/skills/lane/SKILL.md";
-const SKILL_ALIAS: &str = ".claude/skills";
-const SKILL_ALIAS_TARGET: &str = "../.agents/skills";
+const SKILL_ALIAS: &str = ".claude/skills/lane";
+const SKILL_ALIAS_TARGET: &str = "../../.agents/skills/lane";
 
 const POST_COMMIT_MARKER: &str = "# lane: capture Why trailers";
 const POST_COMMIT_END: &str = "# lane: end";
@@ -507,8 +506,11 @@ fn skill_install() -> Result<i32> {
 }
 
 /// Harnesses disagree on where a skill lives, so the other spelling is a link, never a copy:
-/// one file cannot drift from itself. An alias already on disk is left alone, because a real
-/// `.claude/skills` directory holds skills that are not ours.
+/// one file cannot drift from itself.
+///
+/// The link is our entry inside `.claude/skills`, never that directory: a loader lists what a
+/// directory holds, and only opts in to descending through a link. Linking the directory it
+/// scans is the one shape that can go unread, which is the failure this exists to prevent.
 fn link_alias(root: &Path) -> Result<()> {
     let alias = root.join(SKILL_ALIAS);
     if std::fs::symlink_metadata(&alias).is_ok() {
@@ -538,14 +540,18 @@ fn skill_uninstall() -> Result<i32> {
         return Ok(0);
     }
     std::fs::remove_dir(dir)?;
-    // The alias is ours only while it points where we put it, and only until something else
-    // installs a skill beside ours.
+    // The alias is ours only while it points where we put it. Its directory is not: other
+    // skills live there, so it goes only when we emptied it.
     let alias = root.join(SKILL_ALIAS);
-    let ours =
-        std::fs::read_link(&alias).is_ok_and(|target| target == Path::new(SKILL_ALIAS_TARGET));
-    if ours && std::fs::read_dir(root.join(SKILL_HOME))?.next().is_none() {
-        std::fs::remove_file(&alias)?;
-        println!("removed {}", alias.display());
+    if !std::fs::read_link(&alias).is_ok_and(|target| target == Path::new(SKILL_ALIAS_TARGET)) {
+        return Ok(0);
+    }
+    std::fs::remove_file(&alias)?;
+    println!("removed {}", alias.display());
+    if let Some(dir) = alias.parent() {
+        if std::fs::read_dir(dir)?.next().is_none() {
+            std::fs::remove_dir(dir)?;
+        }
     }
     Ok(0)
 }

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -631,8 +631,10 @@ setup
 "$LANE" install skill > /tmp/skill.out 2>&1
 is "the skill lands in the harness-neutral tree" \
    "$([ -f .agents/skills/lane/SKILL.md ] && echo yes || echo no)" "yes"
-is "the other spelling is a link, not a second copy" \
-   "$(readlink .claude/skills)" "../.agents/skills"
+is "the other spelling is our entry, not the directory a loader scans" \
+   "$(readlink .claude/skills/lane)" "../../.agents/skills/lane"
+is "so the directory it scans is real" \
+   "$([ -L .claude/skills ] && echo link || echo dir)" "dir"
 is "and it resolves to the same file" \
    "$([ -f .claude/skills/lane/SKILL.md ] && echo yes || echo no)" "yes"
 is "it has frontmatter naming the skill" \
@@ -655,31 +657,38 @@ is "the skill installs into the worktree you ran it from" \
    "$([ -f "$TMP/repo/.lane/trees/skillhome/.agents/skills/lane/SKILL.md" ] && echo yes || echo no)" "yes"
 "$LANE" rm skillhome --force > /dev/null 2>&1
 
-echo "== 24b. the alias never clobbers a directory that is not ours =="
+echo "== 24b. the alias is one entry, never the directory =="
 setup
 mkdir -p .claude/skills/other && echo "someone else" > .claude/skills/other/SKILL.md
 "$LANE" install skill > /dev/null 2>&1
-is "a real .claude/skills directory is left alone" \
-   "$([ -L .claude/skills ] && echo link || echo dir)" "dir"
-is "the other skill survives" \
+is "a skill already installed there survives" \
    "$(grep -c 'someone else' .claude/skills/other/SKILL.md)" "1"
-is "ours still installs at its own path" \
-   "$([ -f .agents/skills/lane/SKILL.md ] && echo yes || echo no)" "yes"
+is "and ours arrives beside it" \
+   "$(readlink .claude/skills/lane)" "../../.agents/skills/lane"
 
 setup
 "$LANE" install skill > /dev/null 2>&1
 "$LANE" uninstall skill > /dev/null 2>&1
 is "uninstall removes the skill" \
    "$([ -e .agents/skills/lane/SKILL.md ] && echo yes || echo no)" "no"
-is "and takes the alias it created with it" \
-   "$([ -L .claude/skills ] && echo yes || echo no)" "no"
+is "and the alias it created" \
+   "$([ -L .claude/skills/lane ] && echo yes || echo no)" "no"
+is "and the directory it emptied" \
+   "$([ -d .claude/skills ] && echo yes || echo no)" "no"
+
+setup
+mkdir -p .claude/skills/other && echo x > .claude/skills/other/SKILL.md
+"$LANE" install skill > /dev/null 2>&1
+"$LANE" uninstall skill > /dev/null 2>&1
+is "but never a directory holding someone else's skill" \
+   "$([ -d .claude/skills/other ] && echo yes || echo no)" "yes"
 
 setup
 "$LANE" install skill > /dev/null 2>&1
-mkdir -p .agents/skills/other && echo x > .agents/skills/other/SKILL.md
+rm .claude/skills/lane && ln -s ../../elsewhere .claude/skills/lane
 "$LANE" uninstall skill > /dev/null 2>&1
-is "the alias stays while another skill sits beside ours" \
-   "$(readlink .claude/skills)" "../.agents/skills"
+is "an alias pointing somewhere else is not ours to remove" \
+   "$(readlink .claude/skills/lane)" "../../elsewhere"
 
 echo "== 24c. init repairs a protocol it wrote earlier =="
 setup


### PR DESCRIPTION
Follow-up to #30. Same intent — `.agents/skills` real, `.claude/skills` linked to it — moved down one level, to the shape that demonstrably loads.

## Why #30 was not safe

#30 linked the directory a loader scans:

```
.claude/skills -> ../.agents/skills
```

Nothing on this machine works that way. Every skill that actually loads is a symlinked **entry** inside a **real** `.claude/skills`:

```
find-skills     -> ../../.agents/skills/find-skills
frontend-design -> ../../.agents/skills/frontend-design
improve         -> /Users/lukeed/repos/personal/dotfiles/home/.agents/skills/improve
codex-agent     -> /Users/lukeed/repos/personal/dotfiles/home/.agents/skills/codex-agent
```

Four of those were loaded in the session that wrote this, which proves the loader follows a symlinked entry. None of them proves it will `read_dir` a scan root that is itself a link — a directory walker lists what a directory holds, but only opts in to descending through a link.

So #30 could have written an alias that is silently never read. That is the exact failure this line of work exists to fix, reintroduced one level up.

## What changes

```rust
const SKILL_ALIAS: &str = ".claude/skills/lane";
const SKILL_ALIAS_TARGET: &str = "../../.agents/skills/lane";
```

`lane install skill` now creates `.claude/skills` as a real directory and links one entry inside it — byte-for-byte the relative form your other nine skills already use:

```
installed /tmp/aliastest/.agents/skills/lane/SKILL.md
linked /tmp/aliastest/.claude/skills/lane -> ../../.agents/skills/lane
```

It also sharpens ownership. lane owns one entry and never the directory, so it cannot collide with skills you install there yourself. `SKILL_HOME` is gone: uninstall no longer has to ask whether anything sits beside us in `.agents/skills`, because the alias names our skill directly.

Uninstall removes the alias only when it still points where we put it, then removes `.claude/skills` only if that emptied it.

## Test plan

- [x] `cargo test` — 175 pass
- [x] `./scripts/test.sh` — 271 assertions, up from 269
- [x] `cargo clippy --all-targets -- -D warnings` and `cargo fmt --check` — clean
- [x] §24 asserts the alias is our entry, that the directory a loader scans is **real**, and that it resolves to the same file
- [x] §24b covers the four ownership cases: a skill already installed there survives and ours arrives beside it; uninstall takes the alias and the directory it emptied; it never takes a directory holding someone else's skill; and an alias repointed elsewhere is not ours to remove
- [x] Live install and uninstall against a scratch repository

This repository moves to the same shape: `.claude/skills/lane -> ../../.agents/skills/lane`, with `.agents/skills/lane/SKILL.md` still pointing into `crates/lane/assets/`.
