### PR TITLE
perf: cache anchor checks

### DIFF
--- a/.lane/memory/crates/lane/src/store.rs/01M26FPVZJX78N4X853R0YG5H4-cache-only-current-source-ha.md
+++ b/.lane/memory/crates/lane/src/store.rs/01M26FPVZJX78N4X853R0YG5H4-cache-only-current-source-ha.md
@@ -3,6 +3,10 @@ id: 01M26FPVZJX78N4X853R0YG5H4
 anchor: struct Checker
 created: 2026-09-10T20:21:22Z
 norm: '1'
+sig: 631dcb4440ecd747
+body_hash: b8fb1bd62fcec8db
+raw_hash: a3a2704ff3cdfe38
+lines: 508-512
 ---
 
 Cache only current source hashes; notes on one anchor can have different baselines and normalization versions.

--- a/.lane/memory/crates/lane/src/store.rs/01M26FPVZJX78N4X853R0YG5H4-cache-only-current-source-ha.md
+++ b/.lane/memory/crates/lane/src/store.rs/01M26FPVZJX78N4X853R0YG5H4-cache-only-current-source-ha.md
@@ -1,0 +1,8 @@
+---
+id: 01M26FPVZJX78N4X853R0YG5H4
+anchor: struct Checker
+created: 2026-09-10T20:21:22Z
+norm: '1'
+---
+
+Cache only current source hashes; notes on one anchor can have different baselines and normalization versions.

--- a/.lane/memory/crates/lane/src/store.rs/01M26FPW1BFX113TMK9RDG6B43-a-hash-cache-key-needs-the-s.md
+++ b/.lane/memory/crates/lane/src/store.rs/01M26FPW1BFX113TMK9RDG6B43-a-hash-cache-key-needs-the-s.md
@@ -1,0 +1,8 @@
+---
+id: 01M26FPW1BFX113TMK9RDG6B43
+anchor: fn check
+created: 2026-09-10T20:21:23Z
+norm: '1'
+---
+
+A hash cache key needs the source path and exact anchor text because equal SFC spans can use different comment grammars.

--- a/.lane/memory/crates/lane/src/store.rs/01M26FPW1BFX113TMK9RDG6B43-a-hash-cache-key-needs-the-s.md
+++ b/.lane/memory/crates/lane/src/store.rs/01M26FPW1BFX113TMK9RDG6B43-a-hash-cache-key-needs-the-s.md
@@ -3,6 +3,10 @@ id: 01M26FPW1BFX113TMK9RDG6B43
 anchor: fn check
 created: 2026-09-10T20:21:23Z
 norm: '1'
+sig: f992a2eb9ef89b47
+body_hash: 7726bcf620dc6ba1
+raw_hash: 74e8aad381b1c6f2
+lines: 544-645
 ---
 
 A hash cache key needs the source path and exact anchor text because equal SFC spans can use different comment grammars.

--- a/.lane/memory/crates/lane/src/syntax.rs/01M0TMPTR29GTK9N5MA1Z0PHKD-line-starts-must-preserve-st.md
+++ b/.lane/memory/crates/lane/src/syntax.rs/01M0TMPTR29GTK9N5MA1Z0PHKD-line-starts-must-preserve-st.md
@@ -4,8 +4,9 @@ anchor: struct Source
 created: 2026-08-24T19:09:49Z
 norm: '1'
 sig: 7877fe79130c24bf
-body_hash: ea97b192f427557c
-raw_hash: 046908bc9d1ec197
+body_hash: 58093f5720689b3c
+raw_hash: fb61fe97069c3559
+vouched: 2026-09-10T20:21:23Z
 lines: 225-231
 ---
 

--- a/.lane/memory/crates/lane/src/syntax.rs/01M26FPW2WZ57M423MHN7WXSPB-cached-declaration-candidate.md
+++ b/.lane/memory/crates/lane/src/syntax.rs/01M26FPW2WZ57M423MHN7WXSPB-cached-declaration-candidate.md
@@ -1,0 +1,8 @@
+---
+id: 01M26FPW2WZ57M423MHN7WXSPB
+anchor: fn declaration_candidates
+created: 2026-09-10T20:21:23Z
+norm: '1'
+---
+
+Cached declaration candidates retain byte order so bare names resolve to the earliest declaration even after anchor display sorts and removes duplicates.

--- a/.lane/memory/crates/lane/src/syntax.rs/01M26FPW2WZ57M423MHN7WXSPB-cached-declaration-candidate.md
+++ b/.lane/memory/crates/lane/src/syntax.rs/01M26FPW2WZ57M423MHN7WXSPB-cached-declaration-candidate.md
@@ -3,6 +3,10 @@ id: 01M26FPW2WZ57M423MHN7WXSPB
 anchor: fn declaration_candidates
 created: 2026-09-10T20:21:23Z
 norm: '1'
+sig: 7f59cfae03f8ea2b
+body_hash: e2d9f6039099161c
+raw_hash: 3ddf4343acac90ba
+lines: 603-606
 ---
 
 Cached declaration candidates retain byte order so bare names resolve to the earliest declaration even after anchor display sorts and removes duplicates.

--- a/crates/lane/src/cli.rs
+++ b/crates/lane/src/cli.rs
@@ -1168,7 +1168,7 @@ fn check_json_rows(
                 "note": note.body.trim(),
             });
             if res.tier != FRESH {
-                row["span"] = serde_json::json!(checker.span_text(note));
+                row["span"] = serde_json::json!(checker.span_text(&note.path(), res.span));
             }
             row
         })

--- a/crates/lane/src/store.rs
+++ b/crates/lane/src/store.rs
@@ -508,6 +508,7 @@ pub struct Check {
 pub struct Checker {
     root: PathBuf,
     cache: HashMap<String, Option<Source>>,
+    hashes: HashMap<(String, String), (String, String, String)>,
 }
 
 impl Checker {
@@ -515,6 +516,7 @@ impl Checker {
         Checker {
             root: root.to_path_buf(),
             cache: HashMap::new(),
+            hashes: HashMap::new(),
         }
     }
 
@@ -528,12 +530,11 @@ impl Checker {
         self.cache.get(rel).and_then(|slot| slot.as_ref())
     }
 
-    pub fn span_text(&mut self, note: &Note) -> String {
-        let (path, anchor) = (note.path(), note.meta.anchor.clone());
-        let Some(src) = self.source(&path) else {
+    pub fn span_text(&mut self, path: &str, span: Option<Span>) -> String {
+        let Some(span) = span else {
             return String::new();
         };
-        let Some(span) = src.resolve(&anchor) else {
+        let Some(src) = self.source(path) else {
             return String::new();
         };
         let text = src.span_text(span);
@@ -563,6 +564,7 @@ impl Checker {
         let base = note.meta.clone();
 
         let (path, anchor) = (note.path(), note.meta.anchor.clone());
+        let cached = self.hashes.get(&(path.clone(), anchor.clone())).cloned();
         let Some(src) = self.source(&path) else {
             return blank(MISSING);
         };
@@ -571,7 +573,14 @@ impl Checker {
             Resolution::NotFound => return blank(MISSING),
             Resolution::Unparsed => return blank(UNVERIFIABLE),
         };
-        let (sig, body_hash, raw_hash) = src.hashes(span, &anchor);
+        let (sig, body_hash, raw_hash) = match cached {
+            Some(hashes) => hashes,
+            None => {
+                let hashes = src.hashes(span, &anchor);
+                self.hashes.insert((path, anchor), hashes.clone());
+                hashes
+            }
+        };
 
         // Nothing to compare against yet, so this is a first fingerprint, not a change.
         // Adopted, because a note written before its baseline exists keeps none otherwise.
@@ -1052,6 +1061,111 @@ mod tests {
         let res = Checker::new(root.path()).check(&note);
         assert_eq!(res.tier, FRESH);
         assert!(!res.sig.is_empty(), "the fingerprint must be adopted");
+    }
+
+    #[test]
+    fn shared_current_hashes_keep_each_notes_baseline_and_normalization() {
+        let root = tempfile::tempdir().unwrap();
+        let source = "pub fn v() {\n    current();\n}\n";
+        let mut note = fixture(root.path(), source);
+        note.meta.anchor = "fn v".into();
+        let parsed = Source::new(source, "src/a.rs");
+        let span = parsed.resolve("fn v").unwrap();
+        let hashes = parsed.hashes(span, "fn v");
+        let current = crate::syntax::NORM_VERSION;
+        let cases = [
+            (
+                hashes.0.as_str(),
+                hashes.1.as_str(),
+                hashes.2.as_str(),
+                current,
+                FRESH,
+                false,
+                false,
+            ),
+            (
+                hashes.0.as_str(),
+                "old body",
+                "old raw",
+                current,
+                BODY,
+                false,
+                false,
+            ),
+            (
+                "old signature",
+                "old body",
+                "old raw",
+                current,
+                SIG,
+                false,
+                false,
+            ),
+            (
+                "old signature",
+                "old body",
+                hashes.2.as_str(),
+                "0",
+                FRESH,
+                true,
+                false,
+            ),
+            (
+                "old signature",
+                "old body",
+                "old raw",
+                "0",
+                FRESH,
+                true,
+                true,
+            ),
+            ("", "", "", current, FRESH, true, false),
+        ];
+        let mut checker = Checker::new(root.path());
+        for _ in 0..2 {
+            for (sig, body, raw, norm, tier, adopted, rebaselined) in cases {
+                note.meta.sig = sig.into();
+                note.meta.body_hash = body.into();
+                note.meta.raw_hash = raw.into();
+                note.meta.norm = norm.into();
+                let result = checker.check(&note);
+                assert_eq!(result.tier, tier);
+                assert_eq!(result.adopted, adopted);
+                assert_eq!(result.rebaselined, rebaselined);
+                assert_eq!(result.span, Some(span));
+                assert_eq!(result.base, (sig.into(), body.into(), raw.into()));
+                assert_eq!((result.sig, result.body_hash, result.raw_hash), hashes);
+            }
+        }
+    }
+
+    #[test]
+    fn shared_spans_keep_the_anchors_comment_language() {
+        let root = tempfile::tempdir().unwrap();
+        let path = "src/View.svelte";
+        let source = "<style>\n.item { color: red; /* keep this */ }\n</style>\n";
+        std::fs::create_dir_all(root.path().join("src")).unwrap();
+        std::fs::write(root.path().join(path), source).unwrap();
+        let parsed = Source::new(source, path);
+        let span = parsed.resolve("@file").unwrap();
+        assert_eq!(parsed.resolve("#style"), Some(span));
+        let whole = parsed.hashes(span, "@file");
+        let style = parsed.hashes(span, "#style");
+        assert_ne!(whole.1, style.1);
+        seed_note(root.path(), path, "01M0A", "keep the style");
+        let mut note = load_notes(root.path(), None).pop().unwrap();
+        let mut checker = Checker::new(root.path());
+        for (anchor, expected) in [
+            ("@file", &whole),
+            ("#style", &style),
+            ("@file", &whole),
+            ("#style", &style),
+        ] {
+            note.meta.anchor = anchor.into();
+            let result = checker.check(&note);
+            assert_eq!(result.span, Some(span));
+            assert_eq!(&(result.sig, result.body_hash, result.raw_hash), expected);
+        }
     }
 
     #[test]

--- a/crates/lane/src/syntax.rs
+++ b/crates/lane/src/syntax.rs
@@ -336,6 +336,7 @@ pub struct Source {
     ext: String,
     grammar: Option<&'static Grammar>,
     tree: Option<Tree>,
+    declarations: OnceLock<Vec<Anchor>>,
 }
 
 impl Source {
@@ -354,6 +355,7 @@ impl Source {
             ext,
             grammar,
             tree,
+            declarations: OnceLock::new(),
         }
     }
 
@@ -414,7 +416,7 @@ impl Source {
     pub(crate) fn anchors(&self) -> Vec<Anchor> {
         let mut rest = self.block_candidates();
         rest.extend(self.heading_candidates());
-        rest.extend(self.declaration_candidates());
+        rest.extend(self.declaration_candidates().iter().cloned());
         rest.sort_by(|a, b| {
             a.span
                 .start
@@ -593,12 +595,17 @@ impl Source {
             return None;
         }
         candidates
-            .into_iter()
+            .iter()
             .find(|candidate| candidate.value.split_whitespace().last() == Some(anchor))
             .map(|candidate| candidate.span)
     }
 
-    fn declaration_candidates(&self) -> Vec<Anchor> {
+    fn declaration_candidates(&self) -> &[Anchor] {
+        self.declarations
+            .get_or_init(|| self.collect_declarations())
+    }
+
+    fn collect_declarations(&self) -> Vec<Anchor> {
         let Some(tree) = self.tree.as_ref() else {
             return Vec::new();
         };
@@ -995,6 +1002,31 @@ impl Item {}\n";
                 .collect::<Vec<_>>(),
             ["fn run", "const run"]
         );
+    }
+
+    #[test]
+    fn repeated_queries_keep_duplicate_and_bare_resolution_order() {
+        let source = Source::new(
+            "fn run() {\n    first();\n}\nconst run: u8 = 1;\nfn run() {\n    second();\n}\n",
+            "a.rs",
+        );
+        for _ in 0..2 {
+            let anchors = source.anchors();
+            assert_eq!(anchors.len(), 3);
+            assert_eq!(anchors[1].value, "fn run");
+            assert_eq!(anchors[1].span, Span { start: 1, end: 3 });
+            let Qualification::Ambiguous(choices) = source.qualify("run") else {
+                panic!("expected ambiguity");
+            };
+            assert_eq!(choices, anchors[1..]);
+            assert_eq!(source.resolve("run"), Some(Span { start: 1, end: 3 }));
+            assert_eq!(source.resolve("fn run"), Some(Span { start: 1, end: 3 }));
+            assert_eq!(source.resolve("const run"), Some(Span { start: 4, end: 4 }));
+            assert!(matches!(
+                source.resolve_detail("fn missing"),
+                Resolution::NotFound
+            ));
+        }
     }
 
     #[test]

--- a/crates/lane/tests/anchor_cache.rs
+++ b/crates/lane/tests/anchor_cache.rs
@@ -1,0 +1,160 @@
+use lane::note::{Meta, Note};
+use serde_json::Value;
+use std::fs;
+use std::path::Path;
+use std::process::Command;
+use tempfile::TempDir;
+
+fn run(root: &Path, program: &str, args: &[&str]) -> String {
+    let output = Command::new(program)
+        .args(args)
+        .current_dir(root)
+        .env("GIT_CONFIG_NOSYSTEM", "1")
+        .env("GIT_CONFIG_GLOBAL", "/dev/null")
+        .env_remove("GIT_DIR")
+        .env_remove("GIT_COMMON_DIR")
+        .env_remove("GIT_WORK_TREE")
+        .env_remove("GIT_CONFIG")
+        .env_remove("GIT_CONFIG_COUNT")
+        .env_remove("GIT_CONFIG_PARAMETERS")
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "{program} {args:?}: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    String::from_utf8(output.stdout).unwrap()
+}
+
+fn lane(root: &Path, args: &[&str]) -> String {
+    run(root, env!("CARGO_BIN_EXE_lane"), args)
+}
+
+fn fixture() -> TempDir {
+    let temp = TempDir::new().unwrap();
+    for args in [
+        &["init", "-qb", "main"][..],
+        &["config", "user.name", "t"],
+        &["config", "user.email", "t@t.t"],
+        &["config", "commit.gpgsign", "false"],
+        &["commit", "--allow-empty", "-qm", "initial"],
+    ] {
+        run(temp.path(), "git", args);
+    }
+    lane(temp.path(), &["init"]);
+    fs::create_dir(temp.path().join("src")).unwrap();
+    temp
+}
+
+fn add(root: &Path, path: &str, text: &str) {
+    lane(root, &["note", "add", path, "-a", "fn verify", text]);
+}
+
+fn check(root: &Path) -> Vec<Value> {
+    serde_json::from_str(&lane(root, &["check", "--json"])).unwrap()
+}
+
+fn row<'a>(rows: &'a [Value], text: &str) -> &'a Value {
+    rows.iter().find(|row| row["note"] == text).unwrap()
+}
+
+#[test]
+fn check_and_audit_keep_independent_baselines_and_files() {
+    let temp = fixture();
+    let root = temp.path();
+    let first = "pub fn verify(value: usize) -> usize {\n    value + 1 // original\n}\n";
+    let second = "pub fn verify(value: usize) -> usize {\n    value + 9\n}\n";
+    fs::write(root.join("src/a.rs"), first).unwrap();
+    fs::write(root.join("src/b.rs"), second).unwrap();
+    add(root, "src/a.rs", "a old");
+    add(root, "src/b.rs", "b note");
+    lane(root, &["audit", "--base", "main"]);
+
+    fs::write(
+        root.join("src/a.rs"),
+        "pub fn verify(value: usize) -> usize {\r\n value   + 1 // revised\r\n}\r\n",
+    )
+    .unwrap();
+    assert!(check(root).iter().all(|row| row["tier"] == "fresh"));
+    add(root, "src/a.rs", "a formatted");
+    lane(root, &["audit", "--base", "main"]);
+    let baselines: Vec<_> = lane::store::load_notes(root, None)
+        .into_iter()
+        .map(|note| (note.file.unwrap(), note.raw))
+        .collect();
+
+    let changed = "pub fn verify(value: usize) -> usize {\n    value + 2\n}\n";
+    fs::write(root.join("src/a.rs"), changed).unwrap();
+    add(root, "src/a.rs", "a current");
+    let audit: Value =
+        serde_json::from_str(&lane(root, &["audit", "--base", "main", "--json"])).unwrap();
+    assert_eq!(audit["checked"]["content-changed"], 2);
+    assert_eq!(audit["checked"]["fresh"], 2);
+    for (path, bytes) in baselines {
+        assert_eq!(fs::read_to_string(path).unwrap(), bytes);
+    }
+    let rows = check(root);
+    assert_eq!(rows.len(), 4);
+    for text in ["a old", "a formatted"] {
+        assert_eq!(row(&rows, text)["tier"], "content-changed");
+        assert_eq!(row(&rows, text)["span"], changed);
+    }
+    for text in ["a current", "b note"] {
+        assert_eq!(row(&rows, text)["tier"], "fresh");
+        assert!(row(&rows, text).get("span").is_none());
+    }
+    lane(
+        root,
+        &[
+            "note",
+            "confirm",
+            row(&rows, "a old")["id"].as_str().unwrap(),
+        ],
+    );
+    let rows = check(root);
+    assert_eq!(row(&rows, "a old")["tier"], "fresh");
+    assert_eq!(row(&rows, "a formatted")["tier"], "content-changed");
+    assert_eq!(row(&rows, "b note")["tier"], "fresh");
+}
+
+#[test]
+fn check_json_keeps_missing_and_unparsed_spans_empty() {
+    let temp = fixture();
+    let root = temp.path();
+    fs::write(root.join("src/missing.rs"), "fn keep() {}\n").unwrap();
+    fs::write(root.join("src/unknown.swift"), "func verify() {}\n").unwrap();
+    for (index, (path, anchor)) in [
+        ("src/missing.rs", "fn verify"),
+        ("src/missing.rs", "fn verify"),
+        ("src/unknown.swift", "func verify"),
+        ("src/unknown.swift", "func verify"),
+        ("src/absent.rs", "@file"),
+    ]
+    .into_iter()
+    .enumerate()
+    {
+        let id = format!("01M0{index:022}");
+        Note::new(
+            Meta {
+                id: id.clone(),
+                anchor: anchor.into(),
+                ..Default::default()
+            },
+            format!("finding {index}"),
+        )
+        .write(&lane::store::note_dir(root, path).join(format!("{id}-note.md")))
+        .unwrap();
+    }
+    let rows = check(root);
+    assert_eq!(rows.len(), 5);
+    for row in rows {
+        let expected = if row["path"] == "src/unknown.swift" {
+            "unverifiable"
+        } else {
+            "anchor-missing"
+        };
+        assert_eq!(row["tier"], expected);
+        assert_eq!(row["span"], "");
+    }
+}


### PR DESCRIPTION
When several notes refer to one source file, `check` and `audit` rerun its declaration query for each note and recompute hashes for repeated anchors. Drift JSON also resolves each span again.

Cache the ordered declaration candidates on each `Source` and current hashes by file path plus exact anchor on each `Checker`. Render drift from the resolved `Check.span`. Each note keeps its own baseline and normalization comparison; SFC anchors retain their comment grammar. The caches live with the current source/checker and do not change normalization.

Release benchmarks compare main `18933e1` against source commit `2a60a517` (final head `783a194` only records memory). Each build has 20 samples per case, with all samples retained.

| Case | Before mean / median / SD (ms) | After mean / median / SD (ms) |
|---|---:|---:|
| `check`, 1,000 functions / 51,890 B, 1 note | 44.41 / 41.83 / 7.43 | 43.40 / 41.31 / 4.57 |
| `check --json` (drifted), 1,000 functions / 51,890 B, 1 note | 43.33 / 41.85 / 4.76 | 38.83 / 39.28 / 5.40 |
| `audit`, 1,000 functions / 51,890 B, 1 note | 92.64 / 92.20 / 6.89 | 94.51 / 96.29 / 10.63 |
| `check`, 1,000 functions / 51,890 B, 10 notes | 63.81 / 63.33 / 5.43 | 42.11 / 41.09 / 3.76 |
| `check --json` (drifted), 1,000 functions / 51,890 B, 10 notes | 86.93 / 84.98 / 6.85 | 41.83 / 39.79 / 12.08 |
| `audit`, 1,000 functions / 51,890 B, 10 notes | 109.65 / 112.47 / 9.39 | 90.15 / 89.74 / 5.42 |
| `check`, 1,000 functions / 51,890 B, 100 notes | 271.55 / 270.88 / 7.92 | 45.39 / 44.25 / 4.15 |
| `check --json` (drifted), 1,000 functions / 51,890 B, 100 notes | 491.42 / 489.01 / 11.10 | 44.85 / 44.61 / 5.31 |
| `audit`, 1,000 functions / 51,890 B, 100 notes | 315.03 / 314.44 / 8.26 | 95.66 / 94.42 / 4.21 |
| `anchors --json`, 1,000 functions / 51,890 B, 100 notes | 17.81 / 16.59 / 3.44 | 17.53 / 16.44 / 2.62 |
| `check`, whole file / 1,130,500 B, 1 note | 289.36 / 288.40 / 6.93 | 289.60 / 288.76 / 4.44 |
| `audit`, whole file / 1,130,500 B, 1 note | 339.64 / 336.32 / 12.15 | 339.24 / 334.86 / 18.46 |
| `check`, whole file / 1,130,500 B, 5 notes | 863.79 / 858.69 / 9.26 | 290.08 / 288.17 / 7.93 |
| `audit`, whole file / 1,130,500 B, 5 notes | 900.28 / 898.92 / 9.63 | 329.71 / 328.18 / 6.76 |
| `check`, one function / 55 B, 1 note | 30.19 / 29.84 / 3.77 | 30.31 / 29.59 / 3.13 |
| `audit`, one function / 55 B, 1 note | 81.46 / 73.26 / 37.70 | 77.53 / 75.52 / 8.94 |
| `anchors --json`, one function / 55 B, 1 note | 7.83 / 6.72 / 2.33 | 7.64 / 7.16 / 1.79 |
| `check`, one function / 55 B, 5 notes | 28.93 / 28.07 / 3.61 | 31.90 / 29.36 / 5.71 |
| `audit`, one function / 55 B, 5 notes | 74.52 / 71.55 / 10.59 | 82.23 / 79.97 / 11.63 |

Method: Apple M1 Max, macOS 26.6.2, Apple Git 2.50.1, Rust 1.98.0, `cargo build --release --locked -p lane` for both builds. Reused baseline binary `8874b08`; its source and dependency diff to main is empty. Hyperfine used `--shell=none`, two reversed-order batches of 10 runs, and 3 warmups per batch. Git global/system config was disabled and `LC_ALL=C`. APFS caches were warm; other builds/tests were paused. Audit restored the committed note files outside timing. All 19 cases had identical stdout. Raw Hyperfine JSON, logs, and fixture data are retained locally.

Small controls were repeated with two reversed batches of 25 runs per build (50 samples each), again with 3 warmups. This did not repeat the original roughly 10% slower means. Git process counts stayed at one for `check` and three for `audit`, measured with Trace2 outside timing.

| Case | Before mean / median / SD (ms) | After mean / median / SD (ms) |
|---|---:|---:|
| `check`, one function / 55 B, 1 note | 31.48 / 31.23 / 3.50 | 31.88 / 29.21 / 6.94 |
| `audit`, one function / 55 B, 1 note | 78.64 / 76.81 / 7.08 | 76.57 / 75.24 / 5.71 |
| `check`, one function / 55 B, 5 notes | 31.53 / 30.99 / 4.58 | 31.81 / 31.05 / 3.79 |
| `audit`, one function / 55 B, 5 notes | 77.81 / 77.39 / 4.82 | 80.09 / 78.66 / 8.98 |

The small five-note audit remains variable: the repeat measured 77.81 → 80.09 ms, with SD 4.82 / 8.98 ms. These controls do not establish a speedup; both the original and confirmation samples remain in the report. Timings cover local warm-cache commands, not remote operations or Linux performance.

Validation: `lane audit --base main` and `lane check` (84 fresh, no drift), formatting, `cargo check`, clippy with warnings denied, 205 workspace tests, and 338 CLI assertions. Workspace tests and CLI assertions passed on macOS and Linux; Linux used tmpfs and Rust 1.97.1. Tests cover independent note baselines/normalization, equal anchor names in different files, comment/whitespace/CRLF edits, duplicate and bare names, SFC shared spans, missing/unparsed anchors, and drift JSON. An additional comparison regenerated all 123 fixture note files byte-for-byte with both binaries, including their signature/body/raw hashes and line spans.
