### PR TITLE
chore: tighten readme & cli help text

### DIFF
--- a/.lane/memory/crates/lane/assets/skill.md/01M0ER1X7801FW524YV2G8TNQQ-ships-via-include-str-so-an.md
+++ b/.lane/memory/crates/lane/assets/skill.md/01M0ER1X7801FW524YV2G8TNQQ-ships-via-include-str-so-an.md
@@ -4,9 +4,9 @@ anchor: '@file'
 created: 2026-08-20T04:23:47Z
 norm: '1'
 sig: cb3f91d54eee30e5
-body_hash: 06104e7bd6d74049
-raw_hash: 5b4328723498dff8
-vouched: 2026-08-26T03:30:34Z
+body_hash: 42c8667ceea8e5c9
+raw_hash: 96910d001090a8d9
+vouched: 2026-08-26T21:16:50Z
 lines: 1-86
 ---
 

--- a/.lane/memory/crates/lane/assets/skill.md/01M0ER1X7801FW524YV2G8TNQQ-ships-via-include-str-so-an.md
+++ b/.lane/memory/crates/lane/assets/skill.md/01M0ER1X7801FW524YV2G8TNQQ-ships-via-include-str-so-an.md
@@ -4,9 +4,9 @@ anchor: '@file'
 created: 2026-08-20T04:23:47Z
 norm: '1'
 sig: cb3f91d54eee30e5
-body_hash: 42c8667ceea8e5c9
-raw_hash: 96910d001090a8d9
-vouched: 2026-08-26T21:16:50Z
+body_hash: bd9c0ba2cf9855b6
+raw_hash: 2b6a42a6023d69be
+vouched: 2026-08-26T22:08:28Z
 lines: 1-86
 ---
 

--- a/.lane/memory/crates/lane/src/help.rs/01M0ZYYJ0NQ2NTYMPG0XNWKV24-install-and-uninstall-must-n.md
+++ b/.lane/memory/crates/lane/src/help.rs/01M0ZYYJ0NQ2NTYMPG0XNWKV24-install-and-uninstall-must-n.md
@@ -1,0 +1,12 @@
+---
+id: 01M0ZYYJ0NQ2NTYMPG0XNWKV24
+anchor: const ROOT
+created: 2026-08-26T21:17:16Z
+norm: '1'
+sig: 90d5fdee579d9fb6
+body_hash: ca41d82c1a7c6482
+raw_hash: ad2155f23865c8b6
+lines: 155-187
+---
+
+install and uninstall must name hooks and the agent skill separately; Git hooks are not agent integrations

--- a/crates/lane/assets/skill.md
+++ b/crates/lane/assets/skill.md
@@ -5,7 +5,8 @@ description: Use lane in this repository — create isolated worktrees, read exi
 
 # lane
 
-This repository keeps durable context as Markdown under `.lane/`. Read it before editing a file, then record only the non-obvious constraints another agent would otherwise have to rediscover.
+This repository keeps durable context / memories as Markdown under `.lane/`. 
+You must read before editing a file, via `lane why <path>`, then record only the non-obvious constraints or decisions another agent would otherwise have to rediscover.
 
 ## Workflow
 
@@ -52,9 +53,12 @@ lane note unpin <id>    # remove that protection
 
 ## Record what must stay true
 
-Not every file or commit needs a note. Record significant, non-obvious constraints — never a summary of the change.
+Not every file or commit needs a note. Only record significant, non-obvious constraints — never a summary of the change.
 
-Add a `Why:` trailer when the finding belongs with a commit:
+### Commit Message Trailer(s)
+
+If `lane install hooks` has been run, then `git` hooks are active and you can add notes while writing commit messages.
+Include a `Why:` trailer when the finding belongs with a commit:
 
 ```text
 make verification constant-time
@@ -62,9 +66,13 @@ make verification constant-time
 Why: src/auth.rs#fn verify | early return leaks token length
 ```
 
-The form is `Why: <path>[#<anchor>] | <text>`. The path and ` | ` separator are required; omit the anchor to target the whole file. Run `lane install hooks` once if trailers are not being captured.
+The form is `Why: <path>[#<anchor>] | <text>`. The path and ` | ` separator are required; omit the anchor to target the whole file. 
 
-Record a finding directly when it does not belong to a commit:
+Run `lane install hooks` once if trailers are not being captured.
+
+### Manually
+
+Record a finding directly when it does not belong to a commit, or if `lane install hooks` has not been run:
 
 ```bash
 lane note add src/auth.rs -a "fn verify" "must stay constant-time"

--- a/crates/lane/assets/skill.md
+++ b/crates/lane/assets/skill.md
@@ -22,7 +22,7 @@ lane push              # push the lane for a pull request
 
 `lane merge` rebases, audits memory, updates local trunk, and removes the lane. Commit or stash tracked changes first.
 
-When trunk is protected, use `lane push` instead. After the pull request merges, run `lane prune`. Use `lane ls --json` for machine-readable lane state.
+The push workflow is for protected trunks. After the pull request merges, run `lane prune`. Use `lane ls --json` for machine-readable lane state.
 
 ## Read before editing
 

--- a/crates/lane/assets/skill.md
+++ b/crates/lane/assets/skill.md
@@ -1,107 +1,96 @@
 ---
 name: lane
-description: Use lane in this repository — open a worktree with `lane new`, read what earlier lanes learned about a file before editing it, and record what must stay true as a `Why:` commit trailer or a `lane note`.
+description: Use lane in this repository — create isolated worktrees, read existing context before editing, and record constraints that future work must preserve.
 ---
 
 # lane
 
-This repository keeps memory about its own code in `.lane/`. Notes are plain markdown. Their text is replaced with a successor rather than edited in place; explicit confirmation and pinning update metadata. Read them before you edit, and leave one behind when you learn something the next agent would otherwise rediscover.
+This repository keeps durable context as Markdown under `.lane/`. Read it before editing a file, then record only the non-obvious constraints another agent would otherwise have to rediscover.
 
-## The loop
+## Workflow
 
 ```bash
-lane new fix-login     # branch + worktree; the build cache arrives by reference
+lane new fix-login     # create a branch and worktree
 # edit and commit as usual
-lane merge             # rebase, audit memory, fast-forward trunk, delete the lane
+lane merge             # land on local trunk
+lane merge --squash    # land on local trunk as one commit
+lane push              # push the lane for a pull request
 ```
 
-`lane new` prints the path. Work there, not in the parent tree. `lane merge` rebases, so commit or stash tracked changes first; untracked files are fine.
+`lane new` prints the worktree path. Work there, not in the parent checkout.
 
-Where trunk is protected, `lane push` rebases, audits, commits memory, and sends the lane to the remote. Once it merges run `lane prune` to remove the lane. `lane ls` marks a lane `pushed` while the remote has its tip, and `landed` once its remote branch is retired or trunk already holds the work.
+`lane merge` rebases, audits memory, updates local trunk, and removes the lane. Commit or stash tracked changes first.
 
-Use `lane ls --json` as the reliable machine-readable inventory when coordinating
-multiple lanes.
+When trunk is protected, use `lane push` instead. After the pull request merges, run `lane prune`. Use `lane ls --json` for machine-readable lane state.
 
-## Read before you edit
+## Read before editing
 
 ```bash
 lane why src/auth.rs
-lane why src/            # every note beneath a directory
+lane why src/
 ```
 
-Do this for every file you are about to change. `lane why` is the compact reading view;
-`lane why --json` returns full ids, paths, anchors, timestamps, and note text. Give it a
-directory to survey an area before you know which file you need. Run `lane check` when
-you need freshness and the ids of notes that require action.
+Run `lane why` for every file you intend to edit. A directory returns all notes beneath it; `--json` includes full ids, anchors, timestamps, and note text.
 
-Before `lane merge`, run `lane check`. It lists every note that is not fresh, each with the id you need next. Read the note and its current span, then take exactly one action:
+Run `lane check` before landing. For every stale note, take exactly one action:
 
-- `lane note confirm <id>` when the note is still true. This updates that note's own baseline, so commit it — a confirmation you do not commit is one nobody else gets.
-- `lane note replace <id> "<rewrite>"` when the subject is still right but the sentence is wrong. It inherits the predecessor's path and anchor unless you override them.
-- `lane note retire <id>` when the constraint is gone.
-
-At a terminal, `lane note edit <id>` shows the live note and guides a human through
-the same actions, including pin or unpin. Agents and scripts should use the direct
-commands above so they never depend on prompts.
-
-Any unambiguous prefix of an id works, so the ten characters `lane check` and `lane why` print are enough. `lane check --json` carries the same rows plus each note's body and current span, for when you would rather not open the files.
-
-A `?` cannot be resolved because the file has no grammar. An `x` means the symbol is gone; let audit move that note to the attic instead of vouching for it.
-
-Use `lane note restore <id>` to recover a retired note. `lane note pin <id>` protects a live note from eviction; `lane note unpin <id>` removes that protection.
-
-Notes are evicted oldest and stalest first, and only when an anchor is over budget.
-
-## Record what you learned
-
-IMPORTANT: Not every file nor every commit needs a memory and/or Why trailer! Only significant, non-obvious decisions should be recorded.
-
-You are already writing a commit message, so use it:
-
+```bash
+lane note confirm <id>              # the note is still true
+lane note replace <id> "<rewrite>"  # the constraint has changed
+lane note retire <id>               # the constraint no longer applies
 ```
-make verify constant-time
+
+An unambiguous id prefix is enough. Use `lane note edit <id>` for the interactive menu, or the direct commands above in scripts and agent workflows.
+
+Other lifecycle commands:
+
+```bash
+lane note restore <id>  # restore a retired note
+lane note pin <id>      # protect a note from eviction
+lane note unpin <id>    # remove that protection
+```
+
+## Record what must stay true
+
+Not every file or commit needs a note. Record significant, non-obvious constraints — never a summary of the change.
+
+Add a `Why:` trailer when the finding belongs with a commit:
+
+```text
+make verification constant-time
 
 Why: src/auth.rs#fn verify | early return leaks token length
 ```
 
-The form is `Why: <path>[#<anchor>] | <text>`, in the trailer block at the end. The ` | ` and the path are required; omitting `#<anchor>` means the whole file. If nothing is captured, run `lane install hooks` once.
+The form is `Why: <path>[#<anchor>] | <text>`. The path and ` | ` separator are required; omit the anchor to target the whole file. Run `lane install hooks` once if trailers are not being captured.
 
-When the insight does not arrive at a commit boundary:
+Record a finding directly when it does not belong to a commit:
 
 ```bash
 lane note add src/auth.rs -a "fn verify" "must stay constant-time"
 ```
 
-Supplying text is always non-interactive and defaults an omitted anchor to `@file`. Omit text only when you want an interactive anchor selector and one-line note prompt.
-
-## The one rule
-
-**Record what must stay true, not what you did.**
-
-The subject above already says `make verify constant-time`; the note says why that has to hold. A subject describes a change, a note describes a constraint that outlives it. A trailer that mostly restates its own subject is rejected rather than stored.
+Supplying text is non-interactive and defaults to `@file` when `-a` is omitted. Omit the text only when you want the interactive prompt.
 
 ## Anchors
 
-An anchor is what the note is *about*, not where it lives.
+An anchor describes what a note is about:
 
 | anchor | matches |
 |---|---|
-| `fn verify` | a declaration, by keyword and name |
-| `verify` | any declaration of that name |
-| `#script`, `#style` | a top-level block in `.svelte`, `.vue`, html |
-| `## Rate limiting` | a markdown section |
-| `@file` | the whole file — the default |
+| `fn verify` | a declaration by kind and name |
+| `verify` | a uniquely named declaration |
+| `#script`, `#style` | a top-level component block |
+| `## Rate limiting` | a Markdown section |
+| `@file` | the whole file |
 
-When you do not already know a valid anchor, run `lane anchors <path> --json`
-and prefer the canonical value it returns. A unique bare declaration name is
-canonicalized when recorded; an ambiguous one is refused with its choices.
+Run `lane anchors <path> --json` and prefer the canonical anchor it returns. Ambiguous declaration names are refused with their available choices.
 
-One note, one thought. Do not classify it — a note costs one command, on purpose.
+## Rules
 
-## Do not
+- Never edit `.lane/` by hand; use the `lane note` commands.
+- Do not pass `--dirty` unless the lane should inherit the parent checkout's uncommitted work.
+- Keep each note to one constraint.
+- Do not record what a commit changed.
 
-- Rewrite anything under `.lane/` by hand; use the `lane note` lifecycle commands.
-- Pass `--dirty` unless you want the parent tree's uncommitted work in your lane.
-- Write notes about what a commit changed, or notes you have not read the file to confirm.
-
-`lane --help` lists every command; `lane <command> --help` explains one.
+Run `lane --help` for the command list, or `lane <command> --help` for details.

--- a/crates/lane/src/help.rs
+++ b/crates/lane/src/help.rs
@@ -157,22 +157,22 @@ const ROOT: &str = "
     $ lane <command> [options]
 
   Commands
-    init         Scaffold memory + merge rules, probe reflink
-    new          Create a CoW lane
-    enter        Change directory into a lane
-    exit         Change directory back to the main worktree
+    init         Initialize lane in a repository
+    new          Create a copy-on-write worktree
+    enter        Enter a lane
+    exit         Return to the main worktree
     ls           List lanes
-    anchors      List addressable anchors in a file
-    note         Manage memory notes
-    install      Install lane's agent integrations
-    uninstall    Remove lane's agent integrations
-    why          Show context for a path
-    check        Staleness report
-    audit        Promote, re-anchor, rank, evict
-    merge        Rebase, audit, fast-forward, remove
-    push         Rebase, audit, push for a pull request
-    prune        Remove lanes whose branch has landed
-    rm           Discard a lane without landing it
+    anchors      List note anchors in a file
+    note         Manage notes
+    install      Install hooks or the agent skill
+    uninstall    Remove hooks or the agent skill
+    why          Show notes for a path
+    check        Find stale notes
+    audit        Reconcile pending and stale notes
+    merge        Land a lane locally
+    push         Push a lane for review
+    prune        Remove landed lanes
+    rm           Discard a lane
     shellenv     Print shell integration
 
   Options
@@ -188,8 +188,8 @@ const ROOT: &str = "
 
 const INIT: &str = "
   Description
-    Scaffold .lane/, the merge rule, and the AGENTS.md protocol, and report
-    whether this filesystem can reflink. Safe to re-run.
+    Create .lane/, add the AGENTS.md protocol, and check reflink support.
+    Safe to re-run.
 
   Usage
     $ lane init
@@ -200,8 +200,8 @@ const INIT: &str = "
 
 const NEW: &str = "
   Description
-    Create a worktree under .lane/trees/ and the branch it is on. Everything
-    git ignores is cloned by reference, so a build cache costs no disk.
+    Create a branch and worktree under .lane/trees/. Ignored files are cloned
+    by reference when the filesystem supports reflinks.
 
   Usage
     $ lane new <name> [options]
@@ -219,8 +219,7 @@ const NEW: &str = "
 
 const LS: &str = "
   Description
-    Every lane's name, whether it has landed, whether it is clean, and how many
-    notes it has yet to land.
+    List each lane's state, worktree status, and pending note count.
 
   Usage
     $ lane ls [--json]
@@ -232,7 +231,7 @@ const LS: &str = "
 
 const ENTER: &str = "
   Description
-    Change directory into a lane. Or `switch` alias.
+    Change directory into a lane. `switch` is an alias.
 
   Usage
     $ lane enter <name>
@@ -258,8 +257,8 @@ const EXIT: &str = "
 
 const ANCHORS: &str = "
   Description
-    List every addressable anchor in source order with its inclusive line range.
-    @file is always present, including for empty and unparsed files.
+    List note anchors in source order with their line ranges. @file is always
+    available, including for empty and unparsed files.
 
   Usage
     $ lane anchors [--json] <PATH>
@@ -274,7 +273,7 @@ const ANCHORS: &str = "
 
 const NOTE: &str = "
   Description
-    Add or interactively edit a note, or apply one lifecycle action directly.
+    Record, update, or retire a memory note.
 
   Usage
     $ lane note <command>
@@ -295,9 +294,7 @@ const NOTE: &str = "
 
 const NOTE_EDIT: &str = "
   Description
-    Show a live note and interactively choose to confirm it, replace its text,
-    retire it, or toggle its eviction protection. Text replacement creates a
-    successor instead of rewriting the existing note.
+    Interactively confirm, replace, retire, pin, or unpin a live note.
 
   Usage
     $ lane note edit <id>
@@ -308,8 +305,8 @@ const NOTE_EDIT: &str = "
 
 const NOTE_ADD: &str = "
   Description
-    Record one finding about a file or anchor. Supplying text never prompts;
-    omit it to select an anchor and enter the note interactively.
+    Record one finding about a file or anchor. Omit text to choose the anchor
+    and enter the note interactively.
 
   Usage
     $ lane note add [options] <path> [text]
@@ -325,8 +322,8 @@ const NOTE_ADD: &str = "
 
 const NOTE_REPLACE: &str = "
   Description
-    Queue a successor for a live note, inheriting its path and anchor unless
-    either is overridden. The predecessor retires when audit promotes it.
+    Replace a live note on the next audit. Path and anchor are inherited unless
+    overridden.
 
   Usage
     $ lane note replace [options] <id> [text]
@@ -342,8 +339,7 @@ const NOTE_REPLACE: &str = "
 
 const NOTE_CONFIRM: &str = "
   Description
-    Confirm that a drifted live note is still true. Any unambiguous id prefix
-    works.
+    Confirm that a drifted note is still true. An unambiguous id prefix works.
 
   Usage
     $ lane note confirm <id>
@@ -398,8 +394,8 @@ const NOTE_UNPIN: &str = "
 
 const INSTALL: &str = "
   Description
-    Install an agent integration. `hooks` captures a commit's `Why:` trailer
-    as a pending note; `skill` teaches an agent the daily loop.
+    Install Git hooks that capture `Why:` trailers, or the lane skill that
+    teaches coding agents the workflow.
 
   Usage
     $ lane install <hooks|skill>
@@ -414,8 +410,7 @@ const INSTALL: &str = "
 
 const UNINSTALL: &str = "
   Description
-    Remove an agent integration. Only lane's own delimited block is spliced
-    out, so the rest of the file survives.
+    Remove lane's Git hooks or agent skill. Unrelated file content is kept.
 
   Usage
     $ lane uninstall <hooks|skill>
@@ -426,9 +421,7 @@ const UNINSTALL: &str = "
 
 const WHY: &str = "
   Description
-    Print what earlier lanes learned about a path, each note with the id you
-    need to re-vouch for it. A directory reports every note beneath it, and no
-    path at all reports the whole store.
+    Show notes for a file or directory. Omit the path to show every note.
 
   Usage
     $ lane why [path] [options]
@@ -446,7 +439,7 @@ const WHY: &str = "
 
 const CHECK: &str = "
   Description
-    Every note that is not fresh, each with the id you need next.
+    List notes whose anchored content has changed.
 
   Usage
     $ lane check [options]
@@ -458,8 +451,8 @@ const CHECK: &str = "
 
 const AUDIT: &str = "
   Description
-    Resolve pending notes against the working tree, re-anchor what moved, and
-    evict past the budget to the attic. `lane merge` runs this for you.
+    Promote pending notes, follow moved anchors, and move notes over budget to
+    the attic. `lane merge` and `lane push` run this automatically.
 
   Usage
     $ lane audit [options]
@@ -474,8 +467,8 @@ const AUDIT: &str = "
 
 const MERGE: &str = "
   Description
-    Land a lane: rebase onto its base, audit memory, fast-forward, and remove
-    the worktree. Landings are locked, so two at once serialize.
+    Rebase onto the lane's base, audit its notes, update the local base branch,
+    and remove the worktree.
 
   Usage
     $ lane merge [name] [options]
@@ -495,8 +488,8 @@ const MERGE: &str = "
 
 const PUSH: &str = "
   Description
-    Rebase a lane onto its base, audit and commit memory, then push it for a
-    pull request. The remote is the branch's upstream or origin.
+    Rebase onto the lane's base, audit and commit its notes, then push the
+    branch for review.
 
   Usage
     $ lane push [name] [options]
@@ -513,9 +506,8 @@ const PUSH: &str = "
 
 const PRUNE: &str = "
   Description
-    Remove every lane whose branch has landed in trunk. A pushed lane sits here
-    until its pull request merges; this is
-    what collects it. Work committed after the merge is never discarded.
+    Remove lanes whose branches have landed. Uncommitted work and commits made
+    after landing are never discarded.
 
   Usage
     $ lane prune [options]
@@ -527,10 +519,8 @@ const PRUNE: &str = "
 
 const RM: &str = "
   Description
-    Discard a lane and everything it still holds: the worktree, the branch,
-    the pending notes, the per-branch state. Anything that would be lost with
-    it stops the removal and is named instead. A squash or rebase merge counts
-    as landed, where `git branch -d` refuses it.
+    Remove a lane and its branch, worktree, pending notes, and local state.
+    Refuse if anything would be lost unless --force is given.
 
   Usage
     $ lane rm <name> [options]

--- a/readme.md
+++ b/readme.md
@@ -96,13 +96,54 @@ For repositories with protected branches, use `lane push` instead of `lane merge
 
 Run `lane --help` for the command list, or visit the [usage guide](https://lane.lukeed.com/usage) for the full workflow.
 
+## Memory
+
+Memory is ordinary Markdown committed with the repository:
+
+```text
+.lane/
+  memory/<path>/<ulid>-<slug>.md   live notes and confirmed fingerprints
+  attic/<path>/<ulid>-<slug>.md    retired notes, still recoverable
+  trees/<name>/                    local worktrees, never committed
+```
+
+New notes use distinct files, so parallel lanes can annotate the same code without editing the same bytes. `lane note confirm <id>` re-vouches for a drifted note by updating its confirmed fingerprint. Pin and unpin likewise update retention metadata. If two branches make conflicting judgments about the same note, Git makes that disagreement visible.
+
+Notes are written directly to `.lane/memory/` without a baseline. The next audit baselines them after any rebase, follows source-file renames, and moves superseded, unpinned missing, or unpinned over-budget notes to `.lane/attic/` rather than deleting them.
+
+Freshness is computed for the anchored span, not the whole file:
+
+| result | meaning |
+|---|---|
+| `fresh` | the anchored span is unchanged |
+| `content-changed` | its implementation changed |
+| `contract-changed` | its declaration changed |
+| `anchor-missing` | the symbol no longer resolves |
+| `unverifiable` | lane has no grammar for that anchor |
+
+Anchors include declarations such as `fn verify`, Markdown headings such as `## Rate limiting`, component blocks such as `#script`, and `@file` for a whole file. Run `lane anchors src/auth.rs` to list the canonical values and their line ranges. A unique bare name such as `verify` is stored as its canonical value; a name shared by multiple declaration kinds is refused with the available choices. Comments and whitespace are normalized out of fingerprints.
+
+Resolve drift with exactly one of these actions:
+
+```sh
+$ lane note confirm <id>
+$ lane note replace <id> '<replacement>'
+$ lane note retire <id>
+```
+
+Run `lane note edit <id>` for a guided terminal menu over the same actions, including pinning or unpinning the note.
+
+Replacement inherits the live note's path and anchor. Retire and restore move bytes unchanged between live memory and the attic; pin and unpin control eviction. For a new note, supplied text never prompts and defaults to `@file` without `-a`; omit text to use the interactive anchor selector and one-line prompt.
+
 ## Development
 
 ```sh
+$ ./scripts/build.sh        # release-build and install the local lane binary
 $ cargo fmt --all --check
 $ cargo clippy --workspace --all-targets -- -D warnings
 $ cargo test --workspace
-$ ./scripts/test.sh
+$ ./scripts/test.sh         # end to end against temporary Git repositories
+$ ./scripts/check-linux.sh  # run the same gates without reflink support
 ```
 
 ## License

--- a/readme.md
+++ b/readme.md
@@ -4,6 +4,19 @@
 
 Lane creates isolated worktrees without leaving behind the ignored build caches that make a checkout fast. It can also attach durable notes to a file or symbol, then flag them when the relevant code changes. Lane never calls a model.
 
+> [!TIP]
+> **Why another worktree tool?**
+>
+> When you run `git worktree add`, it creates a clean checkout but leaves behind everything Git ignores: `target/`, `node_modules/`, virtual environments, generated files, and local `.env` files. This means you must reinstall and/or build from scratch, despite already having all your caches warm on disk. On a reflink filesystem, lane clones those entries by reference. The new lane starts warm while allocating new storage only for the blocks it changes.
+> 
+> Lane uses `clonefile(2)` on APFS and `FICLONE` on Linux filesystems that support it, including btrfs and XFS with reflink enabled. If reflinks are unavailable, lane creates a normal worktree and does not byte-copy ignored caches. When desired, `lane new --dirty` also carries tracked edits and untracked, non-ignored files; without reflinks, those changed files are copied normally.
+>
+> Lanes live under `.lane/trees/` and are excluded through `.git/info/exclude`, so the worktrees themselves are never committed.
+>
+> Lane can also attach durable notes/memories to a file or symbol, then flag them when the relevant code changes. 
+>
+> Lane never calls a model.
+
 ## Install
 
 Prebuilt binaries are available for macOS and Linux on arm64 and x86_64:
@@ -26,11 +39,14 @@ Lane requires Rust 1.85 or newer when building from source.
 
 ## Setup
 
-Add the shell wrapper to `.zshrc` or `.bashrc`:
+For each new shell, you will need to install the `lane shellenv` wrapper to automatically `cd` into & out of lanes.
+Or you may add the shell wrapper to `.zshrc` or `.bashrc` to auto-run: 
 
 ```sh
 eval "$(lane shellenv)"
 ```
+
+> While not necessary, this more convenient than manually running `cd .lane/trees/<new lane>` repeatedly.
 
 Then initialize each repository:
 
@@ -46,8 +62,8 @@ This creates the memory store, adds a short agent protocol to `AGENTS.md`, and r
 Optional tooling can capture `Why:` commit trailers or install the fuller agent workflow:
 
 ```sh
-$ lane install hooks
-$ lane install skill
+$ lane install hooks  # capture targeted Why: trailers from commits
+$ lane install skill  # install the fuller workflow for coding agents
 ```
 
 ## Usage
@@ -60,7 +76,10 @@ $ lane note add src/auth.rs -a 'fn verify' \
 
 # edit and commit as usual
 $ lane check
+
 $ lane merge
+# or
+$ lane push
 ```
 
 `lane new` creates a branch and worktree under `.lane/trees/`. On APFS, btrfs, and reflink-enabled XFS, ignored files are cloned by reference. Otherwise, Lane creates a normal Git worktree and skips ignored files.

--- a/readme.md
+++ b/readme.md
@@ -1,190 +1,90 @@
-# lane
+# lane [![CI](https://github.com/lukeed/lane/actions/workflows/ci.yml/badge.svg)](https://github.com/lukeed/lane/actions/workflows/ci.yml)
 
-> Copy-on-write worktrees with memory that survives them. One tool.
+> Copy-on-write Git worktrees with memory that survives them.
 
-Lane opens an isolated branch and worktree without giving up the ignored build caches that make a checkout fast. While you work, notes attach decisions to a file and symbol. When that code changes later, lane flags the note instead of quietly trusting stale context. Lane itself never calls a model.
-
-```bash
-lane new fix-login
-lane why src/auth.rs
-lane note add src/auth.rs -a 'fn verify' 'tokens rotate on refresh'
-# edit and commit as usual
-lane check
-lane merge
-```
-
-## Why another worktree tool?
-
-`git worktree add` creates a clean checkout but leaves behind everything Git ignores: `target/`, `node_modules/`, virtual environments, generated files, and local `.env` files. On a reflink filesystem, lane clones those entries by reference. The new lane starts warm while allocating new storage only for the blocks it changes.
-
-Lane uses `clonefile(2)` on APFS and `FICLONE` on Linux filesystems that support it, including btrfs and XFS with reflink enabled. If reflinks are unavailable, lane creates a normal worktree and does not byte-copy ignored caches. `lane new --dirty` also carries tracked edits and untracked, non-ignored files; without reflinks, those changed files are copied normally.
-
-Lanes live under `.lane/trees/` and are excluded through `.git/info/exclude`, so the worktrees themselves are never committed.
+Lane creates isolated worktrees without leaving behind the ignored build caches that make a checkout fast. It can also attach durable notes to a file or symbol, then flag them when the relevant code changes. Lane never calls a model.
 
 ## Install
 
 Prebuilt binaries are available for macOS and Linux on arm64 and x86_64:
 
-```bash
-curl -fsSL https://lane.lukeed.com | sh
+```sh
+$ curl -fsSL https://lane.lukeed.com | sh
 ```
 
-The installer writes to `~/.local/bin` by default. Set `LANE_INSTALL` to choose another directory or `LANE_VERSION` to pin a release. You can also install with Cargo:
+The installer writes to `~/.local/bin` by default. Set `LANE_INSTALL` to choose another directory, or `LANE_VERSION` to pin a release.
 
-```bash
-cargo binstall --git https://github.com/lukeed/lane lane
-cargo install --git https://github.com/lukeed/lane
+You may also install with Cargo:
+
+```sh
+$ cargo binstall --git https://github.com/lukeed/lane lane
+# or
+$ cargo install --git https://github.com/lukeed/lane
 ```
 
-From a source checkout, build and replace the `lane` binary in Cargo's bin directory with:
+Lane requires Rust 1.85 or newer when building from source.
 
-```bash
-./scripts/build.sh
-```
+## Setup
 
-Lane requires Rust 1.85 or newer.
+Add the shell wrapper to `.zshrc` or `.bashrc`:
 
-## Set up a repository
-
-Enable the shell wrapper once in `.zshrc` or `.bashrc`; it is what lets `lane new`, `lane enter`, `lane exit` and `lane merge` move the shell:
-
-```bash
+```sh
 eval "$(lane shellenv)"
 ```
 
 Then initialize each repository:
 
-```bash
-cd yourrepo
-lane init
-git add .lane AGENTS.md
-git commit -m 'initialize lane'
+```sh
+$ cd yourrepo
+$ lane init
+$ git add .lane AGENTS.md
+$ git commit -m 'initialize lane'
 ```
 
-`lane init` creates the memory store and a short context protocol in `AGENTS.md`, and reports whether the current filesystem supports reflinks.
+This creates the memory store, adds a short agent protocol to `AGENTS.md`, and reports whether the filesystem supports reflinks.
 
-Optional integrations:
+Optional tooling can capture `Why:` commit trailers or install the fuller agent workflow:
 
-```bash
-lane install hooks    # capture targeted Why: trailers from commits
-lane install skill    # install the fuller workflow for coding agents
+```sh
+$ lane install hooks
+$ lane install skill
 ```
 
-## Daily workflow
+## Usage
 
-Open a lane and read its existing context before editing:
+```sh
+$ lane new fix-login
+$ lane why src/auth.rs
+$ lane note add src/auth.rs -a 'fn verify' \
+    'must stay constant-time; early return leaks token length'
 
-```bash
-lane new fix-login
-lane why src/auth.rs
+# edit and commit as usual
+$ lane check
+$ lane merge
 ```
 
-Record what must stay true, not a summary of the change:
+`lane new` creates a branch and worktree under `.lane/trees/`. On APFS, btrfs, and reflink-enabled XFS, ignored files are cloned by reference. Otherwise, Lane creates a normal Git worktree and skips ignored files.
 
-```bash
-lane note add src/auth.rs -a 'fn verify' \
-  'must stay constant-time; early return leaks token length'
+Notes record what must stay true, not what a commit changed. They are stored as Markdown under `.lane/memory/` and anchored to a declaration, Markdown section, component block, or whole file. When an anchor drifts, choose one action:
+
+```sh
+$ lane note confirm <id>                  # still true
+$ lane note replace <id> '<replacement>'  # needs an update
+$ lane note retire <id>                   # no longer applies
 ```
 
-After committing the code, inspect any drift and land the lane:
+For repositories with protected branches, use `lane push` instead of `lane merge`. After the pull request lands, run `lane prune`.
 
-```bash
-lane check
-lane merge                    # rebase, audit memory, fast-forward, remove
-lane merge --squash           # land the lane as one commit
-```
-
-For a protected trunk, prepare and push the lane instead:
-
-```bash
-lane push
-```
-
-The worktree remains available while its pull request is open. After the local trunk contains the lane's changes, including through a squash or rebase merge, `lane ls` marks it `landed` and `lane prune` removes it. Prune refuses lanes that still contain uncommitted work, pending notes, or commits absent from trunk.
-
-Run `lane --help` or `lane <command> --help` for the complete command surface.
-
-## Commands
-
-```bash
-lane init                            # probe reflink, scaffold memory + context protocol
-lane new fix-login                   # CoW worktree + branch
-lane new spike --dirty               # carry uncommitted work too
-lane ls
-lane anchors src/auth.rs             # discover canonical anchors and line ranges
-lane note add src/auth.rs -a "fn verify" "..."  # record a finding
-lane note edit <id>                              # choose a lifecycle action interactively
-lane note replace <id> "replacement text"       # queue a successor
-lane note confirm <id>                           # re-vouch for a drifted note
-lane note retire <id>                            # move a live note to the attic
-lane note restore <id>                           # restore a retired note
-lane note pin <id>                               # protect a note from eviction
-lane note unpin <id>                             # remove eviction protection
-lane why src/auth.rs                 # read what earlier lanes learned
-lane why src/                        # read every note beneath a directory
-lane merge                           # rebase, audit memory, fast-forward, remove
-lane push                            # rebase, audit, and push for a pull request
-lane prune                           # remove lanes whose branch has landed
-```
-
-## Memory
-
-Memory is ordinary Markdown committed with the repository:
-
-```text
-.lane/
-  memory/<path>/<ulid>-<slug>.md   live notes and confirmed fingerprints
-  attic/<path>/<ulid>-<slug>.md    retired notes, still recoverable
-  trees/<name>/                    local worktrees, never committed
-```
-
-New notes use distinct files, so parallel lanes can annotate the same code without editing the same bytes. `lane note confirm <id>` is the deliberate exception: it re-vouches for a drifted note by updating that note's confirmed fingerprint. Pin and unpin likewise update retention metadata. If two branches make conflicting judgments about the same note, Git should make that disagreement visible.
-
-Pending notes live in the lane's own Git directory until the next audit. Audit promotes them, follows source-file renames, and moves superseded, unpinned missing, or unpinned over-budget notes to `.lane/attic/` rather than deleting them.
-
-Freshness is computed for the anchored span, not the whole file:
-
-| result             | meaning                             |
-| ------------------ | ----------------------------------- |
-| `fresh`            | the anchored span is unchanged      |
-| `content-changed`  | its implementation changed          |
-| `contract-changed` | its declaration changed             |
-| `anchor-missing`   | the symbol no longer resolves       |
-| `unverifiable`     | lane has no grammar for that anchor |
-
-Anchors include declarations such as `fn verify`, Markdown headings such as `## Rate limiting`, component blocks such as `#script`, and `@file` for a whole file. Run `lane anchors src/auth.rs` to list the canonical values and their line ranges. A unique bare name such as `verify` is stored as its canonical value; a name shared by multiple declaration kinds is refused with the available choices. Comments and whitespace are normalized out of fingerprints.
-
-Resolve drift with exactly one of these actions:
-
-```bash
-lane note confirm <id>
-lane note replace <id> '<replacement>'
-lane note retire <id>
-```
-
-Run `lane note edit <id>` for a guided terminal menu over the same actions,
-including pinning or unpinning the note.
-
-Replacement inherits the live note's path and anchor. Retire and restore move bytes unchanged between live memory and the attic; pin and unpin control eviction. For a new note, supplied text never prompts and defaults to `@file` without `-a`; omit text to opt into the interactive anchor selector and one-line prompt.
+Run `lane --help` for the command list, or visit the [usage guide](https://lane.lukeed.com/usage) for the full workflow.
 
 ## Development
 
-```bash
-./scripts/build.sh        # release-build and install the local lane binary
-cargo fmt --all --check
-cargo clippy --workspace --all-targets -- -D warnings
-cargo test --workspace   # unit and integration tests
-./scripts/test.sh         # end to end against temporary Git repositories
-./scripts/check-linux.sh  # the same gates in Linux without reflink support
+```sh
+$ cargo fmt --all --check
+$ cargo clippy --workspace --all-targets -- -D warnings
+$ cargo test --workspace
+$ ./scripts/test.sh
 ```
-
-The interactive tour creates a disposable example repository:
-
-```bash
-cargo run -p lane-tour -- start
-```
-
-Full usage and command reference: [lane.lukeed.com/usage](https://lane.lukeed.com/usage).
 
 ## License
 

--- a/readme.md
+++ b/readme.md
@@ -76,7 +76,6 @@ $ lane note add src/auth.rs -a 'fn verify' \
 
 # edit and commit as usual
 $ lane check
-
 $ lane merge
 # or
 $ lane push
@@ -84,17 +83,11 @@ $ lane push
 
 `lane new` creates a branch and worktree under `.lane/trees/`. On APFS, btrfs, and reflink-enabled XFS, ignored files are cloned by reference. Otherwise, Lane creates a normal Git worktree and skips ignored files.
 
-Notes record what must stay true, not what a commit changed. They are stored as Markdown under `.lane/memory/` and anchored to a declaration, Markdown section, component block, or whole file. When an anchor drifts, choose one action:
-
-```sh
-$ lane note confirm <id>                  # still true
-$ lane note replace <id> '<replacement>'  # needs an update
-$ lane note retire <id>                   # no longer applies
-```
+Notes record what must stay true, not what a commit changed. They are stored as Markdown under `.lane/memory/` and anchored to a declaration, Markdown section, component block, or whole file.
 
 For repositories with protected branches, use `lane push` instead of `lane merge`. After the pull request lands, run `lane prune`.
 
-Run `lane --help` for the command list, or visit the [usage guide](https://lane.lukeed.com/usage) for the full workflow.
+Run `lane --help` for the command list, or visit the [usage guide](https://lane.lukeed.com/usage) for the full workflow. See [Audit](#audit) for how to review existing memories before landing.
 
 ## Memory
 
@@ -111,6 +104,16 @@ New notes use distinct files, so parallel lanes can annotate the same code witho
 
 Notes are written directly to `.lane/memory/` without a baseline. The next audit baselines them after any rebase, follows source-file renames, and moves superseded, unpinned missing, or unpinned over-budget notes to `.lane/attic/` rather than deleting them.
 
+Anchors include declarations such as `fn verify`, Markdown headings such as `## Rate limiting`, component blocks such as `#script`, and `@file` for a whole file. Run `lane anchors src/auth.rs` to list the canonical values and their line ranges. A unique bare name such as `verify` is stored as its canonical value; a name shared by multiple declaration kinds is refused with the available choices. Comments and whitespace are normalized out of fingerprints.
+
+### Audit
+
+Run `lane check` to get the status report for existing memories:
+
+```sh
+$ lane check
+```
+
 Freshness is computed for the anchored span, not the whole file:
 
 | result | meaning |
@@ -121,14 +124,12 @@ Freshness is computed for the anchored span, not the whole file:
 | `anchor-missing` | the symbol no longer resolves |
 | `unverifiable` | lane has no grammar for that anchor |
 
-Anchors include declarations such as `fn verify`, Markdown headings such as `## Rate limiting`, component blocks such as `#script`, and `@file` for a whole file. Run `lane anchors src/auth.rs` to list the canonical values and their line ranges. A unique bare name such as `verify` is stored as its canonical value; a name shared by multiple declaration kinds is refused with the available choices. Comments and whitespace are normalized out of fingerprints.
-
 Resolve drift with exactly one of these actions:
 
 ```sh
-$ lane note confirm <id>
-$ lane note replace <id> '<replacement>'
-$ lane note retire <id>
+$ lane note confirm <id>                  # still true
+$ lane note replace <id> '<replacement>'  # needs an update
+$ lane note retire <id>                   # no longer applies
 ```
 
 Run `lane note edit <id>` for a guided terminal menu over the same actions, including pinning or unpinning the note.

--- a/www/src/pages/usage.md
+++ b/www/src/pages/usage.md
@@ -17,7 +17,7 @@ something behind when it closes.
 ```bash
 $ lane new fix-login        # branch + worktree, the build cache by reference
 # work, commit as usual
-$ lane merge                # rebase, distill memory, fast-forward, delete
+$ lane merge                # rebase, audit memory, fast-forward, delete
 ```
 
 ---
@@ -25,10 +25,10 @@ $ lane merge                # rebase, distill memory, fast-forward, delete
 ## Setup
 
 ```bash
-$ cargo install --path crates/lane
+$ curl -fsSL https://lane.lukeed.com | sh
 $ eval "$(lane shellenv)"   # add to .zshrc: makes `lane new` and `lane enter` cd
 $ cd yourproject && lane init
-$ git add .lane .gitattributes AGENTS.md
+$ git add .lane AGENTS.md
 $ git commit -m "lane: context memory"
 ```
 
@@ -80,9 +80,7 @@ $ git config --add lane.exclude packages/legacy/node_modules
 
 ### Leave notes while you work
 
-There are two ways in. They write to the same queue and the next audit promotes
-both, so a note made either way is the same note afterwards. Use whichever
-suits the moment, or both.
+There are two ways in. Both write a note directly to `.lane/memory/`, where it is readable and visible to Git immediately. The next audit records its first baseline after any rebase. Use whichever suits the moment, or both.
 
 **Option one — a command, whenever you notice something.**
 
@@ -177,7 +175,7 @@ whether a note's anchored code has drifted and get the id needed to resolve it.
 ```bash
 $ lane merge
   rebased onto main
-  memory: +2 new; checked 8: 7 fresh, 1 content-changed, 0 contract-changed, 0 missing
+  memory: +0 new; checked 8: 7 fresh, 1 content-changed, 0 contract-changed, 0 missing
   committed memory update
   fast-forwarded main
   removed lane fix-login
@@ -221,6 +219,7 @@ normalized so comments and whitespace don't count:
 | `content-changed` | implementation moved | flagged until you resolve it |
 | `contract-changed` | the described thing changed shape | flagged until you resolve it |
 | `anchor-missing` | symbol gone | evicted to `.lane/attic/` |
+| `unverifiable` | no grammar for this anchor | reported for manual review |
 
 A renamed or moved file is followed, not evicted: `lane audit` reads git's own rename
 detection and moves the notes with it. Eviction means the file or the symbol is
@@ -268,9 +267,7 @@ Any unambiguous prefix of an id works, so the ten characters above are enough;
 an ambiguous one is refused and names what it matched. Add `--json` for the same
 rows plus each note's body and current span, which is what an agent reads.
 
-Replace writes a new file and moves the predecessor to the attic when audit
-promotes it. A `?` has no
-grammar and cannot be resolved. An `x` means the symbol is gone, so audit moves
+Replace writes a new file and moves the predecessor to the attic immediately. A `?` has no grammar and cannot be resolved. An `x` means the symbol is gone, so audit moves
 the note to the attic instead of vouching for it.
 
 ### Budget
@@ -305,8 +302,9 @@ you keep both:
 ## Context memory
 - Before editing a file, read `.lane/memory/<path>/` if it exists, or run `lane why <path>`.
 - Record non-obvious findings with `lane note add <path> -a <anchor> "..."`.
-- Do not edit `.lane/` by hand; `lane merge` manages it.
-- Detailed workflow lives in the `lane` skill; run `lane install skill` if it is absent.
+- Do not edit `.lane/` by hand; landing manages it.
+- Land with `lane merge`, or `lane push` where trunk is protected, then `lane prune` once it merges.
+- Detailed workflow lives in `.agents/skills/lane/SKILL.md`; run `lane install skill` if it is absent.
 ```
 
 That stub is always in context and stays short. `lane install skill` writes the
@@ -360,8 +358,8 @@ The short version. See [commands](/commands) for full information.
 | `lane anchors <file> [--json]` | list canonical anchors and line ranges |
 | `lane note add <file> [-a <anchor>] [<text>]` | record a finding; omit text for interaction |
 | `lane note edit <id>` | interactively confirm, replace, retire, pin, or unpin a live note |
-| `lane note replace <id> [<text>]` | queue a successor, inheriting path and anchor |
-| `lane note confirm <id>` | re-vouch for a resolved live note |
+| `lane note replace <id> [<text>]` | replace a live note, inheriting path and anchor |
+| `lane note confirm <id>` | re-vouch for a drifted live note |
 | `lane note retire <id>` | move a live note to the attic |
 | `lane note restore <id>` | restore a retired note |
 | `lane note pin <id>` | protect a live note from eviction |
@@ -387,7 +385,6 @@ yourproject/
     trees/
       fix-login/                  the lane worktree
   AGENTS.md
-  .git/lane/pending.jsonl         notes not yet promoted, per worktree
 ```
 
 Lanes live in `.lane/trees/` inside the repository and are excluded through `.git/info/exclude`,
@@ -398,9 +395,8 @@ so nothing is committed.
 **`trunk has diverged`** — someone else pushed. `git pull --rebase` on trunk,
 then `lane merge` again.
 
-**Rebase conflict** — resolve in the lane, `git rebase --continue`, rerun
-`lane merge`. Pending notes are untouched; they're only resolved after the
-rebase succeeds.
+**Rebase conflict** — resolve in the lane, `git rebase --continue`, then rerun
+`lane merge`. New notes receive their first baseline only after the rebase succeeds.
 
 **`lane has uncommitted changes`** — commit or stash first; the rebase refuses
 tracked changes either way. Untracked files are fine and need no stashing.
@@ -412,4 +408,4 @@ worktree; commit or stash there first. Nothing in the lane was touched.
 holds the memory lock. It exits immediately rather than waiting; rerun the
 command after that operation finishes.
 
-**A note is simply wrong** — delete the file and commit. Nothing else references it.
+**A note is simply wrong** — run `lane note retire <id>` and commit the move to the attic.


### PR DESCRIPTION
## Summary

- rewrite the README around installation, setup, and the daily workflow
- correct and tighten the complete CLI help surface
- clarify the lane agent skill and remove its hard-wrapped prose

## Verification

- `cargo fmt --all --check`
- `cargo test --workspace`
- rendered `lane -h`, `lane install -h`, and `lane uninstall -h`