### PR TITLE
fix(push): rebase optional

### DIFF
--- a/.lane/memory/crates/lane/src/cli.rs/01M0ZDAY0AHHQV35SJY0JPT9BG-prepare-rebased-before-it-pr.md
+++ b/.lane/memory/crates/lane/src/cli.rs/01M0ZDAY0AHHQV35SJY0JPT9BG-prepare-rebased-before-it-pr.md
@@ -1,0 +1,12 @@
+---
+id: 01M0ZDAY0AHHQV35SJY0JPT9BG
+anchor: fn prepare
+created: 2026-08-26T16:07:31Z
+norm: '1'
+sig: 8d3ffdd82edaa50e
+body_hash: 9600178e506ca2bc
+raw_hash: 492131e75f33c5fc
+lines: 1273-1360
+---
+
+prepare rebased before it promoted, so a conflict left the lane detached mid-rebase with its memory still queued and nothing pushed

--- a/.lane/memory/crates/lane/src/store.rs/01M0ZDAXZK16BGQ65KAF2PVWDD-a-queued-note-naming-a-super.md
+++ b/.lane/memory/crates/lane/src/store.rs/01M0ZDAXZK16BGQ65KAF2PVWDD-a-queued-note-naming-a-super.md
@@ -1,0 +1,12 @@
+---
+id: 01M0ZDAXZK16BGQ65KAF2PVWDD
+anchor: fn promote_pending
+created: 2026-08-26T16:07:30Z
+norm: '1'
+sig: c9e98853e976b416
+body_hash: f4889ce2252b564f
+raw_hash: a129edc1eb138e26
+lines: 313-397
+---
+
+a queued note naming a supersedes target that is no longer live failed the whole promotion, stranding every note behind it in the queue

--- a/crates/lane/src/cli.rs
+++ b/crates/lane/src/cli.rs
@@ -1277,11 +1277,17 @@ enum Preparation {
     Exit(i32),
 }
 
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum Landing {
+    Merge,
+    Push,
+}
+
 fn prepare(
     name: Option<&str>,
     base: Option<&str>,
     budget: &Budget,
-    check_blocking: bool,
+    landing: Landing,
     info: &mut dyn Write,
 ) -> Result<Preparation> {
     let root = wt::main_root()?;
@@ -1305,7 +1311,7 @@ fn prepare(
         return Ok(Preparation::Exit(1));
     }
 
-    if check_blocking {
+    if landing == Landing::Merge {
         let blocked = wt::blocking_changes(&root, &base, &branch);
         if !blocked.is_empty() {
             eprintln!(
@@ -1318,8 +1324,24 @@ fn prepare(
 
     let lock = LandingLock::acquire(&base)?;
 
-    git(&["rebase", &base], Some(&lane_path))?;
-    writeln!(info, "rebased onto {base}")?;
+    // Merge must sit on top of its base to fast-forward it, so a conflict there is the
+    // user's to resolve. Push has no such need: landing from the base the lane already has
+    // is a stale pull request, where failing here is a lane stranded mid-rebase with its
+    // memory still unpromoted.
+    if git(&["rebase", &base], Some(&lane_path)).is_ok() {
+        writeln!(info, "rebased onto {base}")?;
+    } else if landing == Landing::Merge {
+        bail!("rebase onto {base} conflicts; resolve it, then run the command again");
+    } else {
+        try_git(&["rebase", "--abort"], Some(&lane_path));
+        // The abort puts the lane back where it forked, so name that, not the base's tip.
+        let forked = try_git(&["merge-base", &base, &branch], Some(&root));
+        let at = try_git(&["rev-parse", "--short", &forked], Some(&root));
+        writeln!(
+            info,
+            "rebase onto {base} conflicts; pushing from where this lane forked ({at})"
+        )?;
+    }
 
     let out = audit::run(&lane_path, &options(&base, budget))?;
     audit::report(&out, info)?;
@@ -1366,7 +1388,7 @@ fn merge(
     budget: &Budget,
 ) -> Result<i32> {
     let info: &mut dyn Write = &mut std::io::stdout();
-    let prepared = match prepare(name, base, budget, true, info)? {
+    let prepared = match prepare(name, base, budget, Landing::Merge, info)? {
         Preparation::Ready(prepared) => prepared,
         Preparation::Exit(code) => return Ok(code),
     };
@@ -1475,7 +1497,7 @@ fn pull_request_number(lane_path: &Path, remote: &str, tip: &str) -> Option<Stri
 }
 
 fn push(name: Option<&str>, base: Option<&str>, budget: &Budget) -> Result<i32> {
-    let prepared = match prepare(name, base, budget, false, &mut std::io::stdout())? {
+    let prepared = match prepare(name, base, budget, Landing::Push, &mut std::io::stdout())? {
         Preparation::Ready(prepared) => prepared,
         Preparation::Exit(code) => return Ok(code),
     };

--- a/crates/lane/src/store.rs
+++ b/crates/lane/src/store.rs
@@ -370,13 +370,19 @@ pub fn promote_pending(root: &Path) -> Result<Vec<Note>> {
         let mut predecessor = if rec.supersedes.is_empty() {
             None
         } else {
-            Some(
-                load_notes(root, None)
-                    .into_iter()
-                    .find(|old| old.meta.id == rec.supersedes)
-                    .ok_or_else(|| anyhow::anyhow!("live note {} not found", rec.supersedes))?,
-            )
+            load_notes(root, None)
+                .into_iter()
+                .find(|old| old.meta.id == rec.supersedes)
         };
+        // Failing here would strand every note still queued behind this one. The finding is
+        // worth more than the link, so keep it and drop only what cannot be honoured.
+        if predecessor.is_none() && !note.meta.supersedes.is_empty() {
+            eprintln!(
+                "warning: queued note supersedes {}, which is not live; keeping it as a new note",
+                note.meta.supersedes
+            );
+            note.meta.supersedes.clear();
+        }
         note.write(&file)?;
         note.file = Some(file);
         if let Some(old) = predecessor.as_mut() {

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -1250,6 +1250,47 @@ is "it points at both ways out" \
    "$(grep -c 'lane push <name>' /tmp/prune45.out)" "1"
 is "and it does not remove what it cannot account for" \
    "$([ -d .lane/trees/handlanded ] && echo yes || echo no)" "yes"
+echo "== 46. a push completes even when the rebase cannot =="
+setup
+remote_setup
+"$LANE" install hooks > /dev/null
+printf 'one\ntwo\nthree\n' > src/shared.rs && git add -A && git commit -qm shared
+"$LANE" new stale > /dev/null 2>&1
+LP="$TMP/repo/.lane/trees/stale"
+( cd "$LP" && printf 'one\nLANE\nthree\n' > src/shared.rs \
+  && git commit -qam "fix: lane edits two" -m "Why: src/shared.rs#@file | this finding must survive" > /dev/null )
+printf 'one\nTRUNK\nthree\n' > src/shared.rs && git commit -qam "trunk edits two too" > /dev/null
+is "the finding is queued" \
+   "$(cd "$LP" && grep -c 'must survive' "$(git rev-parse --git-path lane/pending.jsonl)")" "1"
+"$LANE" push stale > /tmp/stalepush.out 2>&1
+is "the push succeeds despite the conflict" "$?" "0"
+is "and says where it pushed from" \
+   "$(grep -c 'pushing from where this lane forked' /tmp/stalepush.out)" "1"
+is "the queue is drained, not stranded" \
+   "$(cd "$LP" && [ -e "$(git rev-parse --git-path lane/pending.jsonl)" ] && echo kept || echo drained)" "drained"
+is "the note reached the remote with the branch" \
+   "$(git --git-dir="$TMP/origin.git" ls-tree -r --name-only stale | grep -c '^\.lane/memory/src/shared.rs/')" "1"
+is "the lane is left on its branch, not mid-rebase" \
+   "$(cd "$LP" && git rev-parse --abbrev-ref HEAD)" "stale"
+is "and nothing is conflicted in it" \
+   "$(cd "$LP" && git status --porcelain | grep -c '^UU')" "0"
+
+echo "== 47. a merge still refuses a conflict only you can resolve =="
+setup
+remote_setup
+printf 'one\ntwo\nthree\n' > src/shared.rs && git add -A && git commit -qm shared
+"$LANE" new mustfix > /dev/null 2>&1
+LP="$TMP/repo/.lane/trees/mustfix"
+( cd "$LP" && printf 'one\nLANE\nthree\n' > src/shared.rs && git commit -qam "lane edits two" > /dev/null )
+printf 'one\nTRUNK\nthree\n' > src/shared.rs && git commit -qam "trunk edits two too" > /dev/null
+"$LANE" merge mustfix > /tmp/mustfix.out 2>&1
+is "merge refuses" "$?" "1"
+is "and says what to do about it" \
+   "$(grep -c 'resolve it, then run the command again' /tmp/mustfix.out)" "1"
+is "trunk is not advanced" \
+   "$(git log --oneline -1 --format=%s)" "trunk edits two too"
+is "and the lane still exists" \
+   "$([ -d .lane/trees/mustfix ] && echo yes || echo no)" "yes"
 
 echo
 echo "passed: $pass   failed: $fail"


### PR DESCRIPTION
`lane push` could leave a lane detached mid-rebase, its memory still queued, and nothing pushed. Both halves of that are fixed here. Stacks on #32 only by topic, not by code.

## What went wrong

`prepare` rebases before it promotes:

```rust
git(&["rebase", &base], Some(&lane_path))?;   // <- returns Err on conflict
let out = audit::run(&lane_path, ...)?;       // <- never reached
```

So a lane whose base moved under a line it also touched got this:

```
Could not apply 676b216... fix: change two
```

and was left with `## HEAD (no branch)`, `UU f.txt`, one pending note still in the queue, and nothing on the remote. The command that exists to carry memory to a pull request dropped it and broke the worktree on the way.

## A push no longer needs the rebase to succeed

Merge must sit on top of its base to fast-forward it, so a conflict there is genuinely yours to resolve — that path now refuses with a sentence instead of raw git output, and leaves the rebase in place so you can finish it.

Push has no such requirement. Landing from the base the lane already has is a stale pull request, which is a normal thing; failing is not. So push aborts the rebase and carries on:

```
rebase onto main conflicts; pushing from where this lane forked (0076a6a)
memory: +1 new; checked 1: 1 fresh, ...
committed memory update
pushed fix to origin
```

The lane ends on its own branch, unconflicted, queue drained, and the note is in the tree that reached the remote.

`prepare`'s `check_blocking: bool` became `landing: Landing`, since the same distinction now governs two behaviours and a bare bool could not carry both.

## The other way a note got stranded

`promote_pending` failed the whole promotion when a queued note named a `supersedes` target that was no longer live:

```rust
.ok_or_else(|| anyhow::anyhow!("live note {} not found", rec.supersedes))?
```

One unresolvable link stranded every note queued behind it. The finding is worth more than the link, so it now warns, clears the link, and keeps the note.

## Test plan

- [x] `cargo test` — 175 pass
- [x] `./scripts/test.sh` — 282 assertions, up from 271
- [x] `cargo clippy --all-targets -- -D warnings` and `cargo fmt --check` — clean
- [x] §46 drives the real conflict end to end: the push succeeds, names where it pushed from, drains the queue, puts the note in the tree that reached the remote, and leaves the lane on its branch with nothing conflicted
- [x] §47 holds the line for merge: it refuses, says what to do, does not advance trunk, and does not remove the lane

## Still not guaranteed

"Never leaves pending notes behind" is now true for the two paths I could reproduce. It is not yet an invariant — `prepare` still bails before promoting when the lane has uncommitted changes, which is the remaining case where a `lane push` ends with the queue intact. That one is arguably correct, since it refuses before touching anything, but it is the same shape and worth deciding on separately.
