### PR TITLE
perf: scope note reads

### DIFF
--- a/.lane/memory/crates/lane/src/store.rs/01M0ZVQK7JQZWJEA6TNH1SKVW2-a-queue-made-memory-durable.md
+++ b/.lane/memory/crates/lane/src/store.rs/01M0ZVQK7JQZWJEA6TNH1SKVW2-a-queue-made-memory-durable.md
@@ -4,8 +4,9 @@ anchor: fn write_note
 created: 2026-08-26T20:20:50Z
 norm: '1'
 sig: 361c872f1efe14f1
-body_hash: 081a37b045a427c4
-raw_hash: 04967398ab34c542
+body_hash: 433a5bd5e17c89fa
+raw_hash: 9aea17b7c4aa0f5c
+vouched: 2026-09-10T20:07:11Z
 lines: 316-367
 ---
 

--- a/.lane/memory/crates/lane/src/store.rs/01M0ZVRC0B2QBS0P5QQ09TV6Z3-a-note-is-written-with-no-ba.md
+++ b/.lane/memory/crates/lane/src/store.rs/01M0ZVRC0B2QBS0P5QQ09TV6Z3-a-note-is-written-with-no-ba.md
@@ -4,8 +4,9 @@ anchor: fn write_note
 created: 2026-08-26T20:21:24Z
 norm: '1'
 sig: 361c872f1efe14f1
-body_hash: 081a37b045a427c4
-raw_hash: 04967398ab34c542
+body_hash: 433a5bd5e17c89fa
+raw_hash: 9aea17b7c4aa0f5c
+vouched: 2026-09-10T20:07:11Z
 lines: 316-367
 ---
 

--- a/.lane/memory/crates/lane/src/store.rs/01M26E7RQPY49MP1JKE1ST80BX-filter-the-logical-path-deri.md
+++ b/.lane/memory/crates/lane/src/store.rs/01M26E7RQPY49MP1JKE1ST80BX-filter-the-logical-path-deri.md
@@ -1,0 +1,8 @@
+---
+id: 01M26E7RQPY49MP1JKE1ST80BX
+anchor: fn load_note_tree
+created: 2026-09-10T19:55:40Z
+norm: '1'
+---
+
+Filter the logical path derived from each note location before reading its contents. Physical subtree pruning changes which notes are visible when a path contains another .lane component.

--- a/.lane/memory/crates/lane/src/store.rs/01M26E7RQPY49MP1JKE1ST80BX-filter-the-logical-path-deri.md
+++ b/.lane/memory/crates/lane/src/store.rs/01M26E7RQPY49MP1JKE1ST80BX-filter-the-logical-path-deri.md
@@ -3,6 +3,10 @@ id: 01M26E7RQPY49MP1JKE1ST80BX
 anchor: fn load_note_tree
 created: 2026-09-10T19:55:40Z
 norm: '1'
+sig: 96f2c0ee1f62000b
+body_hash: 74839292c36dd1c8
+raw_hash: b2619ffe0051d9da
+lines: 148-164
 ---
 
 Filter the logical path derived from each note location before reading its contents. Physical subtree pruning changes which notes are visible when a path contains another .lane component.

--- a/.lane/memory/crates/lane/src/store.rs/01M26E7RRGCX1TWTWD5P17H1NA-an-ordinary-add-can-deduplic.md
+++ b/.lane/memory/crates/lane/src/store.rs/01M26E7RRGCX1TWTWD5P17H1NA-an-ordinary-add-can-deduplic.md
@@ -3,6 +3,10 @@ id: 01M26E7RRGCX1TWTWD5P17H1NA
 anchor: fn write_note
 created: 2026-09-10T19:55:40Z
 norm: '1'
+sig: 361c872f1efe14f1
+body_hash: 433a5bd5e17c89fa
+raw_hash: 9aea17b7c4aa0f5c
+lines: 313-365
 ---
 
 An ordinary add can deduplicate within its path, but a replacement can name a predecessor on another path. Keep predecessor lookup across live memory and exclude the attic.

--- a/.lane/memory/crates/lane/src/store.rs/01M26E7RRGCX1TWTWD5P17H1NA-an-ordinary-add-can-deduplic.md
+++ b/.lane/memory/crates/lane/src/store.rs/01M26E7RRGCX1TWTWD5P17H1NA-an-ordinary-add-can-deduplic.md
@@ -1,0 +1,8 @@
+---
+id: 01M26E7RRGCX1TWTWD5P17H1NA
+anchor: fn write_note
+created: 2026-09-10T19:55:40Z
+norm: '1'
+---
+
+An ordinary add can deduplicate within its path, but a replacement can name a predecessor on another path. Keep predecessor lookup across live memory and exclude the attic.

--- a/crates/lane/src/note.rs
+++ b/crates/lane/src/note.rs
@@ -78,7 +78,7 @@ impl Note {
 
 /// A note we cannot parse still has to be visible, so fall back to the whole file as body.
 /// `.lane/memory/<path>/<ulid>-<slug>.md`, so the directory names the file the note is about.
-fn path_from_location(file: &Path) -> String {
+pub(crate) fn path_from_location(file: &Path) -> String {
     let parts: Vec<String> = file
         .parent()
         .unwrap_or(Path::new(""))

--- a/crates/lane/src/store.rs
+++ b/crates/lane/src/store.rs
@@ -156,14 +156,11 @@ fn load_note_tree(root: &Path, tree: &str, filter: Option<&str>) -> Vec<Note> {
         .filter(|e| e.file_type().is_file())
         .map(|e| e.into_path())
         .filter(|p| p.extension().is_some_and(|x| x == "md"))
+        .filter(|p| filter.is_none_or(|f| within(&note::path_from_location(p), f)))
         .collect();
     files.sort();
 
-    files
-        .iter()
-        .filter_map(|p| note::parse(p).ok())
-        .filter(|n| filter.is_none_or(|f| within(&n.path(), f)))
-        .collect()
+    files.iter().filter_map(|p| note::parse(p).ok()).collect()
 }
 
 /// Whether a note path is the filter itself or sits under it. The boundary is a
@@ -320,7 +317,8 @@ pub fn write_note(root: &Path, rec: &PendingNote) -> Result<Option<Note>> {
         rec.text.trim().to_string(),
         rec.supersedes.clone(),
     );
-    let live = load_notes(root, None);
+    let filter = rec.supersedes.is_empty().then_some(rec.path.as_str());
+    let live = load_notes(root, filter);
     let known = live.iter().any(|note| {
         (
             note.path(),

--- a/crates/lane/tests/note_scope.rs
+++ b/crates/lane/tests/note_scope.rs
@@ -1,0 +1,240 @@
+use serde_json::Value;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output};
+use tempfile::TempDir;
+
+fn run(root: &Path, program: &str, args: &[&str]) -> Output {
+    let output = Command::new(program)
+        .args(args)
+        .current_dir(root)
+        .env_remove("GIT_DIR")
+        .env_remove("GIT_COMMON_DIR")
+        .env_remove("GIT_WORK_TREE")
+        .env_remove("GIT_CONFIG_COUNT")
+        .env_remove("GIT_CONFIG_PARAMETERS")
+        .env("GIT_CONFIG_GLOBAL", "/dev/null")
+        .env("GIT_CONFIG_NOSYSTEM", "1")
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "{program} {args:?}: {}{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    output
+}
+
+fn lane(root: &Path, args: &[&str]) -> Output {
+    run(root, env!("CARGO_BIN_EXE_lane"), args)
+}
+
+fn repository() -> TempDir {
+    let temp = TempDir::new().unwrap();
+    run(temp.path(), "git", &["init", "-qb", "main"]);
+    temp
+}
+
+fn add(root: &Path, path: &str, text: &str) -> Output {
+    let source = root.join(path);
+    std::fs::create_dir_all(source.parent().unwrap()).unwrap();
+    std::fs::write(source, "pub fn run() {}\n").unwrap();
+    lane(root, &["note", "add", path, "-a", "fn run", text])
+}
+
+fn rows(root: &Path, path: &str) -> Vec<Value> {
+    serde_json::from_slice(&lane(root, &["why", path, "--json"]).stdout).unwrap()
+}
+
+fn note_file(root: &Path, path: &str) -> PathBuf {
+    std::fs::read_dir(root.join(".lane/memory").join(path))
+        .unwrap()
+        .next()
+        .unwrap()
+        .unwrap()
+        .path()
+}
+
+fn damage(root: &Path, path: &str) {
+    let file = note_file(root, path);
+    let text = std::fs::read_to_string(&file).unwrap();
+    std::fs::write(
+        file,
+        text.replacen("created:", "created: duplicate\ncreated:", 1),
+    )
+    .unwrap();
+}
+
+#[test]
+fn scoped_reads_and_additions_skip_unrelated_frontmatter() {
+    let temp = repository();
+    let root = temp.path();
+    add(root, "src/target.rs", "keep the target invariant");
+    add(root, "src-gen/other.rs", "keep the other invariant");
+    damage(root, "src-gen/other.rs");
+
+    for path in ["src/target.rs", "src", "missing.rs"] {
+        assert!(lane(root, &["why", path, "--json"]).stderr.is_empty());
+    }
+    let before = rows(root, "src/target.rs");
+    assert!(
+        add(root, "src/target.rs", "keep the target invariant")
+            .stderr
+            .is_empty()
+    );
+    assert_eq!(rows(root, "src/target.rs"), before);
+    assert!(
+        add(root, "src/target.rs", "keep another target invariant")
+            .stderr
+            .is_empty()
+    );
+    assert_eq!(rows(root, "src/target.rs").len(), 2);
+    assert!(
+        add(root, "src/second.rs", "keep the target invariant")
+            .stderr
+            .is_empty()
+    );
+    assert_eq!(rows(root, "src/second.rs").len(), 1);
+
+    for args in [
+        &["why", "--json"][..],
+        &["why", "src-gen/other.rs", "--json"],
+        &["check", "--json"],
+    ] {
+        let output = lane(root, args);
+        assert!(String::from_utf8_lossy(&output.stderr).contains("unreadable frontmatter"));
+    }
+}
+
+#[test]
+fn directory_scopes_keep_component_boundaries_and_missing_sources() {
+    let temp = repository();
+    let root = temp.path();
+    for path in ["src/one.rs", "src/deep/two.rs", "src-gen/three.rs"] {
+        add(root, path, "keep the invariant");
+    }
+    std::fs::remove_file(root.join("src/one.rs")).unwrap();
+
+    assert_eq!(rows(root, "src").len(), 2);
+    assert_eq!(rows(root, "src/one.rs").len(), 1);
+    assert_eq!(rows(root, "src/deep").len(), 1);
+    assert!(rows(root, "src/de").is_empty());
+    assert_eq!(rows(root, ".").len(), 3);
+    assert_eq!(rows(&root.join("src"), ".").len(), 2);
+}
+
+#[test]
+fn replacements_keep_cross_path_links_and_retired_notes_separate() {
+    let temp = repository();
+    let root = temp.path();
+    add(root, "src/old.rs", "keep the original invariant");
+    let old = rows(root, "src/old.rs").remove(0);
+    let id = old["id"].as_str().unwrap();
+    let original = note_file(root, "src/old.rs");
+    let bytes = std::fs::read(&original).unwrap();
+    std::fs::write(root.join("src/new.rs"), "pub fn run() {}\n").unwrap();
+
+    lane(
+        root,
+        &[
+            "note",
+            "replace",
+            id,
+            "keep the new invariant",
+            "--path",
+            "src/new.rs",
+        ],
+    );
+    assert!(rows(root, "src/old.rs").is_empty());
+    assert_eq!(rows(root, "src/new.rs").len(), 1);
+    let replacement = lane::store::load_notes(root, Some("src/new.rs"));
+    assert_eq!(replacement[0].meta.supersedes, id);
+    let retired = root
+        .join(".lane/attic/src/old.rs")
+        .join(original.file_name().unwrap());
+    assert_eq!(std::fs::read(retired).unwrap(), bytes);
+    assert!(!original.exists());
+
+    add(root, "src/old.rs", "keep the original invariant");
+    assert_eq!(rows(root, "src/old.rs").len(), 1);
+    assert_ne!(rows(root, "src/old.rs")[0]["id"], old["id"]);
+    assert_eq!(lane::store::load_retired(root, Some("src/old.rs")).len(), 1);
+}
+
+#[cfg(unix)]
+#[test]
+fn scoped_reads_do_not_follow_inner_memory_symlinks() {
+    let temp = repository();
+    let root = temp.path();
+    let external = TempDir::new().unwrap();
+    for (index, path) in ["src/one.rs", "src/deep/two.rs", "src/three.rs"]
+        .into_iter()
+        .enumerate()
+    {
+        add(root, path, "keep the invariant");
+        let from = if index == 2 {
+            note_file(root, path)
+        } else {
+            root.join(".lane/memory")
+                .join(if index == 1 { "src/deep" } else { path })
+        };
+        let to = external.path().join(index.to_string());
+        std::fs::rename(&from, &to).unwrap();
+        std::os::unix::fs::symlink(&to, &from).unwrap();
+        assert!(rows(root, path).is_empty());
+    }
+    assert!(rows(root, "src").is_empty());
+    assert!(rows(root, ".").is_empty());
+}
+
+#[cfg(unix)]
+#[test]
+fn scoped_reads_follow_the_existing_memory_root_symlink() {
+    let temp = repository();
+    let root = temp.path();
+    let external = TempDir::new().unwrap();
+    add(root, "src/one.rs", "keep the invariant");
+    let from = root.join(".lane/memory");
+    let to = external.path().join("memory");
+    std::fs::rename(&from, &to).unwrap();
+    std::os::unix::fs::symlink(&to, &from).unwrap();
+
+    assert_eq!(rows(root, "src/one.rs").len(), 1);
+    assert_eq!(rows(root, "src").len(), 1);
+    assert_eq!(rows(root, ".").len(), 1);
+}
+
+#[test]
+fn scoped_reads_use_the_worktree_memory_root_and_reject_escape_filters() {
+    let temp = repository();
+    let root = temp.path().join(".lane/trees/nested");
+    std::fs::create_dir_all(&root).unwrap();
+    run(&root, "git", &["init", "-qb", "main"]);
+    add(&root, "src/one.rs", "keep the nested invariant");
+    let all = rows(&root, ".");
+    assert_eq!(rows(&root, "src"), all);
+    assert_eq!(all[0]["path"], "src/one.rs");
+
+    for filter in ["../../", "../memory/src", root.to_str().unwrap()] {
+        assert!(lane::store::load_notes(&root, Some(filter)).is_empty());
+    }
+}
+
+#[test]
+fn scoped_reads_keep_the_deepest_lane_path_mapping() {
+    let temp = repository();
+    let root = temp.path();
+    add(
+        root,
+        "vendor/.lane/context/src/one.rs",
+        "keep the invariant",
+    );
+    let all = rows(root, ".");
+    assert_eq!(all[0]["path"], "src/one.rs");
+    assert_eq!(rows(root, "src/one.rs"), all);
+    assert_eq!(rows(root, "src"), all);
+    assert!(rows(root, "vendor").is_empty());
+
+    add(root, "src/one.rs", "keep the invariant");
+    assert_eq!(rows(root, "src/one.rs"), all);
+}


### PR DESCRIPTION
`lane why <path>` and ordinary note additions read and parsed every live note. Select notes by their existing logical path before sorting, reading, and parsing their contents. Ordinary additions use the path filter for duplicate detection; replacements still resolve predecessors across live memory.

Measured on Apple M1 Max, macOS 26.6.2, Rust 1.98.0, locked release builds. Before: `8874b08`, whose Cargo manifests, lockfile, and crate sources match main `18933e1`. After: code commit `2229a224`.

| Command | Unrelated notes | Before ms, mean / median | After ms, mean / median |
|---|---:|---:|---:|
| `why target.rs --json` | 0 | 6.08 / 5.54 | 6.64 / 6.19 |
| new `note add` | 0 | 12.27 / 10.36 | 10.86 / 9.91 |
| duplicate `note add` | 0 | 9.87 / 8.56 | 9.14 / 8.15 |
| `why target.rs --json` | 100 | 12.92 / 11.94 | 9.42 / 8.45 |
| new `note add` | 100 | 19.57 / 17.21 | 15.88 / 14.52 |
| duplicate `note add` | 100 | 13.74 / 13.00 | 11.38 / 10.37 |
| `why target.rs --json` | 1000 | 189.24 / 188.33 | 18.53 / 17.90 |
| new `note add` | 1000 | 191.80 / 191.77 | 37.50 / 37.27 |
| duplicate `note add` | 1000 | 184.65 / 184.45 | 20.06 / 19.96 |

Each fixture keeps five target notes and at most five notes per unrelated source. Each build has 100 samples per case, with ten warmups before each 50-run batch and reversed build order in the second batch. Hyperfine uses no command shell. Both builds use the same fixture and isolated Git config; all outliers remain in the results. New-add preparation retires its previous benchmark note through `lane note retire` outside the timed interval, keeping five live target notes. Output and note-state parity were checked separately.

The five-note controls show no consistent gain; their startup cost dominates. The implementation still walks the full memory tree. It skips unrelated note reads and YAML parsing, which preserves the existing deepest-`.lane` path mapping and symlink traversal. Scoped commands now omit diagnostics from unrelated notes.

Validation: formatting, workspace check, clippy with warnings denied, 207 workspace tests, and 338 CLI assertions pass on macOS and on Linux with Rust 1.97.1 and tmpfs. Seven new CLI tests cover scoped diagnostics, duplicate additions, component boundaries, deleted sources, cross-path replacement, live/attic separation, symlinks, nested worktrees, and escape filters. Lane audit and check report 83 fresh notes with no stale, missing, or unverifiable notes.
