### PR TITLE
feat: support fish shellenv

### DIFF
--- a/.lane/memory/crates/lane/src/args.rs/01M13BX3KZ69CZF71P2VNVYZJH-bare-shellenv-must-keep-emit.md
+++ b/.lane/memory/crates/lane/src/args.rs/01M13BX3KZ69CZF71P2VNVYZJH-bare-shellenv-must-keep-emit.md
@@ -3,6 +3,10 @@ id: 01M13BX3KZ69CZF71P2VNVYZJH
 anchor: fn parse_shellenv
 created: 2026-08-28T05:01:28Z
 norm: '1'
+sig: 3fa482d69d59ecf6
+body_hash: 0e6b1940031e5ed1
+raw_hash: 51fa9b5059fb4458
+lines: 337-352
 ---
 
 bare shellenv must keep emitting bash-compatible syntax so existing eval configs remain valid

--- a/.lane/memory/crates/lane/src/args.rs/01M13BX3KZ69CZF71P2VNVYZJH-bare-shellenv-must-keep-emit.md
+++ b/.lane/memory/crates/lane/src/args.rs/01M13BX3KZ69CZF71P2VNVYZJH-bare-shellenv-must-keep-emit.md
@@ -1,0 +1,8 @@
+---
+id: 01M13BX3KZ69CZF71P2VNVYZJH
+anchor: fn parse_shellenv
+created: 2026-08-28T05:01:28Z
+norm: '1'
+---
+
+bare shellenv must keep emitting bash-compatible syntax so existing eval configs remain valid

--- a/.lane/memory/www/src/pages/index.astro/01M104R3X0MZM3XWPBB7NV09W0-must-remain-prerender-false.md
+++ b/.lane/memory/www/src/pages/index.astro/01M104R3X0MZM3XWPBB7NV09W0-must-remain-prerender-false.md
@@ -4,8 +4,9 @@ anchor: '@file'
 created: 2026-08-26T22:58:41Z
 norm: '1'
 sig: cb3f91d54eee30e5
-body_hash: 0fcc9847f5ae1240
-raw_hash: fceb740860bb5144
+body_hash: 4863fa44df789a6c
+raw_hash: de1244ef5f44fd97
+vouched: 2026-08-28T05:01:28Z
 lines: 1-354
 ---
 

--- a/crates/lane/src/args.rs
+++ b/crates/lane/src/args.rs
@@ -65,6 +65,13 @@ pub enum Installable {
     Skill,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Shell {
+    Bash,
+    Zsh,
+    Fish,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct NewArgs {
     pub name: String,
@@ -156,7 +163,7 @@ pub enum Parsed {
     Push(PushArgs),
     Prune { dry_run: bool },
     Rm(RmArgs),
-    Shellenv,
+    Shellenv { shell: Shell },
     Help(Help),
     Version,
 }
@@ -191,7 +198,7 @@ pub fn parse(raw: Vec<OsString>) -> Result<Parsed> {
         Some("push") => parse_push(rest(raw)),
         Some("prune") => parse_prune(rest(raw)),
         Some("rm") => parse_rm(rest(raw)),
-        Some("shellenv") => bare(rest(raw), Help::Shellenv, Parsed::Shellenv),
+        Some("shellenv") => parse_shellenv(rest(raw)),
         Some("-h" | "--help") => Ok(Parsed::Help(Help::Root)),
         Some("-V" | "--version") => Ok(Parsed::Version),
         None => Ok(Parsed::Help(Help::Root)),
@@ -325,6 +332,23 @@ fn parse_ls(raw: Vec<OsString>) -> Result<Parsed> {
     let json = pargs.contains("--json");
     none(positionals(pargs, after, Help::Ls)?, Help::Ls)?;
     Ok(Parsed::Ls { json })
+}
+
+fn parse_shellenv(raw: Vec<OsString>) -> Result<Parsed> {
+    let (flags, after) = terminated(raw);
+    let mut pargs = pico_args::Arguments::from_vec(flags);
+    if pargs.contains(["-h", "--help"]) {
+        return Ok(Parsed::Help(Help::Shellenv));
+    }
+    let shell = match at_most_one(positionals(pargs, after, Help::Shellenv)?, Help::Shellenv)?
+        .as_deref()
+    {
+        None | Some("bash") => Shell::Bash,
+        Some("zsh") => Shell::Zsh,
+        Some("fish") => Shell::Fish,
+        Some(other) => anyhow::bail!("unsupported shell '{other}'; expected bash, zsh, or fish"),
+    };
+    Ok(Parsed::Shellenv { shell })
 }
 
 fn parse_anchors(raw: Vec<OsString>) -> Result<Parsed> {

--- a/crates/lane/src/cli.rs
+++ b/crates/lane/src/cli.rs
@@ -1,6 +1,8 @@
 //! Command surface. Every command returns an exit code; failures bubble as errors.
 
-use crate::args::{self, Budget, Installable, NoteAddArgs, NoteCommand, NoteReplaceArgs, Parsed};
+use crate::args::{
+    self, Budget, Installable, NoteAddArgs, NoteCommand, NoteReplaceArgs, Parsed, Shell,
+};
 use crate::audit;
 use crate::capture;
 use crate::git::{self, git, try_git};
@@ -86,7 +88,7 @@ pub fn run() -> Result<i32> {
         Parsed::Push(args) => push(args.name.as_deref(), args.base.as_deref(), &args.budget),
         Parsed::Prune { dry_run } => prune(dry_run),
         Parsed::Rm(args) => rm(&args.name, args.force),
-        Parsed::Shellenv => shellenv(),
+        Parsed::Shellenv { shell } => shellenv(shell),
     }
 }
 
@@ -1544,9 +1546,7 @@ fn rm(name: &str, force: bool) -> Result<i32> {
     Ok(0)
 }
 
-fn shellenv() -> Result<i32> {
-    println!(
-        r#"lane() {{
+const POSIX_SHELLENV: &str = r#"lane() {
   local p
   case "$1" in
     new|enter|switch|exit) p=$(command lane "$@") || return; cd "$p" ;;
@@ -1556,7 +1556,32 @@ fn shellenv() -> Result<i32> {
            cd "$PWD" 2>/dev/null || cd "$p" ;;
     *)     command lane "$@" ;;
   esac
-}}"#
+}"#;
+
+const FISH_SHELLENV: &str = r#"function lane --description 'lane worktree wrapper with auto-cd'
+    set -l p
+    switch "$argv[1]"
+        case new enter switch exit
+            set p (command lane $argv); or return
+            cd $p
+        # Read the destination first: merge deletes the worktree, and nothing runs from a
+        # directory that no longer exists. Stay put unless it was ours that went away.
+        case merge
+            set p (command lane exit); or return
+            command lane $argv; or return
+            cd $PWD 2>/dev/null; or cd $p
+        case '*'
+            command lane $argv
+    end
+end"#;
+
+fn shellenv(shell: Shell) -> Result<i32> {
+    println!(
+        "{}",
+        match shell {
+            Shell::Bash | Shell::Zsh => POSIX_SHELLENV,
+            Shell::Fish => FISH_SHELLENV,
+        }
     );
     Ok(0)
 }
@@ -1564,6 +1589,15 @@ fn shellenv() -> Result<i32> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn shellenv_scripts_match_each_shell() {
+        assert!(POSIX_SHELLENV.starts_with("lane() {"));
+        assert!(POSIX_SHELLENV.contains("command lane \"$@\""));
+        assert!(FISH_SHELLENV.starts_with("function lane"));
+        assert!(FISH_SHELLENV.contains("command lane $argv"));
+        assert!(FISH_SHELLENV.ends_with("end"));
+    }
 
     #[test]
     fn long_lane_names_keep_following_columns_aligned() {

--- a/crates/lane/src/help.rs
+++ b/crates/lane/src/help.rs
@@ -536,7 +536,10 @@ const SHELLENV: &str = "
     and `lane merge` leave the shell in the right directory.
 
   Usage
-    $ eval \"$(lane shellenv)\"
+    $ eval \"$(lane shellenv [bash|zsh|fish])\"
+
+  Arguments
+    SHELL         Shell syntax to print (default: bash)
 
   Options
     -h, --help    Display this message

--- a/crates/lane/tests/args.rs
+++ b/crates/lane/tests/args.rs
@@ -72,8 +72,26 @@ fn help_wins_over_the_arguments_beside_it() {
 fn commands_without_arguments_take_none() {
     assert_eq!(ok(&["init"]), Parsed::Init);
     assert_eq!(ok(&["ls"]), Parsed::Ls { json: false });
-    assert_eq!(ok(&["shellenv"]), Parsed::Shellenv);
+    assert_eq!(ok(&["shellenv"]), Parsed::Shellenv { shell: Shell::Bash });
     assert!(err(&["ls", "extra"]).contains("unexpected argument 'extra' found"));
+}
+
+#[test]
+fn shellenv_accepts_supported_shells() {
+    assert_eq!(
+        ok(&["shellenv", "bash"]),
+        Parsed::Shellenv { shell: Shell::Bash }
+    );
+    assert_eq!(
+        ok(&["shellenv", "zsh"]),
+        Parsed::Shellenv { shell: Shell::Zsh }
+    );
+    assert_eq!(
+        ok(&["shellenv", "fish"]),
+        Parsed::Shellenv { shell: Shell::Fish }
+    );
+    assert!(err(&["shellenv", "nu"]).contains("unsupported shell 'nu'"));
+    assert!(err(&["shellenv", "fish", "extra"]).contains("unexpected argument 'extra'"));
 }
 
 #[test]

--- a/readme.md
+++ b/readme.md
@@ -39,11 +39,17 @@ Lane requires Rust 1.85 or newer when building from source.
 
 ## Setup
 
-For each new shell, you will need to install the `lane shellenv` wrapper to automatically `cd` into & out of lanes.
-Or you may add the shell wrapper to `.zshrc` or `.bashrc` to auto-run: 
+For each new shell, install the `lane shellenv` wrapper to automatically `cd` into and out of lanes.
+Add this to `.zshrc` or `.bashrc`:
 
 ```sh
 eval "$(lane shellenv)"
+```
+
+Or add the Fish wrapper to `~/.config/fish/config.fish`:
+
+```fish
+lane shellenv fish | source
 ```
 
 > While not necessary, this more convenient than manually running `cd .lane/trees/<new lane>` repeatedly.


### PR DESCRIPTION
Closes #39

- accepts `bash`, `zsh`, or `fish` as an explicit shell target
- preserves the existing no-argument Bash/Zsh-compatible output
- emits a Fish wrapper with the same auto-cd and merge behavior
- documents Fish setup and covers parsing/output with tests

Tested with `cargo test -p lane`.