### PR TITLE
fix: support worktrees of a bare repository

### DIFF
--- a/.lane/memory/crates/lane/src/worktree.rs/01M268PVBRZ8V1M48CE7W19M2J-git-lists-physical-worktree.md
+++ b/.lane/memory/crates/lane/src/worktree.rs/01M268PVBRZ8V1M48CE7W19M2J-git-lists-physical-worktree.md
@@ -1,0 +1,8 @@
+---
+id: 01M268PVBRZ8V1M48CE7W19M2J
+anchor: fn list_lanes
+created: 2026-09-10T18:19:02Z
+norm: '1'
+---
+
+Git lists physical worktree paths even when .lane/trees is a symlink.

--- a/crates/lane/src/git.rs
+++ b/crates/lane/src/git.rs
@@ -49,7 +49,9 @@ pub fn git_ok(args: &[&str], cwd: Option<&Path>) -> bool {
 ///
 /// `git_dir` is per-worktree; `common_dir` is shared by every linked worktree.
 /// Keep those separate: lane's pending queue and identity intentionally live in
-/// the former, while the primary worktree is the parent of the latter.
+/// the former, while the primary worktree is the parent of the latter. A bare
+/// repository has no primary worktree, so the worktree lane was invoked from
+/// (or the one hosting the current lane) stands in for it.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct RepoLayout {
     pub git_dir: PathBuf,
@@ -86,10 +88,10 @@ fn resolve_layout(
             Err(error) => return Err(error).context("read git commondir"),
         },
     };
-    let main_root = common_dir
-        .parent()
-        .context("git common directory has no parent")?
-        .to_path_buf();
+    let main_root = match primary_worktree(&common_dir) {
+        Some(root) => root,
+        None => lane_host(&repo_root),
+    };
 
     Ok(RepoLayout {
         git_dir,
@@ -97,6 +99,23 @@ fn resolve_layout(
         repo_root,
         main_root,
     })
+}
+
+fn primary_worktree(common_dir: &Path) -> Option<PathBuf> {
+    let parent = common_dir.parent()?;
+    let owns_common_dir = std::fs::canonicalize(parent.join(".git")).ok()? == common_dir;
+    owns_common_dir.then(|| parent.to_path_buf())
+}
+
+fn lane_host(repo_root: &Path) -> PathBuf {
+    let mut parts = repo_root.components().rev();
+    let _name = parts.next();
+    let trees = parts.next().map(|c| c.as_os_str() == "trees");
+    let lane = parts.next().map(|c| c.as_os_str() == ".lane");
+    match (trees, lane) {
+        (Some(true), Some(true)) => parts.rev().collect(),
+        _ => repo_root.to_path_buf(),
+    }
 }
 
 fn find_repo_root(start: &Path) -> Result<PathBuf> {
@@ -263,6 +282,51 @@ mod tests {
         assert_eq!(layout.main_root, std::fs::canonicalize(root).unwrap());
     }
 
+    fn bare() -> (TempDir, PathBuf, PathBuf) {
+        let temp = TempDir::new().unwrap();
+        let bare = temp.path().join("repo.git");
+        let checkout = temp.path().join("branches/main");
+        std::fs::create_dir_all(bare.join("worktrees/main")).unwrap();
+        std::fs::create_dir_all(&checkout).unwrap();
+        std::fs::write(bare.join("worktrees/main/commondir"), "../..\n").unwrap();
+        std::fs::write(
+            checkout.join(".git"),
+            format!("gitdir: {}\n", bare.join("worktrees/main").display()),
+        )
+        .unwrap();
+        (temp, bare, checkout)
+    }
+
+    #[test]
+    fn bare_repository_anchors_on_the_invoking_worktree() {
+        let (_temp, bare, checkout) = bare();
+        let nested = checkout.join("src");
+        std::fs::create_dir_all(&nested).unwrap();
+
+        let layout = resolve_layout(&nested, None, None).unwrap();
+        assert_eq!(layout.common_dir, std::fs::canonicalize(&bare).unwrap());
+        assert_eq!(layout.repo_root, std::fs::canonicalize(&checkout).unwrap());
+        assert_eq!(layout.main_root, layout.repo_root);
+    }
+
+    #[test]
+    fn bare_repository_lane_resolves_its_hosting_worktree() {
+        let (_temp, bare, checkout) = bare();
+        let lane = checkout.join(".lane/trees/alpha");
+        std::fs::create_dir_all(&lane).unwrap();
+        std::fs::create_dir_all(bare.join("worktrees/alpha")).unwrap();
+        std::fs::write(bare.join("worktrees/alpha/commondir"), "../..\n").unwrap();
+        std::fs::write(
+            lane.join(".git"),
+            format!("gitdir: {}\n", bare.join("worktrees/alpha").display()),
+        )
+        .unwrap();
+
+        let layout = resolve_layout(&lane, None, None).unwrap();
+        assert_eq!(layout.repo_root, std::fs::canonicalize(&lane).unwrap());
+        assert_eq!(layout.main_root, std::fs::canonicalize(&checkout).unwrap());
+    }
+
     #[test]
     fn absolute_gitdir_and_environment_overrides_win() {
         let (_temp, root) = primary();
@@ -292,10 +356,7 @@ mod tests {
             layout.common_dir,
             std::fs::canonicalize(&alternate_common).unwrap()
         );
-        assert_eq!(
-            layout.main_root,
-            std::fs::canonicalize(alternate_common.parent().unwrap()).unwrap()
-        );
+        assert_eq!(layout.main_root, std::fs::canonicalize(&lane).unwrap());
     }
 
     fn repository() -> TempDir {

--- a/crates/lane/src/worktree.rs
+++ b/crates/lane/src/worktree.rs
@@ -167,11 +167,12 @@ pub struct Lane {
 
 pub fn list_lanes(root: &Path) -> Vec<Lane> {
     let out = try_git(&["worktree", "list", "--porcelain"], Some(root));
+    let trees = lanes_dir(root);
     let mut lanes = Vec::new();
     let (mut path, mut branch) = (String::new(), String::new());
 
     let flush = |path: &mut String, branch: &mut String, lanes: &mut Vec<Lane>| {
-        if !path.is_empty() && Path::new(path.as_str()) != root {
+        if Path::new(path.as_str()).starts_with(&trees) {
             lanes.push(Lane {
                 path: PathBuf::from(path.as_str()),
                 branch: if branch.is_empty() {

--- a/crates/lane/src/worktree.rs
+++ b/crates/lane/src/worktree.rs
@@ -168,6 +168,7 @@ pub struct Lane {
 pub fn list_lanes(root: &Path) -> Vec<Lane> {
     let out = try_git(&["worktree", "list", "--porcelain"], Some(root));
     let trees = lanes_dir(root);
+    let trees = trees.canonicalize().unwrap_or(trees);
     let mut lanes = Vec::new();
     let (mut path, mut branch) = (String::new(), String::new());
 

--- a/crates/lane/tests/worktree_symlinks.rs
+++ b/crates/lane/tests/worktree_symlinks.rs
@@ -1,0 +1,97 @@
+use lane::git::git;
+use serde_json::Value;
+use std::path::Path;
+use std::process::Command;
+use tempfile::TempDir;
+
+fn lane(root: &Path, args: &[&str]) -> String {
+    let output = Command::new(env!("CARGO_BIN_EXE_lane"))
+        .args(args)
+        .current_dir(root)
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "lane {args:?}: {}{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    String::from_utf8(output.stdout).unwrap()
+}
+
+fn repository() -> TempDir {
+    let temp = TempDir::new().unwrap();
+    let root = temp.path();
+    for args in [
+        &["init", "-qb", "main"][..],
+        &["config", "user.name", "Test"],
+        &["config", "user.email", "test@example.test"],
+        &["config", "commit.gpgsign", "false"],
+        &["config", "core.hooksPath", ".git/hooks"],
+    ] {
+        git(args, Some(root)).unwrap();
+    }
+    std::fs::write(root.join("file.txt"), "base\n").unwrap();
+    lane(root, &["init"]);
+    git(&["add", "-A"], Some(root)).unwrap();
+    git(&["commit", "-qm", "base"], Some(root)).unwrap();
+    temp
+}
+
+#[cfg(unix)]
+#[test]
+fn symlinked_trees_keep_lanes_visible_and_mergeable() {
+    let temp = repository();
+    let root = temp.path();
+    let external = TempDir::new().unwrap();
+    let trees = external.path().join("trees");
+    let sibling = external.path().join("trees-sibling");
+    std::fs::create_dir(&trees).unwrap();
+    std::os::unix::fs::symlink(&trees, root.join(".lane/trees")).unwrap();
+    git(
+        &[
+            "worktree",
+            "add",
+            "-qb",
+            "sibling",
+            sibling.to_str().unwrap(),
+        ],
+        Some(root),
+    )
+    .unwrap();
+
+    lane(root, &["new", "topic"]);
+    let rows: Vec<Value> = serde_json::from_str(&lane(root, &["ls", "--json"])).unwrap();
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0]["name"], "topic");
+    let topic = trees.join("topic").canonicalize().unwrap();
+    assert_eq!(rows[0]["path"], topic.to_str().unwrap());
+
+    std::fs::write(topic.join("file.txt"), "changed\n").unwrap();
+    git(&["add", "file.txt"], Some(&topic)).unwrap();
+    git(&["commit", "-qm", "change"], Some(&topic)).unwrap();
+    lane(root, &["merge", "topic"]);
+
+    assert_eq!(
+        std::fs::read_to_string(root.join("file.txt")).unwrap(),
+        "changed\n"
+    );
+    assert!(!topic.exists());
+    assert!(sibling.is_dir());
+    assert_eq!(lane(root, &["ls", "--json"]).trim(), "[]");
+}
+
+#[test]
+fn missing_trees_keep_registered_lanes_visible() {
+    let temp = repository();
+    let root = temp.path();
+    lane(root, &["new", "gone"]);
+    std::fs::remove_dir_all(root.join(".lane/trees")).unwrap();
+
+    let rows: Vec<Value> = serde_json::from_str(&lane(root, &["ls", "--json"])).unwrap();
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0]["name"], "gone");
+
+    lane(root, &["rm", "gone", "--force"]);
+    assert_eq!(lane(root, &["ls", "--json"]).trim(), "[]");
+}


### PR DESCRIPTION
## Problem

`main_root` is always the parent of the git common directory. That is the primary worktree for a normal clone, but a bare repository (`git clone --bare` + `git worktree add`) has no primary worktree. From a worktree of a bare repo, lane resolves the directory *above* the bare repo, and every command that runs git there fails:

```
$ cd repo.git/branches/main
$ lane new feat
error: git rev-parse --git-path info/exclude failed: fatal: not a git repository (or any of the parent directories): .git
```

`lane init` also drops `.lane/` in that unrelated parent directory.

## Fix

- `main_root` is derived from the common directory only when its parent's `.git` resolves to it. Otherwise it anchors on the invoking worktree, or on the worktree hosting the current lane when called from inside `.lane/trees/<name>`.
- `list_lanes` keeps only worktrees under `.lane/trees/`. Without this, sibling worktrees of a bare repo and the bare directory itself show up in `lane ls` and get walked by `prune`.

One existing assertion changed: with a `GIT_COMMON_DIR` override whose parent owns no `.git`, `main_root` now falls back to the worktree instead of the override's parent.

## Verification

- `cargo test --workspace`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo fmt --check`: clean.
- Two new unit tests for the bare layout (invoking worktree, and from inside a lane).
- Manual: `git init --bare` + `git worktree add branches/main`, then `lane init`, `lane new`, `lane ls`, `lane merge` from `branches/main`. Lanes land under `branches/main/.lane/trees/`, a sibling worktree is not listed, and `merge` fast-forwards main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
