### PR TITLE
feat: set squash messages

### DIFF
--- a/.lane/memory/crates/lane/src/args.rs/01M26096J1404TC3YRQTWB5NPK-validate-custom-messages-bef.md
+++ b/.lane/memory/crates/lane/src/args.rs/01M26096J1404TC3YRQTWB5NPK-validate-custom-messages-bef.md
@@ -1,0 +1,8 @@
+---
+id: 01M26096J1404TC3YRQTWB5NPK
+anchor: fn parse_merge
+created: 2026-09-10T15:51:46Z
+norm: '1'
+---
+
+Validate custom messages before prepare; Git rejects a blank message only after squash has staged changes on trunk.

--- a/.lane/memory/crates/lane/src/args.rs/01M26096J1404TC3YRQTWB5NPK-validate-custom-messages-bef.md
+++ b/.lane/memory/crates/lane/src/args.rs/01M26096J1404TC3YRQTWB5NPK-validate-custom-messages-bef.md
@@ -3,6 +3,10 @@ id: 01M26096J1404TC3YRQTWB5NPK
 anchor: fn parse_merge
 created: 2026-09-10T15:51:46Z
 norm: '1'
+sig: 6bf69ab7b5d6f14b
+body_hash: 981fae06237ddaae
+raw_hash: 8a88d58cf685f70c
+lines: 515-541
 ---
 
 Validate custom messages before prepare; Git rejects a blank message only after squash has staged changes on trunk.

--- a/.lane/memory/crates/lane/src/cli.rs/01M0Y1XE69YXQJ4YTZBXMXDE4F-outside-a-lane-exits-2-a-dir.md
+++ b/.lane/memory/crates/lane/src/cli.rs/01M0Y1XE69YXQJ4YTZBXMXDE4F-outside-a-lane-exits-2-a-dir.md
@@ -4,9 +4,9 @@ anchor: fn merge
 created: 2026-08-26T03:30:39Z
 norm: '1'
 sig: 45beab2c07c04d68
-body_hash: 1a5253221dc0a2c2
-raw_hash: bf1d0e65194358e9
-vouched: 2026-08-26T22:48:36Z
+body_hash: 1e83dc03177caf8c
+raw_hash: 3c48f47b180f04ea
+vouched: 2026-09-10T15:51:46Z
 lines: 1348-1405
 supersedes: 01M0TVF10VM7DTYH3E4BCHP9MH
 ---

--- a/.lane/memory/scripts/test.sh/01M0TWCNXMN78W0QRM93WYJFDW-a-shared-cargo-target-dir-ca.md
+++ b/.lane/memory/scripts/test.sh/01M0TWCNXMN78W0QRM93WYJFDW-a-shared-cargo-target-dir-ca.md
@@ -4,9 +4,9 @@ anchor: '@file'
 created: 2026-08-24T21:56:26Z
 norm: '1'
 sig: e3b0c44298fc1c14
-body_hash: 82806365e45af2c5
-raw_hash: 5ffe58f3193a905f
-vouched: 2026-08-29T17:15:08Z
+body_hash: 55673ac72f701f4f
+raw_hash: a48e99d37c451a4d
+vouched: 2026-09-10T15:51:46Z
 lines: 1-884
 ---
 

--- a/.lane/memory/scripts/test.sh/01M0XCG8DP729BYRMTZWT4AS4A-git-push-delete-drops-the-lo.md
+++ b/.lane/memory/scripts/test.sh/01M0XCG8DP729BYRMTZWT4AS4A-git-push-delete-drops-the-lo.md
@@ -4,9 +4,9 @@ anchor: '@file'
 created: 2026-08-25T21:16:25Z
 norm: '1'
 sig: e3b0c44298fc1c14
-body_hash: 82806365e45af2c5
-raw_hash: 5ffe58f3193a905f
-vouched: 2026-08-29T17:15:08Z
+body_hash: 55673ac72f701f4f
+raw_hash: a48e99d37c451a4d
+vouched: 2026-09-10T15:51:46Z
 lines: 1-1169
 ---
 

--- a/.lane/memory/scripts/test.sh/01M0ZVQK8S6ASGN0YYHS5GY1X5-the-assertions-that-read-pen.md
+++ b/.lane/memory/scripts/test.sh/01M0ZVQK8S6ASGN0YYHS5GY1X5-the-assertions-that-read-pen.md
@@ -4,9 +4,9 @@ anchor: '@file'
 created: 2026-08-26T20:20:50Z
 norm: '1'
 sig: e3b0c44298fc1c14
-body_hash: 82806365e45af2c5
-raw_hash: 5ffe58f3193a905f
-vouched: 2026-08-29T17:15:08Z
+body_hash: 55673ac72f701f4f
+raw_hash: a48e99d37c451a4d
+vouched: 2026-09-10T15:51:46Z
 lines: 1-1277
 ---
 

--- a/.lane/memory/scripts/test.sh/01M0ZXVYPJHXHTQ1YDBK9KGXJ3-three-assertions-checked-tha.md
+++ b/.lane/memory/scripts/test.sh/01M0ZXVYPJHXHTQ1YDBK9KGXJ3-three-assertions-checked-tha.md
@@ -4,9 +4,9 @@ anchor: '@file'
 created: 2026-08-26T20:58:16Z
 norm: '1'
 sig: e3b0c44298fc1c14
-body_hash: 82806365e45af2c5
-raw_hash: 5ffe58f3193a905f
-vouched: 2026-08-29T17:15:08Z
+body_hash: 55673ac72f701f4f
+raw_hash: a48e99d37c451a4d
+vouched: 2026-09-10T15:51:46Z
 lines: 1-1343
 ---
 

--- a/crates/lane/src/args.rs
+++ b/crates/lane/src/args.rs
@@ -126,6 +126,7 @@ pub struct MergeArgs {
     pub base: Option<String>,
     pub keep: bool,
     pub squash: bool,
+    pub message: Option<String>,
     pub budget: Budget,
 }
 
@@ -517,16 +518,24 @@ fn parse_merge(raw: Vec<OsString>) -> Result<Parsed> {
     if pargs.contains(["-h", "--help"]) {
         return Ok(Parsed::Help(Help::Merge));
     }
+    let message: Option<String> = pargs.opt_value_from_str(["-m", "--message"])?;
     let base = pargs.opt_value_from_str("--base")?;
     let keep = pargs.contains("--keep");
     let squash = pargs.contains("--squash");
     let budget = budget(&mut pargs)?;
     let name = at_most_one(positionals(pargs, after, Help::Merge)?, Help::Merge)?;
+    if let Some(message) = &message {
+        if !squash {
+            return Err(missing(&["--squash"], Help::Merge));
+        }
+        anyhow::ensure!(!message.trim().is_empty(), "--message cannot be empty");
+    }
     Ok(Parsed::Merge(MergeArgs {
         name,
         base,
         keep,
         squash,
+        message,
         budget,
     }))
 }

--- a/crates/lane/src/cli.rs
+++ b/crates/lane/src/cli.rs
@@ -83,6 +83,7 @@ pub fn run() -> Result<i32> {
             args.base.as_deref(),
             args.keep,
             args.squash,
+            args.message.as_deref(),
             &args.budget,
         ),
         Parsed::Push(args) => push(args.name.as_deref(), args.base.as_deref(), &args.budget),
@@ -1395,6 +1396,7 @@ fn merge(
     base: Option<&str>,
     keep: bool,
     squash: bool,
+    message: Option<&str>,
     budget: &Budget,
 ) -> Result<i32> {
     let info: &mut dyn Write = &mut std::io::stdout();
@@ -1413,10 +1415,8 @@ fn merge(
 
     if squash {
         git(&["merge", "--squash", &branch], Some(&root))?;
-        git(
-            &["commit", "-q", "-m", &format!("lane: merged {branch}")],
-            Some(&root),
-        )?;
+        let message = message.map_or_else(|| format!("lane: merged {branch}"), str::to_owned);
+        git(&["commit", "-q", "-m", &message], Some(&root))?;
         writeln!(info, "squash-merged {branch} into {base}")?;
     } else {
         wt::fast_forward(&root, &base, &branch)?;

--- a/crates/lane/src/help.rs
+++ b/crates/lane/src/help.rs
@@ -474,16 +474,18 @@ const MERGE: &str = "
     $ lane merge [name] [options]
 
   Options
-    --base <ref>        Rebase onto <ref> instead of the recorded base
-    --squash            Squash the lane's commits into one landing commit
-    --keep              Leave the worktree in place after landing
-    --max-notes <n>     Notes kept per anchor (default: 5)
-    --max-chars <n>     Characters kept per anchor (default: 1200)
-    -h, --help          Display this message
+    --base <ref>          Rebase onto <ref> instead of the recorded base
+    --squash              Squash the lane's commits into one landing commit
+    -m, --message <text>  Set the commit message (requires --squash; cannot be blank)
+    --keep                Leave the worktree in place after landing
+    --max-notes <n>       Notes kept per anchor (default: 5)
+    --max-chars <n>       Characters kept per anchor (default: 1200)
+    -h, --help            Display this message
 
   Examples
     $ lane merge
     $ lane merge --squash
+    $ lane merge --squash -m \"feat: add login\"
 ";
 
 const PUSH: &str = "

--- a/crates/lane/tests/args.rs
+++ b/crates/lane/tests/args.rs
@@ -179,6 +179,7 @@ fn the_shell_function_s_own_invocation_still_parses() {
             base: None,
             keep: false,
             squash: false,
+            message: None,
             budget: Budget::default(),
         })
     );
@@ -601,6 +602,7 @@ fn merge_and_rm_read_the_rest_of_their_flags() {
             base: Some("release".into()),
             keep: true,
             squash: true,
+            message: None,
             budget: Budget::default(),
         })
     );
@@ -619,6 +621,61 @@ fn merge_and_rm_read_the_rest_of_their_flags() {
         }
     );
     assert_eq!(ok(&["exit"]), Parsed::Exit);
+}
+
+#[test]
+fn merge_reads_a_custom_squash_message() {
+    let message = "feat: add login\n\nKeep sessions across restarts.\n\nRefs: #123";
+    let expected = Parsed::Merge(MergeArgs {
+        name: Some("fix-login".into()),
+        base: None,
+        keep: false,
+        squash: true,
+        message: Some(message.into()),
+        budget: Budget::default(),
+    });
+    for flag in ["-m", "--message"] {
+        assert_eq!(
+            ok(&["merge", "fix-login", "--squash", flag, message]),
+            expected
+        );
+        assert_eq!(
+            ok(&["merge", flag, message, "--squash", "fix-login"]),
+            expected
+        );
+    }
+    assert_eq!(
+        ok(&["merge", "--squash", &format!("-m{message}"), "fix-login"]),
+        expected
+    );
+    assert_eq!(
+        ok(&[
+            "merge",
+            "--squash",
+            &format!("--message={message}"),
+            "fix-login",
+        ]),
+        expected
+    );
+}
+
+#[test]
+fn merge_requires_squash_for_a_custom_message() {
+    for flag in ["-m", "--message"] {
+        assert_eq!(absent(&["merge", flag, "feat: add login"]), ["--squash"]);
+    }
+}
+
+#[test]
+fn merge_refuses_missing_and_blank_messages() {
+    for flag in ["-m", "--message"] {
+        assert!(parse_words(&["merge", "--squash", flag]).is_err());
+        for message in ["", " ", "\n\t "] {
+            assert!(
+                err(&["merge", "--squash", flag, message]).contains("--message cannot be empty")
+            );
+        }
+    }
 }
 
 #[test]

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -782,6 +782,58 @@ is "and names it merged" \
   "$(git log -1 --format=%s | grep -c '^lane: merged sq$')" "1"
 is "and removed the branch" "$(git branch --list sq | wc -l | tr -d ' ')" "0"
 
+for FLAG in -m --message; do
+  setup
+  "$LANE" new custom > /dev/null 2>&1
+  LP="$TMP/repo/.lane/trees/custom"
+  ( cd "$LP" && echo "fn one() {}" > src/one.rs && git add -A && git commit -qm "one" \
+    && echo "fn two() {}" > src/two.rs && git add -A && git commit -qm "two" \
+    && "$LANE" note add src/one.rs -a "fn one" "one must stay available to callers" > /dev/null )
+  TRUNK_TIP=$(git rev-parse HEAD)
+  LANE_TIP=$(git rev-parse custom)
+  LANE_STATUS=$(git -C "$LP" status --porcelain)
+  BEFORE=$(git rev-list --count HEAD)
+  CUSTOM_MESSAGE='feat: custom squash
+
+Keep "quotes", $values, and `commands` as text.
+
+Refs: #123
+Change-Type: feature'
+
+  "$LANE" merge custom "$FLAG" "$CUSTOM_MESSAGE" > "$TMP/message.out" 2>&1
+  is "$FLAG requires --squash" "$?" "2"
+  is "$FLAG names the required squash flag" \
+    "$(grep -c '^  --squash$' "$TMP/message.out")" "1"
+  for MESSAGE in "" $' \n\t'; do
+    "$LANE" merge custom --squash "$FLAG" "$MESSAGE" > "$TMP/message.out" 2>&1
+    is "$FLAG refuses a blank message" "$?" "2"
+    is "$FLAG explains the blank message" \
+      "$(grep -c -- '--message cannot be empty' "$TMP/message.out")" "1"
+  done
+  is "$FLAG invalid messages leave trunk at its tip" "$(git rev-parse HEAD)" "$TRUNK_TIP"
+  is "$FLAG invalid messages leave trunk clean" "$(git status --porcelain)" ""
+  is "$FLAG invalid messages leave the lane at its tip" "$(git rev-parse custom)" "$LANE_TIP"
+  is "$FLAG invalid messages leave pending memory untouched" \
+    "$(git -C "$LP" status --porcelain)" "$LANE_STATUS"
+
+  if [ "$FLAG" = "-m" ]; then
+    ( cd "$LP" && "$LANE" merge --squash "$FLAG" "$CUSTOM_MESSAGE" > "$TMP/message.out" 2>&1 )
+  else
+    "$LANE" merge custom --squash "$FLAG" "$CUSTOM_MESSAGE" > "$TMP/message.out" 2>&1
+  fi
+  is "$FLAG squash merge succeeds" "$?" "0"
+  is "$FLAG squash lands exactly one commit" "$(( $(git rev-list --count HEAD) - BEFORE ))" "1"
+  is "$FLAG preserves the full custom message" "$(git log -1 --format=%B)" "$CUSTOM_MESSAGE"
+  is "$FLAG preserves Git trailers" "$(git log -1 --format=%B | git interpret-trailers --parse)" \
+    $'Refs: #123\nChange-Type: feature'
+  is "$FLAG lands both source commits" "$(git show HEAD:src/one.rs && git show HEAD:src/two.rs)" \
+    $'fn one() {}\nfn two() {}'
+  is "$FLAG lands the lane memory" \
+    "$("$LANE" why src/one.rs | grep -c 'one must stay available to callers')" "1"
+  is "$FLAG removes the lane worktree" "$([ -d "$LP" ] && echo yes || echo no)" "no"
+  is "$FLAG removes the lane branch" "$(git branch --list custom | wc -l | tr -d ' ')" "0"
+done
+
 echo "== 29. reading context does not modify the tree =="
 setup
 is "why json is an empty array before a note exists" \

--- a/www/src/data/commands.ts
+++ b/www/src/data/commands.ts
@@ -170,12 +170,13 @@ export let commands: Command[] = [
 	},
 	{
 		name: "merge",
-		usage: "lane merge [<name>] [--base <ref>] [--keep] [--squash]",
+		usage: "lane merge [<name>] [--base <ref>] [--keep] [--squash [-m <text>]]",
 		summary: "rebases the lane onto its base, audits memory, commits it, fast-forwards the base, and removes the lane.",
 		options: [
 			{ flag: "--base", arg: "<ref>", about: "ref to rebase onto and advance; defaults to the lane's recorded base." },
 			{ flag: "--keep", arg: null, about: "keep the lane worktree and branch after landing." },
 			{ flag: "--squash", arg: null, about: "squash the lane's commits into one landing commit." },
+			{ flag: "-m, --message", arg: "<text>", about: "set a non-blank commit message; requires --squash. Defaults to lane: merged <branch>." },
 			{ flag: "--max-notes", arg: "<n>", about: "keep at most this many notes per path and anchor; default 5." },
 			{ flag: "--max-chars", arg: "<n>", about: "keep at most this many characters per path and anchor; default 1200." },
 		],

--- a/www/src/pages/usage.md
+++ b/www/src/pages/usage.md
@@ -155,6 +155,18 @@ $ lane merge
 
 `merge` never touches the network for git. Add `--keep` to preserve the worktree, `--squash` to land one commit, or `--base <name>` to use a different base. Use `lane push` for a pull request — see [Pull requests](#pull-requests).
 
+Set the squash commit message with `lane merge --squash -m "feat: add login"`. The long form is `--message <text>`. The message cannot be blank and requires `--squash`. If omitted, the message is `lane: merged <branch>`.
+
+One message value can include newlines for a body and trailers:
+
+```bash
+lane merge --squash -m 'feat: add login
+
+Keep sessions across restarts.
+
+Refs: #123'
+```
+
 ### Pull requests
 
 Where trunk is protected, `lane push` rebases, audits, commits memory, and pushes the lane:
@@ -293,7 +305,7 @@ The short version. See [commands](/commands) for full information.
 | `lane why <path> [-a <anchor>]` | read the notes on a file or a directory; changes nothing |
 | `lane check [--json]` | staleness report; exits 1 on missing anchors |
 | `lane audit [--base <ref>]` | run the memory pass alone |
-| `lane merge [<name>] [--keep] [--base <ref>] [--squash]` | rebase, audit, fast-forward, remove |
+| `lane merge [<name>] [--keep] [--base <ref>] [--squash [-m <text>]]` | rebase, audit, fast-forward, remove |
 | `lane push [<name>] [--base <ref>]` | rebase, audit, commit memory, and push for a pull request |
 | `lane prune [--dry-run]` | remove lanes whose branch has landed in trunk |
 | `lane rm <name> [--force]` | discard a lane; it stops and names uncommitted work, pending notes, or commits trunk does not have, `--force` drops them |


### PR DESCRIPTION
`lane merge --squash` always used `lane: merged <branch>`. Add `-m` and `--message` to set a custom commit message, including multiline bodies and Git trailers. The default stays unchanged. Blank messages and use without `--squash` are rejected before the repository changes.

Validation: 338 E2E checks, workspace Rust tests, Clippy with warnings denied, formatting, `cargo check`, and the docs build all pass.
